### PR TITLE
Executor Capability Reporting with Graceful Degradation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,6 +67,6 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased] - 2025-12-03
+
+### Added
+- **Executor Capability Reporting (Optional Feature)**
+  - Executors can now advertise their DynamicCommandWhitelist configuration to the central API
+  - New `CapabilityModule` stores capability data in Redis with TTL-based expiration
+  - API endpoints: `POST /executor/capabilities`, `POST /executor/heartbeat`, `GET /api/v1/clusters/{cluster_id}/capabilities`
+  - New cluster detail endpoint: `GET /debug/clusters/{cluster_id}` shows comprehensive cluster status including capabilities
+  - Helm configuration: `executor.capabilities.enabled` and `executor.capabilities.heartbeatInterval`
+  - Graceful degradation: feature is optional, disabled by default, and failures don't affect core functionality
+  - Backwards compatible: older executors work with new API, new executors work with older API
+  - Input validation: mode enum restriction, max list sizes to prevent oversized payloads
+  - Capability cleanup on token revoke: prevents stale advertisements
+  - Reviewed by Gemini 3 and GPT-5 with identified issues addressed
+
 ## [Unreleased] - 2025-09-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Kubently (*Kubernetes + Agentically*) enables AI agents to troubleshoot Kubernet
 
 ```bash
 # Install CLI
-npm install -g @kubently/cli
+npm i -g @kubently/cli
 
 # Deploy to your cluster
 git clone https://github.com/kubently/kubently.git

--- a/deployment/helm/kubently/prompts/system.prompt.yaml
+++ b/deployment/helm/kubently/prompts/system.prompt.yaml
@@ -95,29 +95,27 @@ content: |-
 
   # Task Management
 
-  You have access to the todo_write tool to help you manage and track debugging workflows. Use this tool VERY frequently to ensure that you are tracking your debugging progress and giving the user visibility into your investigation.
-  This tool is EXTREMELY helpful for complex issues that require checking multiple resources and correlating information. If you do not use this tool when debugging complex issues, you may miss important steps - and that is unacceptable.
+  You have access to the todo_write tool to help you manage debugging workflows. Use this tool at the START of complex investigations to plan your approach, then ONLY update it when you've COMPLETED the investigation or found the answer.
 
-  It is critical that you mark todos as completed as soon as you finish each debugging step. Do not batch up multiple tasks before marking them as completed.
+  IMPORTANT: Do NOT call todo_write after every kubectl command. This wastes tokens and slows down debugging. Only use it:
+  - Once at the START to plan (if the issue is complex)
+  - Once at the END to mark completed (if you used it at the start)
+
+  For simple issues (1-3 kubectl commands), skip todo_write entirely.
 
   Examples:
 
   <example>
   user: Debug why my pods are not starting
-  assistant: I'm going to use the todo_write tool to track our debugging steps:
-  - Check pod status and events
-  - Examine pod descriptions for errors
-  - Review container logs
-  - Verify image availability
-  - Check resource constraints
+  assistant: [runs kubectl get pods -n namespace]
 
-  Let me start by checking the pod status...
+  I see the pod is in ImagePullBackOff state. Let me check the events:
 
-  [runs kubectl get pods -n namespace]
+  [runs kubectl get events -n namespace --field-selector involvedObject.name=nginx-pod]
 
-  I found the issue: ImagePullBackOff - the container image 'nginx:latests' has a typo (should be 'nginx:latest')
+  Root cause: The container image 'nginx:latests' has a typo - should be 'nginx:latest'.
 
-  [marks todos as completed]
+  Fix: Update the deployment image to `nginx:latest`
   </example>
 
   <example>
@@ -172,11 +170,11 @@ content: |-
 
   # Tool usage policy
 
-  - When debugging complex issues, always use todo_write to track your investigation steps
   - When debugging, always start with non-invasive read operations (get, describe, logs)
   - Use the most specific kubectl commands to reduce output noise
   - Batch multiple kubectl commands when investigating related resources
   - When checking multiple namespaces, use -A flag efficiently
+  - STOP and provide your answer once you've identified the issue - don't over-investigate
 
   # Token-Efficient kubectl Patterns
 
@@ -230,20 +228,27 @@ content: |-
 
   ## Critical Behaviors
 
+  ### WHEN TO STOP AND RESPOND:
+  IMPORTANT: You MUST stop investigating and provide your answer when ANY of these conditions are met:
+  - You found the root cause (e.g., CrashLoopBackOff with clear error in logs)
+  - You gathered enough evidence to explain the issue
+  - You've made 5+ tool calls - synthesize what you know and respond
+  - The user asked a simple question that doesn't need deep investigation
+
+  DO NOT keep investigating indefinitely. After finding an issue, STOP and tell the user what you found.
+
   ### DO:
-  - Use todo_write for complex multi-step debugging
-  - Use multiple commands to verify each finding
+  - Stop and respond once you identify the issue
   - Check events, logs, and descriptions
   - Look at timestamps and correlate events
   - Consider recent changes or deployments
   - Verify network paths (service → endpoints → pods)
-  - Check resource quotas and limits
-  - Examine node health and capacity
 
   ### DON'T:
+  - Keep calling tools after you've found the answer
+  - Use todo_write after every kubectl command
   - Assume resource names match namespace names
-  - Trust a single data point
-  - Skip "obvious" checks
+  - Trust a single data point without context
   - Ignore warning events
   - Overlook RBAC or security contexts
 

--- a/deployment/helm/kubently/templates/executor-deployment.yaml
+++ b/deployment/helm/kubently/templates/executor-deployment.yaml
@@ -74,6 +74,15 @@ spec:
         - name: KUBENTLY_WHITELIST_DB
           value: "/var/lib/kubently/whitelist.db"
         {{- end }}
+        {{- /* Capability reporting configuration (optional feature) */}}
+        {{- if .Values.executor.capabilities }}
+        {{- if .Values.executor.capabilities.enabled }}
+        - name: KUBENTLY_REPORT_CAPABILITIES
+          value: "true"
+        - name: KUBENTLY_HEARTBEAT_INTERVAL
+          value: {{ .Values.executor.capabilities.heartbeatInterval | default 300 | quote }}
+        {{- end }}
+        {{- end }}
         {{- range $key, $value := .Values.executor.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -190,6 +190,24 @@ executor:
   #   verbs: ["get", "list", "watch"]
 
   # ----------------------------------------------------------------------------
+  # Capability Reporting (Optional)
+  # ----------------------------------------------------------------------------
+  # When enabled, executors advertise their command whitelist configuration
+  # to the central API. This allows the agent to know what each cluster
+  # can do before sending commands.
+  #
+  # This feature is completely optional - if disabled or if reporting fails,
+  # the system continues to function normally (graceful degradation).
+  capabilities:
+    # Enable capability reporting to central API
+    # Set to true to advertise what this executor can do
+    enabled: false
+
+    # Heartbeat interval (seconds) to refresh capability TTL
+    # Capabilities expire after 1 hour by default; heartbeat keeps them alive
+    heartbeatInterval: 300  # 5 minutes
+
+  # ----------------------------------------------------------------------------
   # Environment Variables
   # ----------------------------------------------------------------------------
   env:

--- a/deployment/helm/test-values.yaml
+++ b/deployment/helm/test-values.yaml
@@ -1,0 +1,92 @@
+# Test values for local Kubently deployment
+# This file provides minimal configuration for quick testing.
+# For full deployment configuration, see secrets/test-values.yaml
+
+api:
+  replicaCount: 1
+
+  image:
+    repository: ghcr.io/kubently/kubently
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 8080
+    targetPort: 8080
+
+  env:
+    LOG_LEVEL: "INFO"
+    LLM_PROVIDER: "anthropic-claude"
+    PORT: "8080"
+    API_PORT: "8080"
+
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+executor:
+  enabled: true
+
+  image:
+    repository: ghcr.io/kubently/kubently-executor
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  # REQUIRED: Set these via --set flags or override this file
+  # Example:
+  #   --set executor.clusterId=local
+  #   --set executor.apiUrl=http://kubently-api:8080
+  #   --set executor.token=$(openssl rand -hex 32)
+  clusterId: ""
+  apiUrl: ""
+  token: ""
+
+  env:
+    LOG_LEVEL: "INFO"
+
+  security:
+    mode: "readOnly"
+    commandWhitelist:
+      enabled: true
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: true
+    existingSecret: "kubently-redis-password"
+  master:
+    persistence:
+      enabled: false  # Disabled for local testing
+
+ingress:
+  enabled: false
+
+serviceAccount:
+  create: true
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000

--- a/docs/AGENTGATEWAY_SETUP.md
+++ b/docs/AGENTGATEWAY_SETUP.md
@@ -1,0 +1,572 @@
+# Setting Up Agentgateway in Front of Kubently
+
+This guide covers deploying [kgateway/agentgateway](https://kgateway.dev/docs/agentgateway/latest/) as an API gateway in front of Kubently, enabling centralized authentication, A2A protocol handling, and traffic management for your AI agent infrastructure.
+
+## Overview
+
+**Agentgateway** is an open-source, Kubernetes-native gateway specifically designed for AI agent connectivity. It provides:
+
+- **A2A Protocol Support**: Native understanding of the Agent-to-Agent (A2A) protocol
+- **MCP Integration**: Model Context Protocol tool routing
+- **Traffic Management**: Load balancing, retries, timeouts for agent traffic
+- **Security**: Centralized authentication, TLS termination, CORS handling
+
+### Architecture
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│   AI Client     │────▶│   Agentgateway   │────▶│    Kubently     │
+│  (Claude, etc)  │     │   (Port 8080)    │     │   (Port 8080)   │
+└─────────────────┘     └──────────────────┘     └─────────────────┘
+        │                       │
+        │  POST /a2a/           │  Pass-through
+        │  (no auth header)     │  + inject X-API-Key
+        ▼                       ▼
+```
+
+**Key benefits:**
+- Clients don't need to manage API keys - the gateway injects them
+- A2A protocol-aware routing with proper SSE streaming support
+- Single entry point for multiple AI agent backends
+
+## Prerequisites
+
+- Kubernetes cluster (1.25+)
+- `kubectl` configured with cluster access
+- `helm` v3.x installed
+- Kubently deployed and running
+
+## Step 1: Install Gateway API CRDs
+
+The Kubernetes Gateway API provides the foundational Custom Resource Definitions (CRDs) that agentgateway extends.
+
+```bash
+# Install the standard Gateway API CRDs (v1.4.0)
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
+```
+
+**Verify installation:**
+
+```bash
+kubectl get crds | grep gateway
+```
+
+Expected output:
+```
+gatewayclasses.gateway.networking.k8s.io
+gateways.gateway.networking.k8s.io
+httproutes.gateway.networking.k8s.io
+referencegrants.gateway.networking.k8s.io
+```
+
+## Step 2: Install kgateway with Agentgateway Enabled
+
+kgateway is the control plane that manages agentgateway proxies. Install it with the agentgateway feature flag enabled.
+
+```bash
+# Install kgateway with agentgateway enabled
+helm upgrade --install kgateway oci://ghcr.io/kgateway-dev/kgateway-helm \
+  --namespace kgateway-system \
+  --create-namespace \
+  --set agentgateway.enabled=true
+```
+
+**Verify installation:**
+
+```bash
+# Check kgateway controller is running
+kubectl get pods -n kgateway-system
+
+# Verify the agentgateway GatewayClass exists
+kubectl get gatewayclass agentgateway
+```
+
+Expected output:
+```
+NAME           CONTROLLER                    ACCEPTED   AGE
+agentgateway   kgateway.dev/agentgateway     True       1m
+```
+
+## Step 3: Configure the Backend Service for A2A Protocol
+
+Agentgateway uses the Kubernetes `appProtocol` field on Services to identify A2A backends. This enables protocol-aware routing and proper handling of A2A's JSON-RPC over SSE communication pattern.
+
+**Option A: Patch existing service**
+
+```bash
+kubectl patch svc kubently-api -n kubently --type='json' -p='[
+  {"op": "add", "path": "/spec/ports/0/appProtocol", "value": "kgateway.dev/a2a"}
+]'
+```
+
+**Option B: Update Helm values** (recommended for production)
+
+Add to your Kubently `values.yaml`:
+
+```yaml
+api:
+  service:
+    ports:
+      - name: http
+        port: 8080
+        targetPort: 8080
+        appProtocol: kgateway.dev/a2a
+```
+
+**Verify the service configuration:**
+
+```bash
+kubectl get svc kubently-api -n kubently -o jsonpath='{.spec.ports[0].appProtocol}'
+```
+
+Expected output:
+```
+kgateway.dev/a2a
+```
+
+## Step 4: Create the Gateway Resource
+
+The Gateway resource defines the network entrypoint - the listener configuration that accepts incoming traffic.
+
+```yaml
+# gateway.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: agentgateway
+  namespace: kgateway-system
+  labels:
+    app: agentgateway
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+      allowedRoutes:
+        namespaces:
+          from: All  # Allow HTTPRoutes from any namespace
+```
+
+**Apply:**
+
+```bash
+kubectl apply -f gateway.yaml
+```
+
+**Key configuration details:**
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| `gatewayClassName` | `agentgateway` | References the agentgateway proxy template |
+| `listeners[].port` | `8080` | External port the gateway listens on |
+| `listeners[].protocol` | `HTTP` | Protocol for this listener |
+| `allowedRoutes.namespaces.from` | `All` | Permits routes from any namespace to attach |
+
+**Verify Gateway is programmed:**
+
+```bash
+kubectl get gateway agentgateway -n kgateway-system
+```
+
+Expected output:
+```
+NAME           CLASS          ADDRESS         PROGRAMMED   AGE
+agentgateway   agentgateway   <IP or pending> True         1m
+```
+
+## Step 5: Create the HTTPRoute
+
+The HTTPRoute defines how traffic flows from the Gateway to your backend service. This configuration:
+- Routes `/a2a/*` requests to Kubently
+- Automatically injects the API key header (so clients don't need it)
+
+```yaml
+# httproute.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kubently-route
+  namespace: kubently
+spec:
+  parentRefs:
+    - name: agentgateway
+      namespace: kgateway-system
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /a2a
+      filters:
+        # Inject API key header for authentication
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            add:
+              - name: X-API-Key
+                value: "YOUR_KUBENTLY_API_KEY"
+      backendRefs:
+        - name: kubently-api
+          port: 8080
+```
+
+> **Note**: Replace `YOUR_KUBENTLY_API_KEY` with your actual Kubently API key.
+
+**Apply:**
+
+```bash
+kubectl apply -f httproute.yaml
+```
+
+**Key configuration details:**
+
+| Field | Description |
+|-------|-------------|
+| `parentRefs` | Links this route to the Gateway |
+| `matches[].path` | Match traffic with PathPrefix `/a2a` |
+| `filters[].RequestHeaderModifier` | Inject the `X-API-Key` header automatically |
+| `backendRefs` | Target the kubently-api service on port 8080 |
+
+**Verify HTTPRoute is accepted:**
+
+```bash
+kubectl get httproute kubently-route -n kubently
+```
+
+Check detailed status:
+
+```bash
+kubectl describe httproute kubently-route -n kubently
+```
+
+Look for `Accepted: True` and `ResolvedRefs: True` in the status conditions.
+
+## Step 6: Verify End-to-End Connectivity
+
+### Check Gateway Deployment
+
+```bash
+# Verify the agentgateway proxy pod is running
+kubectl get pods -n kgateway-system -l app.kubernetes.io/name=agentgateway
+
+# Check the gateway service
+kubectl get svc -n kgateway-system
+
+# Check attached routes
+kubectl get gateway agentgateway -n kgateway-system -o jsonpath='{.status.listeners[0].attachedRoutes}'
+# Should output: 1
+```
+
+### Get Gateway Address
+
+```bash
+# For LoadBalancer type (cloud environments)
+GATEWAY_IP=$(kubectl get gateway agentgateway -n kgateway-system -o jsonpath='{.status.addresses[0].value}')
+echo "Gateway IP: $GATEWAY_IP"
+
+# For local testing, port-forward
+kubectl port-forward -n kgateway-system svc/agentgateway 8080:8080 &
+```
+
+### Test A2A Connectivity
+
+```bash
+# Test a streaming message through the gateway
+# Note: No X-API-Key header needed - the gateway injects it!
+curl -s -X POST http://localhost:8080/a2a/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "test-1",
+    "method": "message/stream",
+    "params": {
+      "message": {
+        "messageId": "msg-1",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "hello"}]
+      }
+    }
+  }'
+```
+
+Expected response (SSE stream):
+```
+data: {"id":"test-1","jsonrpc":"2.0","result":{"contextId":"...","kind":"task","status":{"state":"submitted"}}}
+
+data: {"id":"test-1","jsonrpc":"2.0","result":{"kind":"status-update","status":{"state":"working"},...}}
+```
+
+### Test with A2A Client
+
+```bash
+# Using the agent-chat-cli
+uvx https://github.com/cnoe-io/agent-chat-cli.git a2a --host localhost --port 8080 --path /a2a/
+```
+
+## Complete Configuration Files
+
+### All-in-One Manifest
+
+```yaml
+# agentgateway-kubently.yaml
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: agentgateway
+  namespace: kgateway-system
+  labels:
+    app: agentgateway
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kubently-route
+  namespace: kubently
+spec:
+  parentRefs:
+    - name: agentgateway
+      namespace: kgateway-system
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /a2a
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            add:
+              - name: X-API-Key
+                value: "YOUR_KUBENTLY_API_KEY"
+      backendRefs:
+        - name: kubently-api
+          port: 8080
+```
+
+**Apply all resources:**
+
+```bash
+# First, patch the service for A2A protocol
+kubectl patch svc kubently-api -n kubently --type='json' -p='[
+  {"op": "add", "path": "/spec/ports/0/appProtocol", "value": "kgateway.dev/a2a"}
+]'
+
+# Then apply Gateway and HTTPRoute
+kubectl apply -f agentgateway-kubently.yaml
+```
+
+## Alternative: Path Rewriting
+
+If you want clients to access Kubently at `/` instead of `/a2a/`, you can add URL rewriting. However, be aware this can cause redirect loops if Kubently returns redirects.
+
+```yaml
+# httproute-with-rewrite.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kubently-route-rewrite
+  namespace: kubently
+spec:
+  parentRefs:
+    - name: agentgateway
+      namespace: kgateway-system
+  rules:
+    # Route /kubently/* to /a2a/* on backend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /kubently
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            add:
+              - name: X-API-Key
+                value: "YOUR_KUBENTLY_API_KEY"
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /a2a
+      backendRefs:
+        - name: kubently-api
+          port: 8080
+```
+
+> **Warning**: Avoid rewriting from `/` to `/a2a/` as this causes double-rewriting issues when the backend returns redirects.
+
+## Troubleshooting
+
+### Gateway Not Programmed
+
+```bash
+# Check Gateway status
+kubectl describe gateway agentgateway -n kgateway-system
+
+# Check kgateway controller logs
+kubectl logs -n kgateway-system -l app.kubernetes.io/name=kgateway
+```
+
+### HTTPRoute Not Accepted
+
+```bash
+# Check route status
+kubectl describe httproute kubently-route -n kubently
+
+# Common issues:
+# - Backend service doesn't exist
+# - Port mismatch
+# - Namespace permissions (check allowedRoutes)
+```
+
+### Connection Refused
+
+```bash
+# Verify backend service is running
+kubectl get pods -n kubently
+kubectl get svc kubently-api -n kubently
+
+# Check agentgateway proxy logs
+kubectl logs -n kgateway-system -l app.kubernetes.io/name=agentgateway
+```
+
+### A2A Protocol Errors
+
+```bash
+# Verify appProtocol is set
+kubectl get svc kubently-api -n kubently -o jsonpath='{.spec.ports[0].appProtocol}'
+# Should output: kgateway.dev/a2a
+
+# Test direct connectivity (bypassing gateway)
+kubectl port-forward -n kubently svc/kubently-api 8081:8080 &
+curl -s -X POST http://localhost:8081/a2a/ \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: YOUR_KEY" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"message/stream","params":{"message":{"messageId":"m1","role":"user","parts":[{"kind":"text","text":"test"}]}}}'
+```
+
+### 307 Redirect Loops
+
+If you see 307 redirects, this usually means:
+1. The path rewrite is causing double-rewrites
+2. Solution: Use `/a2a` path prefix matching without rewriting (as shown in main config)
+
+## Advanced Configuration
+
+### Adding TLS Termination
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: agentgateway
+  namespace: kgateway-system
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: agentgateway-tls
+            kind: Secret
+      allowedRoutes:
+        namespaces:
+          from: All
+```
+
+### Multiple Backend Routes
+
+Route different paths to different AI agents:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: multi-agent-route
+  namespace: kubently
+spec:
+  parentRefs:
+    - name: agentgateway
+      namespace: kgateway-system
+  rules:
+    # Route /kubently to Kubently (Kubernetes troubleshooting)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /kubently
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            add:
+              - name: X-API-Key
+                value: "KUBENTLY_API_KEY"
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /a2a
+      backendRefs:
+        - name: kubently-api
+          port: 8080
+    # Route /datadog-agent to another A2A agent
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /datadog-agent
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: datadog-agent-api
+          port: 8080
+```
+
+### CORS Configuration
+
+For browser-based AI clients, add CORS headers using a RouteOption (check kgateway docs for exact CRD syntax in your version):
+
+```yaml
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: RouteOption
+metadata:
+  name: cors-policy
+  namespace: kubently
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: kubently-route
+  options:
+    cors:
+      allowOrigins:
+        - "*"
+      allowMethods:
+        - GET
+        - POST
+        - OPTIONS
+      allowHeaders:
+        - "*"
+      exposeHeaders:
+        - "*"
+```
+
+## References
+
+- [Kubernetes Gateway API Specification](https://gateway-api.sigs.k8s.io/)
+- [kgateway Documentation](https://kgateway.dev/docs/)
+- [Agentgateway Documentation](https://kgateway.dev/docs/agentgateway/latest/)
+- [A2A Protocol Specification](https://a2a-protocol.org/latest/)
+- [Kubently Documentation](https://github.com/kubently/kubently)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -23,7 +23,7 @@ The Kubently CLI is required for administration and querying:
 
 ```bash
 # Install Node.js CLI globally
-npm install -g @kubently/cli
+npm i -g @kubently/cli
 
 # Or install from source
 git clone https://github.com/kubently/kubently.git

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -13,7 +13,7 @@ Get Kubently running locally in 5 minutes. For production deployment with extern
 
 ```bash
 # Install CLI
-npm install -g @kubently/cli
+npm i -g @kubently/cli
 
 # Clone and navigate to repo
 git clone https://github.com/kubently/kubently.git

--- a/kubently-cli/README.md
+++ b/kubently-cli/README.md
@@ -4,6 +4,18 @@ Modern Node.js CLI client for Kubently - Interactive Kubernetes Debugging System
 
 ## Installation
 
+### From npm (Recommended)
+
+```bash
+npm i -g @kubently/cli
+```
+
+Or use npx without installing:
+
+```bash
+npx @kubently/cli
+```
+
 ### From Source
 
 ```bash

--- a/kubently-cli/nodejs/CHANGELOG.md
+++ b/kubently-cli/nodejs/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.1.6] - 2025-12-17
+
+### Fixed
+- **Cluster Context Passing**: Fixed issue where cluster ID specified on command line was not passed to the agent
+  - CLI now stores and sends `clusterId` via A2A metadata extension
+  - Agent receives cluster context and uses it automatically in kubectl calls
+  - No longer asks "which cluster?" when cluster is specified via `kubently debug <cluster-id>`
+
+## [2.1.5] - 2025-12-17
+
+### Added
+- **Admin Command**: Added `kubently admin` as a standalone CLI command for direct access to cluster and token management
+  - Users can now run `kubently admin` directly instead of navigating through the interactive menu
+  - Admin operations remain accessible via interactive mode as well
+
 ## [2.1.2] - 2025-01-11
 
 ### Fixed

--- a/kubently-cli/nodejs/README.md
+++ b/kubently-cli/nodejs/README.md
@@ -34,7 +34,7 @@ A modern, beautiful Node.js/TypeScript implementation of the Kubently CLI - your
 ### Install from npm (Recommended)
 
 ```bash
-npm install -g @kubently/cli
+npm i -g @kubently/cli
 ```
 
 Or use with npx (no installation required):

--- a/kubently-cli/nodejs/package-lock.json
+++ b/kubently-cli/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubently-cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubently-cli",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/kubently-cli/nodejs/package.json
+++ b/kubently-cli/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubently/cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Modern Node.js CLI for Kubently - Troubleshooting Kubernetes Agentically",
   "type": "module",
   "main": "dist/index.js",

--- a/kubently-cli/nodejs/package.json
+++ b/kubently-cli/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubently/cli",
-  "version": "2.1.3",
+  "version": "2.1.6",
   "description": "Modern Node.js CLI for Kubently - Troubleshooting Kubernetes Agentically",
   "type": "module",
   "main": "dist/index.js",

--- a/kubently-cli/nodejs/src/commands/cluster.ts
+++ b/kubently-cli/nodejs/src/commands/cluster.ts
@@ -161,6 +161,34 @@ export function clusterCommands(config: Config): Command {
         console.log(chalk.cyan('║ ') + chalk.white('Last Seen:  ') + chalk.gray((status.lastSeen || 'Never').padEnd(46)) + chalk.cyan('║'));
         console.log(chalk.cyan('║ ') + chalk.white('Version:    ') + chalk.gray((status.version || 'Unknown').padEnd(46)) + chalk.cyan('║'));
         console.log(chalk.cyan('║ ') + chalk.white('K8s Version:') + chalk.gray((status.kubernetesVersion || 'Unknown').padEnd(46)) + chalk.cyan('║'));
+
+        // Display capability information if available
+        if (status.mode) {
+          console.log(chalk.cyan('╠═══════════════════════════════════════════════════════════╣'));
+          console.log(chalk.cyan('║') + chalk.white('                    Capabilities                           ') + chalk.cyan('║'));
+          console.log(chalk.cyan('╠═══════════════════════════════════════════════════════════╣'));
+
+          const modeColor = status.mode === 'fullAccess' ? chalk.red :
+                           status.mode === 'extendedReadOnly' ? chalk.yellow :
+                           chalk.green;
+          console.log(chalk.cyan('║ ') + chalk.white('Mode:       ') + modeColor(status.mode.padEnd(46)) + chalk.cyan('║'));
+
+          if (status.capabilities) {
+            const caps = status.capabilities;
+            const features = Object.entries(caps.features || {})
+              .filter(([_, enabled]) => enabled)
+              .map(([name]) => name)
+              .join(', ') || 'None';
+            console.log(chalk.cyan('║ ') + chalk.white('Features:   ') + chalk.gray(features.padEnd(46)) + chalk.cyan('║'));
+            console.log(chalk.cyan('║ ') + chalk.white('Verbs:      ') + chalk.gray((caps.allowed_verbs?.slice(0, 5).join(', ') + (caps.allowed_verbs?.length > 5 ? '...' : '')).padEnd(46)) + chalk.cyan('║'));
+            if (caps.executor_pod) {
+              console.log(chalk.cyan('║ ') + chalk.white('Pod:        ') + chalk.gray(caps.executor_pod.substring(0, 46).padEnd(46)) + chalk.cyan('║'));
+            }
+          }
+        } else {
+          console.log(chalk.cyan('║ ') + chalk.gray('Capabilities: Not reported (executor may need upgrade)'.padEnd(57)) + chalk.cyan('║'));
+        }
+
         console.log(chalk.cyan('╚═══════════════════════════════════════════════════════════╝'));
         
       } catch (error) {

--- a/kubently-cli/nodejs/src/commands/cluster.ts
+++ b/kubently-cli/nodejs/src/commands/cluster.ts
@@ -118,16 +118,14 @@ export function clusterCommands(config: Config): Command {
         console.log(chalk.cyan('╠═══════════════════════════════════════════════════════════╣'));
         
         clusters.forEach((cluster) => {
-          const status = cluster.connected 
-            ? chalk.green('✓ Connected') 
+          const status = cluster.connected
+            ? chalk.green('✓ Connected')
             : chalk.red('✗ Disconnected');
-          const lastSeen = cluster.lastSeen || 'Never';
-          
-          console.log(chalk.cyan('║ ') + 
-            chalk.white('ID: ') + chalk.yellow(cluster.id.padEnd(20)) + 
-            ' ' + status.padEnd(25) + 
-            chalk.gray(` Last: ${lastSeen}`.padEnd(20)) + 
-            chalk.cyan(' ║'));
+
+          console.log(chalk.cyan('║ ') +
+            chalk.white('ID: ') + chalk.yellow(cluster.id.padEnd(20)) +
+            ' ' + status.padEnd(36) +
+            chalk.cyan('║'));
         });
         
         console.log(chalk.cyan('╚═══════════════════════════════════════════════════════════╝'));
@@ -158,9 +156,7 @@ export function clusterCommands(config: Config): Command {
         console.log(chalk.cyan('║') + chalk.white(`         Cluster Status: ${clusterId}`.padEnd(59)) + chalk.cyan('║'));
         console.log(chalk.cyan('╠═══════════════════════════════════════════════════════════╣'));
         console.log(chalk.cyan('║ ') + chalk.white('Status:     ') + (status.connected ? chalk.green('✓ Connected') : chalk.red('✗ Disconnected')).padEnd(58) + chalk.cyan('║'));
-        console.log(chalk.cyan('║ ') + chalk.white('Last Seen:  ') + chalk.gray((status.lastSeen || 'Never').padEnd(46)) + chalk.cyan('║'));
         console.log(chalk.cyan('║ ') + chalk.white('Version:    ') + chalk.gray((status.version || 'Unknown').padEnd(46)) + chalk.cyan('║'));
-        console.log(chalk.cyan('║ ') + chalk.white('K8s Version:') + chalk.gray((status.kubernetesVersion || 'Unknown').padEnd(46)) + chalk.cyan('║'));
 
         // Display capability information if available
         if (status.mode) {

--- a/kubently-cli/nodejs/src/index.ts
+++ b/kubently-cli/nodejs/src/index.ts
@@ -9,6 +9,7 @@ import { debugCommand } from './commands/debug.js';
 import { createLoginCommand } from './commands/login.js';
 import { Config } from './lib/config.js';
 import { runInteractiveMode } from './commands/interactive.js';
+import { runAdminMenu } from './commands/admin.js';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -75,6 +76,14 @@ program.addCommand(createLoginCommand());
 program.addCommand(clusterCommands(config));
 program.addCommand(debugCommand(config));
 
+// Admin command - direct access to admin operations
+program
+  .command('admin')
+  .description('Manage clusters and executor tokens')
+  .action(async () => {
+    await runAdminMenu(config);
+  });
+
 // Version command with extra info
 program
   .command('version')
@@ -92,10 +101,12 @@ program
 
 // Add a default action for when no command is specified
 program.action(async () => {
-  const opts = program.opts();
-  
-  // If api-url and api-key are provided, run interactive mode
-  if (opts.apiUrl && opts.apiKey) {
+  // Use config which respects env vars and config file, not just CLI flags
+  const apiUrl = config.getApiUrl();
+  const apiKey = config.getApiKey();
+
+  // If api-url and api-key are available (from flags, env, or config), run interactive mode
+  if (apiUrl && apiKey) {
     await runInteractiveMode(config);
   } else {
     // Show help if no valid options

--- a/kubently-cli/nodejs/src/lib/a2aClient.ts
+++ b/kubently-cli/nodejs/src/lib/a2aClient.ts
@@ -20,6 +20,7 @@ export interface A2ARequest {
   method: string;
   params: {
     message: A2AMessage;
+    metadata?: Record<string, any>;  // A2A extension metadata
   };
 }
 
@@ -39,6 +40,7 @@ export class KubentlyA2ASession {
   private sessionId: string;
   private requestId: number;
   private config: Config;
+  private clusterId?: string;
 
   constructor(apiUrl: string, apiKey?: string, clusterId?: string, insecure: boolean = false) {
     // Default to https:// if no protocol specified
@@ -49,6 +51,7 @@ export class KubentlyA2ASession {
     this.sessionId = uuidv4();
     this.requestId = 0;
     this.config = new Config();
+    this.clusterId = clusterId;
 
     // Build headers based on authentication method
     const headers: Record<string, string> = {
@@ -105,6 +108,8 @@ export class KubentlyA2ASession {
           }],
           contextId: this.sessionId,  // contextId must be inside message
         },
+        // Pass cluster context via A2A metadata extension
+        metadata: this.clusterId ? { clusterId: this.clusterId } : undefined,
       },
     };
     

--- a/kubently-cli/nodejs/src/lib/adminClient.ts
+++ b/kubently-cli/nodejs/src/lib/adminClient.ts
@@ -6,6 +6,19 @@ export interface AgentToken {
   createdAt: string;
 }
 
+export interface ExecutorCapabilities {
+  cluster_id: string;
+  mode: string;
+  allowed_verbs: string[];
+  restricted_resources: string[];
+  allowed_flags: string[];
+  executor_version?: string;
+  executor_pod?: string;
+  reported_at?: string;
+  expires_at?: string;
+  features: Record<string, boolean>;
+}
+
 export interface ClusterStatus {
   id: string;
   status: string;
@@ -13,6 +26,8 @@ export interface ClusterStatus {
   lastSeen?: string;
   version?: string;
   kubernetesVersion?: string;
+  mode?: string;  // Security mode (readOnly, extendedReadOnly, fullAccess)
+  capabilities?: ExecutorCapabilities;  // Full capability details
 }
 
 export interface ClusterListItem {

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -45,6 +45,7 @@ from kubently.modules.api.oidc_discovery import create_discovery_router
 from kubently.modules.config import get_config
 from kubently.modules.queue import QueueModule
 from kubently.modules.session import SessionModule
+from kubently.modules.capability import CapabilityModule, ExecutorCapabilities
 
 # Get configuration
 config = get_config()
@@ -63,6 +64,7 @@ config_provider: ConfigProvider = EnvConfigProvider()
 auth_service: Optional[AuthenticationService] = None
 session_module: Optional[SessionModule] = None
 queue_module: Optional[QueueModule] = None
+capability_module: Optional[CapabilityModule] = None
 redis_client: Optional[redis.Redis] = None
 a2a_server = None  # A2A server instance
 a2a_app = None  # A2A FastAPI sub-application
@@ -112,7 +114,7 @@ async def lifespan(app: FastAPI):
     """
     Manage application lifecycle - initialize and cleanup resources.
     """
-    global auth_service, session_module, queue_module, redis_client, a2a_server
+    global auth_service, session_module, queue_module, capability_module, redis_client, a2a_server
 
     # Startup
     logger.info("Starting Kubently API  ...")
@@ -126,6 +128,9 @@ async def lifespan(app: FastAPI):
     session_module = SessionModule(redis_client, default_ttl=config.get("session_ttl"))
     queue_module = QueueModule(
         redis_client, max_commands_per_fetch=config.get("max_commands_per_fetch")
+    )
+    capability_module = CapabilityModule(
+        redis_client, default_ttl=config.get("capability_ttl", 3600)
     )
 
     # Mount A2A server (core functionality)
@@ -342,6 +347,155 @@ async def post_result(payload: CommandResult, cluster_id: str = Depends(verify_e
     await queue_module.store_result(payload.command_id, payload.dict())
 
     return {"status": "accepted", "command_id": payload.command_id}
+
+
+# Capability Endpoints (Executor capability reporting)
+
+
+class CapabilityReport(BaseModel):
+    """Capability report from executor - maps to DynamicCommandWhitelist config."""
+
+    mode: str = Field(
+        ...,
+        pattern=r"^(readOnly|extendedReadOnly|fullAccess)$",
+        description="Security mode (readOnly, extendedReadOnly, fullAccess)"
+    )
+    allowed_verbs: list[str] = Field(
+        default_factory=list,
+        max_length=50,
+        description="Allowed kubectl verbs"
+    )
+    restricted_resources: list[str] = Field(
+        default_factory=list,
+        max_length=50,
+        description="Restricted resources"
+    )
+    allowed_flags: list[str] = Field(
+        default_factory=list,
+        max_length=100,
+        description="Allowed flags"
+    )
+    executor_version: Optional[str] = Field(
+        None,
+        max_length=50,
+        description="Executor version"
+    )
+    executor_pod: Optional[str] = Field(
+        None,
+        max_length=253,  # Max K8s pod name length
+        description="Executor pod name"
+    )
+
+
+@app.post("/executor/capabilities")
+async def report_capabilities(
+    report: CapabilityReport,
+    cluster_id: str = Depends(verify_executor_auth),
+):
+    """
+    Report executor capabilities to central API.
+
+    Called by executors on startup to advertise their DynamicCommandWhitelist
+    configuration. This allows the API and agent to know what each cluster
+    can do before sending commands.
+
+    This endpoint is optional - executors that don't report capabilities
+    will still function normally (graceful degradation).
+
+    Returns:
+        200: Capabilities stored successfully
+        401: Unauthorized
+        503: Service not initialized
+    """
+    if not capability_module:
+        raise HTTPException(503, "Service not initialized")
+
+    # Convert report to ExecutorCapabilities
+    capabilities = ExecutorCapabilities(
+        cluster_id=cluster_id,
+        mode=report.mode,
+        allowed_verbs=report.allowed_verbs,
+        restricted_resources=report.restricted_resources,
+        allowed_flags=report.allowed_flags,
+        executor_version=report.executor_version,
+        executor_pod=report.executor_pod,
+        features={
+            "exec": report.mode in ["extendedReadOnly", "fullAccess"],
+            "port_forward": report.mode in ["extendedReadOnly", "fullAccess"],
+            "proxy": report.mode == "fullAccess",
+        },
+    )
+
+    success = await capability_module.store_capabilities(capabilities)
+    if not success:
+        raise HTTPException(500, "Failed to store capabilities")
+
+    return {
+        "status": "success",
+        "message": f"Capabilities stored for cluster {cluster_id}",
+        "mode": report.mode,
+        "ttl_seconds": capability_module.default_ttl,
+    }
+
+
+@app.post("/executor/heartbeat")
+async def executor_heartbeat(
+    cluster_id: str = Depends(verify_executor_auth),
+):
+    """
+    Refresh capability TTL (heartbeat).
+
+    Called periodically by executors to keep their capabilities from expiring.
+    This is optional - if capabilities expire, the system continues to function
+    normally without them.
+
+    Returns:
+        200: TTL refreshed
+        404: No capabilities found (executor may need to re-report)
+        401: Unauthorized
+    """
+    if not capability_module:
+        raise HTTPException(503, "Service not initialized")
+
+    success = await capability_module.refresh_ttl(cluster_id)
+    if not success:
+        # Not an error - just means no capabilities stored (graceful degradation)
+        return {
+            "status": "not_found",
+            "message": f"No capabilities found for cluster {cluster_id}. Consider re-reporting.",
+        }
+
+    return {
+        "status": "success",
+        "message": f"TTL refreshed for cluster {cluster_id}",
+    }
+
+
+@app.get("/api/v1/clusters/{cluster_id}/capabilities")
+async def get_cluster_capabilities(
+    cluster_id: str,
+    auth_info: Tuple[bool, Optional[str]] = Depends(verify_api_key),
+):
+    """
+    Get capabilities for a specific cluster.
+
+    Used by agents to check what operations are allowed before executing commands.
+    Returns null capabilities if none are stored (graceful degradation).
+
+    Returns:
+        200: Capabilities (or null if not stored)
+        401: Unauthorized
+    """
+    if not capability_module:
+        raise HTTPException(503, "Service not initialized")
+
+    capabilities = await capability_module.get_capabilities(cluster_id)
+
+    return {
+        "clusterId": cluster_id,
+        "capabilities": capabilities.to_dict() if capabilities else None,
+        "available": capabilities is not None,
+    }
 
 
 # AI/User/A2A Service Endpoints
@@ -746,6 +900,9 @@ async def revoke_agent_token(
         # Also remove cluster active marker if exists
         await redis_client.delete(f"cluster:active:{cluster_id}")
 
+        # Clean up capabilities to prevent stale advertisements
+        await redis_client.delete(f"cluster:{cluster_id}:capabilities")
+
         logger.info(f"Revoked executor token for cluster: {cluster_id}")
         return Response(status_code=204)
         
@@ -803,6 +960,56 @@ async def list_clusters(
 
     except Exception as e:
         logger.error(f"Failed to list clusters: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/debug/clusters/{cluster_id}")
+async def get_cluster_detail(
+    cluster_id: str,
+    auth_info: Tuple[bool, Optional[str]] = Depends(verify_api_key),
+):
+    """
+    Get detailed status for a specific cluster, including capabilities.
+
+    Returns comprehensive cluster information including:
+    - Token status (whether executor token exists)
+    - Active session status
+    - Executor capabilities (if reported)
+    - Capability TTL remaining
+
+    This endpoint supports graceful degradation - if capabilities haven't
+    been reported, the capabilities field will be null but other status
+    information will still be returned.
+
+    Returns:
+        200: Cluster details
+        401: Unauthorized
+        404: Cluster not found
+    """
+    if not capability_module:
+        raise HTTPException(503, "Service not initialized")
+
+    try:
+        # Use capability module's aggregation method
+        detail = await capability_module.get_cluster_detail(cluster_id)
+
+        # Check if cluster exists at all (has token, session, or capabilities)
+        has_token = detail["status"].get("hasToken", False)
+        has_session = detail["status"].get("hasActiveSession", False)
+        has_capabilities = detail["status"].get("executorReporting", False)
+
+        if not (has_token or has_session or has_capabilities):
+            raise HTTPException(
+                status_code=404,
+                detail=f"Cluster '{cluster_id}' not found. No token, session, or capabilities exist.",
+            )
+
+        return detail
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get cluster detail for {cluster_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
@@ -59,14 +59,18 @@ class KubentlyAgentExecutor(AgentExecutor):
         
         # Use context_id from message like mas-agent-atlassian does
         contextId = context.message.context_id if context.message else None
-        
-        # Debug logging to track context ID
+
+        # Extract cluster ID from A2A metadata extension
+        cluster_id = context.metadata.get('clusterId') if context.metadata else None
+
+        # Debug logging to track context ID and cluster
         logger.info(f"Debug context IDs:")
         logger.info(f"  - context.context_id: {context.context_id}")
         logger.info(f"  - context.message.context_id: {contextId}")
         logger.info(f"  - task.contextId: {task.contextId if task else None}")
-        
-        logger.info(f"Using contextId: {contextId}")
+        logger.info(f"  - cluster_id (from metadata): {cluster_id}")
+
+        logger.info(f"Using contextId: {contextId}, cluster_id: {cluster_id}")
 
         if not context.message:
             raise Exception("No message provided")
@@ -117,9 +121,9 @@ class KubentlyAgentExecutor(AgentExecutor):
         interceptor = get_tool_call_interceptor()
         
         try:
-            logger.info(f"Starting agent execution for query: {query[:100]}")
+            logger.info(f"Starting agent execution for query: {query[:100]}, cluster_id: {cluster_id}")
             chunk_count = 0
-            async for chunk in self.agent.run(messages, thread_id=contextId):
+            async for chunk in self.agent.run(messages, thread_id=contextId, cluster_id=cluster_id):
                 chunk_count += 1
                 # Chunk is a dict, extract content for logging
                 chunk_str = str(chunk)[:100] if chunk else 'EMPTY'

--- a/kubently/modules/capability/__init__.py
+++ b/kubently/modules/capability/__init__.py
@@ -1,0 +1,15 @@
+"""
+Capability Module - Black Box Interface
+
+Purpose: Store and retrieve executor capability advertisements
+Interface: store_capabilities(), get_capabilities(), refresh_ttl()
+Hidden: Redis storage, TTL management, serialization
+
+Provides graceful degradation - missing capabilities don't break functionality.
+Executors report what they can do; agent uses this for better UX but doesn't
+require it for operation.
+"""
+
+from .capability import CapabilityModule, ExecutorCapabilities
+
+__all__ = ["CapabilityModule", "ExecutorCapabilities"]

--- a/kubently/modules/capability/capability.py
+++ b/kubently/modules/capability/capability.py
@@ -1,0 +1,335 @@
+"""
+Capability Module for Kubently API.
+
+This module handles storage and retrieval of executor capability advertisements.
+Executors report their DynamicCommandWhitelist configuration on startup, allowing
+the API and agent to know what each cluster can do before sending commands.
+
+Design Principles:
+- Graceful degradation: Missing capabilities = proceed with current behavior
+- Non-blocking: Capability operations never block core functionality
+- TTL-based: Capabilities expire if executor stops heartbeating
+"""
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("kubently.capability")
+
+
+@dataclass
+class ExecutorCapabilities:
+    """
+    Capability report from an executor.
+
+    Maps directly to DynamicCommandWhitelist.get_config_summary() output,
+    with additional metadata for tracking.
+    """
+
+    cluster_id: str
+    mode: str  # "readOnly", "extendedReadOnly", "fullAccess"
+    allowed_verbs: List[str]
+    restricted_resources: List[str] = field(default_factory=list)
+    allowed_flags: List[str] = field(default_factory=list)
+
+    # Metadata
+    executor_version: Optional[str] = None
+    executor_pod: Optional[str] = None
+    reported_at: Optional[str] = None
+    expires_at: Optional[str] = None
+
+    # Feature flags derived from mode
+    features: Dict[str, bool] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ExecutorCapabilities":
+        """Create from dictionary (e.g., from JSON)."""
+        return cls(
+            cluster_id=data.get("cluster_id", ""),
+            mode=data.get("mode", "unknown"),
+            allowed_verbs=data.get("allowed_verbs", []),
+            restricted_resources=data.get("restricted_resources", []),
+            allowed_flags=data.get("allowed_flags", []),
+            executor_version=data.get("executor_version"),
+            executor_pod=data.get("executor_pod"),
+            reported_at=data.get("reported_at"),
+            expires_at=data.get("expires_at"),
+            features=data.get("features", {}),
+        )
+
+    @classmethod
+    def from_whitelist_summary(
+        cls,
+        cluster_id: str,
+        summary: Dict[str, Any],
+        executor_version: Optional[str] = None,
+        executor_pod: Optional[str] = None,
+    ) -> "ExecutorCapabilities":
+        """
+        Create from DynamicCommandWhitelist.get_config_summary() output.
+
+        This is the primary way executors create capability reports.
+        """
+        mode = summary.get("mode", "unknown")
+
+        # Derive feature flags from mode
+        features = {
+            "exec": mode in ["extendedReadOnly", "fullAccess"],
+            "port_forward": mode in ["extendedReadOnly", "fullAccess"],
+            "proxy": mode == "fullAccess",
+            "cp": mode == "fullAccess",
+        }
+
+        return cls(
+            cluster_id=cluster_id,
+            mode=mode,
+            allowed_verbs=summary.get("allowed_verbs", []),
+            restricted_resources=list(summary.get("restricted_resources", [])),
+            allowed_flags=list(summary.get("allowed_flags", [])),
+            executor_version=executor_version,
+            executor_pod=executor_pod,
+            features=features,
+        )
+
+
+class CapabilityModule:
+    """
+    Manages executor capability storage in Redis.
+
+    Follows the same patterns as SessionModule and AuthModule:
+    - Receives redis_client in __init__
+    - Uses consistent key naming (cluster:{id}:capabilities)
+    - TTL-based expiration with heartbeat refresh
+    """
+
+    # Default TTL: 1 hour - executors should heartbeat every 5 minutes
+    DEFAULT_TTL = 3600
+
+    def __init__(self, redis_client, default_ttl: int = DEFAULT_TTL):
+        """
+        Initialize capability module.
+
+        Args:
+            redis_client: Async Redis client from API Core
+            default_ttl: TTL for capability records in seconds (default: 1 hour)
+        """
+        self.redis = redis_client
+        self.default_ttl = default_ttl
+
+    def _key(self, cluster_id: str) -> str:
+        """Generate Redis key for cluster capabilities."""
+        return f"cluster:{cluster_id}:capabilities"
+
+    async def store_capabilities(
+        self, capabilities: ExecutorCapabilities
+    ) -> bool:
+        """
+        Store executor capabilities in Redis.
+
+        Args:
+            capabilities: Capability report from executor
+
+        Returns:
+            True if stored successfully, False otherwise
+        """
+        try:
+            key = self._key(capabilities.cluster_id)
+
+            # Add timestamps
+            now = datetime.now(UTC)
+            capabilities.reported_at = now.isoformat()
+            capabilities.expires_at = (
+                now + timedelta(seconds=self.default_ttl)
+            ).isoformat()
+
+            # Store with TTL
+            data = json.dumps(capabilities.to_dict())
+            await self.redis.setex(key, self.default_ttl, data)
+
+            logger.info(
+                f"Stored capabilities for cluster {capabilities.cluster_id} "
+                f"(mode: {capabilities.mode}, TTL: {self.default_ttl}s)"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to store capabilities: {e}")
+            return False
+
+    async def get_capabilities(
+        self, cluster_id: str
+    ) -> Optional[ExecutorCapabilities]:
+        """
+        Retrieve executor capabilities from Redis.
+
+        Args:
+            cluster_id: Cluster identifier
+
+        Returns:
+            ExecutorCapabilities if found, None otherwise
+        """
+        try:
+            key = self._key(cluster_id)
+            data = await self.redis.get(key)
+
+            if not data:
+                logger.debug(f"No capabilities found for cluster {cluster_id}")
+                return None
+
+            # Handle bytes from Redis
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+
+            return ExecutorCapabilities.from_dict(json.loads(data))
+
+        except Exception as e:
+            logger.error(f"Failed to get capabilities for {cluster_id}: {e}")
+            return None
+
+    async def refresh_ttl(self, cluster_id: str) -> bool:
+        """
+        Refresh TTL on heartbeat from executor.
+
+        Args:
+            cluster_id: Cluster identifier
+
+        Returns:
+            True if TTL was refreshed, False if key doesn't exist
+        """
+        try:
+            key = self._key(cluster_id)
+
+            # Check if key exists
+            if not await self.redis.exists(key):
+                logger.debug(f"Cannot refresh TTL - no capabilities for {cluster_id}")
+                return False
+
+            # Update expires_at in the stored data
+            data = await self.redis.get(key)
+            if data:
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+
+                capabilities = json.loads(data)
+                capabilities["expires_at"] = (
+                    datetime.now(UTC) + timedelta(seconds=self.default_ttl)
+                ).isoformat()
+
+                # Re-store with fresh TTL
+                await self.redis.setex(key, self.default_ttl, json.dumps(capabilities))
+                logger.debug(f"Refreshed TTL for cluster {cluster_id}")
+                return True
+
+            return False
+
+        except Exception as e:
+            logger.error(f"Failed to refresh TTL for {cluster_id}: {e}")
+            return False
+
+    async def delete_capabilities(self, cluster_id: str) -> bool:
+        """
+        Delete capabilities for a cluster.
+
+        Args:
+            cluster_id: Cluster identifier
+
+        Returns:
+            True if deleted, False otherwise
+        """
+        try:
+            key = self._key(cluster_id)
+            result = await self.redis.delete(key)
+            return result > 0
+
+        except Exception as e:
+            logger.error(f"Failed to delete capabilities for {cluster_id}: {e}")
+            return False
+
+    async def list_all_capabilities(self) -> List[ExecutorCapabilities]:
+        """
+        List capabilities for all clusters.
+
+        Used for admin/monitoring purposes.
+
+        Returns:
+            List of all stored capabilities
+        """
+        try:
+            # Find all capability keys
+            pattern = "cluster:*:capabilities"
+            keys = await self.redis.keys(pattern)
+
+            capabilities_list = []
+            for key in keys:
+                if isinstance(key, bytes):
+                    key = key.decode("utf-8")
+
+                # Extract cluster_id from key
+                parts = key.split(":")
+                if len(parts) >= 2:
+                    cluster_id = parts[1]
+                    caps = await self.get_capabilities(cluster_id)
+                    if caps:
+                        capabilities_list.append(caps)
+
+            return capabilities_list
+
+        except Exception as e:
+            logger.error(f"Failed to list capabilities: {e}")
+            return []
+
+    async def get_cluster_detail(self, cluster_id: str) -> Dict[str, Any]:
+        """
+        Get detailed cluster status including capabilities.
+
+        This aggregates data from multiple Redis keys for admin display.
+
+        Args:
+            cluster_id: Cluster identifier
+
+        Returns:
+            Dictionary with cluster status and capabilities
+        """
+        try:
+            # Check for executor token
+            token_key = f"executor:token:{cluster_id}"
+            has_token = await self.redis.exists(token_key) > 0
+
+            # Check for active session
+            session_key = f"cluster:active:{cluster_id}"
+            has_active_session = await self.redis.exists(session_key) > 0
+
+            # Get capabilities (may be None)
+            capabilities = await self.get_capabilities(cluster_id)
+
+            # Calculate TTL remaining
+            ttl_remaining = None
+            if capabilities:
+                caps_key = self._key(cluster_id)
+                ttl_remaining = await self.redis.ttl(caps_key)
+
+            return {
+                "clusterId": cluster_id,
+                "status": {
+                    "hasToken": has_token,
+                    "hasActiveSession": has_active_session,
+                    "executorReporting": capabilities is not None,
+                },
+                "capabilities": capabilities.to_dict() if capabilities else None,
+                "ttlRemaining": ttl_remaining,
+            }
+
+        except Exception as e:
+            logger.error(f"Failed to get cluster detail for {cluster_id}: {e}")
+            return {
+                "clusterId": cluster_id,
+                "status": {"error": str(e)},
+                "capabilities": None,
+            }

--- a/kubently/modules/executor/sse_executor.py
+++ b/kubently/modules/executor/sse_executor.py
@@ -5,6 +5,10 @@ SSE Kubently Executor - Server-Sent Events based executor.
 This executor uses SSE for real-time command reception, eliminating
 polling and providing instant command delivery in a horizontally
 scaled environment.
+
+Optional capability reporting allows the executor to advertise its
+DynamicCommandWhitelist configuration to the central API, enabling
+capability-aware agent behavior.
 """
 
 import asyncio
@@ -16,11 +20,18 @@ import sys
 import time
 from queue import Queue
 from threading import Thread
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 import requests
 import sseclient
+
+# Optional import - DynamicCommandWhitelist may not be available in all deployments
+try:
+    from kubently.modules.executor.dynamic_whitelist import DynamicCommandWhitelist
+    WHITELIST_AVAILABLE = True
+except ImportError:
+    WHITELIST_AVAILABLE = False
 
 # Configure logging
 logging.basicConfig(
@@ -47,7 +58,20 @@ class SSEKubentlyExecutor:
         # TLS configuration
         self.verify_ssl = os.environ.get("KUBENTLY_SSL_VERIFY", "true").lower() == "true"
         self.ca_cert_path = os.environ.get("KUBENTLY_CA_CERT", None)
-        
+
+        # Capability reporting configuration (optional, disabled by default)
+        # Enable with KUBENTLY_REPORT_CAPABILITIES=true
+        self.report_capabilities = os.environ.get(
+            "KUBENTLY_REPORT_CAPABILITIES", "false"
+        ).lower() == "true"
+        self.heartbeat_interval = int(os.environ.get("KUBENTLY_HEARTBEAT_INTERVAL", "300"))
+        self.whitelist_config_path = os.environ.get(
+            "KUBENTLY_WHITELIST_CONFIG", "/etc/kubently/whitelist.yaml"
+        )
+
+        # Track last heartbeat time
+        self._last_heartbeat = 0
+
         # Security validation: Warn if using HTTP in production
         if self.api_url.startswith("http://") and self.verify_ssl:
             logger.warning("⚠️  Using HTTP without TLS - this should only be used for local development!")
@@ -64,14 +88,22 @@ class SSEKubentlyExecutor:
         }
 
         logger.info(f"SSE executor initialized for cluster: {self.cluster_id}")
+        if self.report_capabilities:
+            logger.info(f"Capability reporting enabled (heartbeat every {self.heartbeat_interval}s)")
 
     def run(self) -> None:
         """
         Main executor loop.
 
         Starts SSE listener and command processor threads.
+        If capability reporting is enabled, reports capabilities on startup.
         """
         logger.info("Starting SSE executor")
+
+        # Report capabilities on startup (if enabled)
+        # This is best-effort - failure doesn't prevent executor from running
+        if self.report_capabilities:
+            self._report_capabilities_on_startup()
 
         # Start command processor thread
         processor_thread = Thread(target=self._process_commands, daemon=True)
@@ -126,6 +158,10 @@ class SSEKubentlyExecutor:
                 elif event.event == "keepalive":
                     # Keepalive received, connection is healthy
                     logger.debug("Keepalive received")
+
+                # Always check heartbeat on any event (not just keepalive)
+                # This ensures high command traffic doesn't starve the heartbeat
+                self._maybe_send_heartbeat()
 
             except json.JSONDecodeError as e:
                 logger.error(f"Failed to parse event data: {e}")
@@ -245,6 +281,130 @@ class SSEKubentlyExecutor:
                 "status": "ERROR",
                 "return_code": -1,
             }
+
+    # Capability Reporting Methods
+
+    def _get_capabilities_payload(self) -> Dict[str, Any]:
+        """
+        Gather capabilities from DynamicCommandWhitelist or use defaults.
+
+        Returns:
+            Dictionary with capability data for the API
+        """
+        # Try to use DynamicCommandWhitelist if available
+        if WHITELIST_AVAILABLE:
+            try:
+                whitelist = DynamicCommandWhitelist(config_path=self.whitelist_config_path)
+                summary = whitelist.get_config_summary()
+                return {
+                    "mode": summary.get("mode", "readOnly"),
+                    "allowed_verbs": summary.get("allowed_verbs", []),
+                    "restricted_resources": list(summary.get("restricted_resources", [])),
+                    "allowed_flags": list(summary.get("allowed_flags", [])),
+                    "executor_version": os.environ.get("EXECUTOR_VERSION", "unknown"),
+                    "executor_pod": os.environ.get("HOSTNAME", "unknown"),
+                }
+            except Exception as e:
+                logger.warning(f"Failed to load whitelist config: {e}, using defaults")
+
+        # Default capabilities (readOnly mode)
+        return {
+            "mode": "readOnly",
+            "allowed_verbs": ["get", "describe", "logs", "top", "explain", "api-resources"],
+            "restricted_resources": ["secrets", "configmaps"],
+            "allowed_flags": ["--namespace", "--all-namespaces", "--selector"],
+            "executor_version": os.environ.get("EXECUTOR_VERSION", "unknown"),
+            "executor_pod": os.environ.get("HOSTNAME", "unknown"),
+        }
+
+    def _report_capabilities_on_startup(self) -> None:
+        """
+        Report capabilities to the API on startup.
+
+        This is best-effort - if it fails, the executor continues normally.
+        The API may not have the capability endpoint (older version), which is fine.
+        """
+        try:
+            url = f"{self.api_url}/executor/capabilities"
+            payload = self._get_capabilities_payload()
+
+            logger.info(f"Reporting capabilities to {url}")
+            logger.debug(f"Capability payload: {payload}")
+
+            verify_setting = self.ca_cert_path if self.ca_cert_path else self.verify_ssl
+
+            response = requests.post(
+                url,
+                json=payload,
+                headers=self.headers,
+                timeout=10,
+                verify=verify_setting,
+            )
+
+            if response.status_code == 200:
+                logger.info(f"Capabilities reported successfully (mode: {payload['mode']})")
+                self._last_heartbeat = time.time()
+            elif response.status_code == 404:
+                # API doesn't have capability endpoint - older version
+                logger.info("Capability endpoint not available (API may be older version), skipping")
+                # Disable further reporting to avoid repeated 404s
+                self.report_capabilities = False
+            else:
+                logger.warning(f"Capability report returned {response.status_code}: {response.text}")
+
+        except requests.exceptions.ConnectionError:
+            logger.warning("Could not connect to API for capability reporting, will retry on heartbeat")
+        except Exception as e:
+            logger.warning(f"Failed to report capabilities: {e}")
+
+    def _send_heartbeat(self) -> None:
+        """
+        Send heartbeat to refresh capability TTL.
+
+        Called periodically during SSE keepalive processing.
+        """
+        try:
+            url = f"{self.api_url}/executor/heartbeat"
+            verify_setting = self.ca_cert_path if self.ca_cert_path else self.verify_ssl
+
+            response = requests.post(
+                url,
+                headers=self.headers,
+                timeout=5,
+                verify=verify_setting,
+            )
+
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("status") == "not_found":
+                    # Capabilities expired - re-report them
+                    logger.info("Capabilities expired, re-reporting...")
+                    self._report_capabilities_on_startup()
+                else:
+                    logger.debug("Heartbeat sent successfully")
+                    self._last_heartbeat = time.time()
+            elif response.status_code == 404:
+                # API doesn't have heartbeat endpoint - disable
+                logger.debug("Heartbeat endpoint not available, disabling capability reporting")
+                self.report_capabilities = False
+            else:
+                logger.debug(f"Heartbeat returned {response.status_code}")
+
+        except Exception as e:
+            logger.debug(f"Heartbeat failed: {e}")
+
+    def _maybe_send_heartbeat(self) -> None:
+        """
+        Send heartbeat if enough time has passed since the last one.
+
+        Called during SSE keepalive processing for efficiency.
+        """
+        if not self.report_capabilities:
+            return
+
+        current_time = time.time()
+        if current_time - self._last_heartbeat >= self.heartbeat_interval:
+            self._send_heartbeat()
 
 
 def main():

--- a/prompts/system.prompt.yaml
+++ b/prompts/system.prompt.yaml
@@ -95,29 +95,27 @@ content: |-
 
   # Task Management
 
-  You have access to the todo_write tool to help you manage and track debugging workflows. Use this tool VERY frequently to ensure that you are tracking your debugging progress and giving the user visibility into your investigation.
-  This tool is EXTREMELY helpful for complex issues that require checking multiple resources and correlating information. If you do not use this tool when debugging complex issues, you may miss important steps - and that is unacceptable.
+  You have access to the todo_write tool to help you manage debugging workflows. Use this tool at the START of complex investigations to plan your approach, then ONLY update it when you've COMPLETED the investigation or found the answer.
 
-  It is critical that you mark todos as completed as soon as you finish each debugging step. Do not batch up multiple tasks before marking them as completed.
+  IMPORTANT: Do NOT call todo_write after every kubectl command. This wastes tokens and slows down debugging. Only use it:
+  - Once at the START to plan (if the issue is complex)
+  - Once at the END to mark completed (if you used it at the start)
+
+  For simple issues (1-3 kubectl commands), skip todo_write entirely.
 
   Examples:
 
   <example>
   user: Debug why my pods are not starting
-  assistant: I'm going to use the todo_write tool to track our debugging steps:
-  - Check pod status and events
-  - Examine pod descriptions for errors
-  - Review container logs
-  - Verify image availability
-  - Check resource constraints
+  assistant: [runs kubectl get pods -n namespace]
 
-  Let me start by checking the pod status...
+  I see the pod is in ImagePullBackOff state. Let me check the events:
 
-  [runs kubectl get pods -n namespace]
+  [runs kubectl get events -n namespace --field-selector involvedObject.name=nginx-pod]
 
-  I found the issue: ImagePullBackOff - the container image 'nginx:latests' has a typo (should be 'nginx:latest')
+  Root cause: The container image 'nginx:latests' has a typo - should be 'nginx:latest'.
 
-  [marks todos as completed]
+  Fix: Update the deployment image to `nginx:latest`
   </example>
 
   <example>
@@ -172,11 +170,11 @@ content: |-
 
   # Tool usage policy
 
-  - When debugging complex issues, always use todo_write to track your investigation steps
   - When debugging, always start with non-invasive read operations (get, describe, logs)
   - Use the most specific kubectl commands to reduce output noise
   - Batch multiple kubectl commands when investigating related resources
   - When checking multiple namespaces, use -A flag efficiently
+  - STOP and provide your answer once you've identified the issue - don't over-investigate
 
   # Token-Efficient kubectl Patterns
 
@@ -230,20 +228,27 @@ content: |-
 
   ## Critical Behaviors
 
+  ### WHEN TO STOP AND RESPOND:
+  IMPORTANT: You MUST stop investigating and provide your answer when ANY of these conditions are met:
+  - You found the root cause (e.g., CrashLoopBackOff with clear error in logs)
+  - You gathered enough evidence to explain the issue
+  - You've made 5+ tool calls - synthesize what you know and respond
+  - The user asked a simple question that doesn't need deep investigation
+
+  DO NOT keep investigating indefinitely. After finding an issue, STOP and tell the user what you found.
+
   ### DO:
-  - Use todo_write for complex multi-step debugging
-  - Use multiple commands to verify each finding
+  - Stop and respond once you identify the issue
   - Check events, logs, and descriptions
   - Look at timestamps and correlate events
   - Consider recent changes or deployments
   - Verify network paths (service → endpoints → pods)
-  - Check resource quotas and limits
-  - Examine node health and capacity
 
   ### DON'T:
+  - Keep calling tools after you've found the answer
+  - Use todo_write after every kubectl command
   - Assume resource names match namespace names
-  - Trust a single data point
-  - Skip "obvious" checks
+  - Trust a single data point without context
   - Ignore warning events
   - Overlook RBAC or security contexts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,12 @@ addopts = """
     --cov-report=html
     --cov-report=xml
 """
+markers = [
+    "kubectl_mock: Tests using mocked kubectl subprocess calls",
+    "integration: Integration tests requiring infrastructure",
+    "e2e: End-to-end tests requiring a real cluster",
+    "slow: Tests that take a long time to run",
+]
 
 [tool.coverage.run]
 source = ["kubently"]

--- a/test-automation/scenarios/03-crashloopbackoff.sh
+++ b/test-automation/scenarios/03-crashloopbackoff.sh
@@ -4,14 +4,15 @@
 # SYMPTOM: Pod repeatedly crashes and restarts, showing CrashLoopBackOff status
 # THE FIX: Fix the command to not exit with error code (remove 'exit 1' or change to successful command)
 
-
+# Allow context override: KUBE_CONTEXT=kind-kind-exec-only ./03-crashloopbackoff.sh setup
+KUBE_CONTEXT="${KUBE_CONTEXT:-kind-kubently}"
 NAMESPACE="test-scenario-03"
 
 if [ "$1" = "setup" ]; then
-    echo "Setting up scenario 03..."
-    
-    kubectl --context kind-kubently create namespace $NAMESPACE --dry-run=client -o yaml | kubectl --context kind-kubently apply -f -
-    cat <<EOF | kubectl --context kind-kubently apply -f -
+    echo "Setting up scenario 03 on context: $KUBE_CONTEXT..."
+
+    kubectl --context $KUBE_CONTEXT create namespace $NAMESPACE --dry-run=client -o yaml | kubectl --context $KUBE_CONTEXT apply -f -
+    cat <<EOF | kubectl --context $KUBE_CONTEXT apply -f -
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -40,8 +41,8 @@ EOF
 fi
 
 if [ "$1" = "cleanup" ]; then
-    echo "Cleaning up scenario 03..."
-    kubectl --context kind-kubently delete namespace $NAMESPACE --ignore-not-found=true
+    echo "Cleaning up scenario 03 on context: $KUBE_CONTEXT..."
+    kubectl --context $KUBE_CONTEXT delete namespace $NAMESPACE --ignore-not-found=true
     exit 0
 fi
 

--- a/test-automation/scenarios/04-runcontainer-missing-configmap.sh
+++ b/test-automation/scenarios/04-runcontainer-missing-configmap.sh
@@ -4,31 +4,32 @@
 # SYMPTOM: Pod stuck in CreateContainerConfigError state
 # THE FIX: Create the missing ConfigMap 'app-config' or remove the envFrom reference
 
-
+# Allow context override: KUBE_CONTEXT=kind-kind-exec-only ./04-runcontainer-missing-configmap.sh setup
+KUBE_CONTEXT="${KUBE_CONTEXT:-kind-kubently}"
 NAMESPACE="test-scenario-04"
 
 if [ "$1" = "setup" ]; then
-    echo "Setting up scenario 04..."
-    
-    kubectl --context kind-kubently create namespace $NAMESPACE --dry-run=client -o yaml | kubectl --context kind-kubently apply -f -
-    cat <<EOF | kubectl --context kind-kubently apply -f -
+    echo "Setting up scenario 04 on context: $KUBE_CONTEXT..."
+
+    kubectl --context $KUBE_CONTEXT create namespace $NAMESPACE --dry-run=client -o yaml | kubectl --context $KUBE_CONTEXT apply -f -
+    cat <<EOF | kubectl --context $KUBE_CONTEXT apply -f -
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: missing-configmap-deployment
+      name: payment-service
       namespace: $NAMESPACE
     spec:
       replicas: 1
       selector:
         matchLabels:
-          app: configmap-app
+          app: payment
       template:
         metadata:
           labels:
-            app: configmap-app
+            app: payment
         spec:
           containers:
-          - name: app
+          - name: api
             image: busybox:latest
             command: ["sh", "-c", "env && sleep 3600"]
             envFrom:
@@ -43,8 +44,8 @@ EOF
 fi
 
 if [ "$1" = "cleanup" ]; then
-    echo "Cleaning up scenario 04..."
-    kubectl --context kind-kubently delete namespace $NAMESPACE --ignore-not-found=true
+    echo "Cleaning up scenario 04 on context: $KUBE_CONTEXT..."
+    kubectl --context $KUBE_CONTEXT delete namespace $NAMESPACE --ignore-not-found=true
     exit 0
 fi
 

--- a/test-automation/scenarios/06-oomkilled.sh
+++ b/test-automation/scenarios/06-oomkilled.sh
@@ -4,14 +4,15 @@
 # SYMPTOM: Pod gets OOMKilled and restarts repeatedly
 # THE FIX: Increase memory limit to accommodate actual memory usage (e.g., to 256Mi)
 
-
+# Allow context override: KUBE_CONTEXT=kind-kind-exec-only ./06-oomkilled.sh setup
+KUBE_CONTEXT="${KUBE_CONTEXT:-kind-kubently}"
 NAMESPACE="test-scenario-06"
 
 if [ "$1" = "setup" ]; then
-    echo "Setting up scenario 06..."
-    
-    kubectl --context kind-kubently create namespace $NAMESPACE --dry-run=client -o yaml | kubectl --context kind-kubently apply -f -
-    cat <<EOF | kubectl --context kind-kubently apply -f -
+    echo "Setting up scenario 06 on context: $KUBE_CONTEXT..."
+
+    kubectl --context $KUBE_CONTEXT create namespace $NAMESPACE --dry-run=client -o yaml | kubectl --context $KUBE_CONTEXT apply -f -
+    cat <<EOF | kubectl --context $KUBE_CONTEXT apply -f -
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -45,8 +46,8 @@ EOF
 fi
 
 if [ "$1" = "cleanup" ]; then
-    echo "Cleaning up scenario 06..."
-    kubectl --context kind-kubently delete namespace $NAMESPACE --ignore-not-found=true
+    echo "Cleaning up scenario 06 on context: $KUBE_CONTEXT..."
+    kubectl --context $KUBE_CONTEXT delete namespace $NAMESPACE --ignore-not-found=true
     exit 0
 fi
 

--- a/test-automation/scenarios/14-service-port-mismatch.sh
+++ b/test-automation/scenarios/14-service-port-mismatch.sh
@@ -4,14 +4,15 @@
 # SYMPTOM: Connection refused when accessing service (port mismatch)
 # THE FIX: Change Service targetPort from 8080 to 80 to match container port
 
-
+# Allow context override: KUBE_CONTEXT=kind-kind-exec-only ./14-service-port-mismatch.sh setup
+KUBE_CONTEXT="${KUBE_CONTEXT:-kind-kubently}"
 NAMESPACE="test-scenario-14"
 
 if [ "$1" = "setup" ]; then
-    echo "Setting up scenario 14..."
-    
-    kubectl --context kind-kubently create namespace $NAMESPACE --dry-run=client -o yaml | kubectl --context kind-kubently apply -f -
-    cat <<EOF | kubectl --context kind-kubently apply -f -
+    echo "Setting up scenario 14 on context: $KUBE_CONTEXT..."
+
+    kubectl --context $KUBE_CONTEXT create namespace $NAMESPACE --dry-run=client -o yaml | kubectl --context $KUBE_CONTEXT apply -f -
+    cat <<EOF | kubectl --context $KUBE_CONTEXT apply -f -
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -57,18 +58,18 @@ spec:
     image: busybox:latest
     command: ["sh", "-c", "while true; do wget -O- http://web-service 2>&1 | head -5; echo '---'; sleep 5; done"]
 EOF
-    kubectl --context kind-kubently get svc,endpoints -n $NAMESPACE
-    kubectl --context kind-kubently logs test-client -n $NAMESPACE --tail=10
-    
+    kubectl --context $KUBE_CONTEXT get svc,endpoints -n $NAMESPACE
+    kubectl --context $KUBE_CONTEXT logs test-client -n $NAMESPACE --tail=10 2>/dev/null || true
+
     # Wait for resources to be ready
     sleep 5
-    
+
     exit 0
 fi
 
 if [ "$1" = "cleanup" ]; then
-    echo "Cleaning up scenario 14..."
-    kubectl --context kind-kubently delete namespace $NAMESPACE --ignore-not-found=true
+    echo "Cleaning up scenario 14 on context: $KUBE_CONTEXT..."
+    kubectl --context $KUBE_CONTEXT delete namespace $NAMESPACE --ignore-not-found=true
     exit 0
 fi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,372 @@
+"""
+Shared pytest fixtures for Kubently tests.
+
+This module provides common fixtures including:
+- KubectlMocker: Mock kubectl subprocess calls with canned responses
+- Redis mocks for session/queue tests
+- FastAPI test client utilities
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Pattern, Union
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# =============================================================================
+# Kubectl Mocking Infrastructure
+# =============================================================================
+
+@dataclass
+class KubectlResponse:
+    """Represents a mocked kubectl command response."""
+    stdout: str = ""
+    stderr: str = ""
+    returncode: int = 0
+
+    def to_completed_process(self) -> MagicMock:
+        """Convert to a subprocess.CompletedProcess-like mock."""
+        result = MagicMock()
+        result.stdout = self.stdout
+        result.stderr = self.stderr
+        result.returncode = self.returncode
+        return result
+
+
+@dataclass
+class KubectlCall:
+    """Record of a kubectl call made during testing."""
+    command: List[str]
+    full_command_str: str
+    matched_pattern: Optional[str] = None
+    response: Optional[KubectlResponse] = None
+
+
+class KubectlMocker:
+    """
+    Mock kubectl subprocess calls with pattern-matched responses.
+
+    This allows testing executor and agent behavior without a real
+    Kubernetes cluster by intercepting subprocess.run calls.
+
+    Usage:
+        def test_pod_diagnosis(kubectl_mocker):
+            kubectl_mocker.register("get pods", KubectlResponse(
+                stdout="NAME  STATUS\\nmypod  CrashLoopBackOff"
+            ))
+
+            # Run code that calls kubectl
+            result = executor._run_kubectl(["get", "pods"])
+
+            # Verify the call was made
+            assert kubectl_mocker.was_called_with("get pods")
+    """
+
+    def __init__(self):
+        self._responses: List[tuple[Union[str, Pattern], KubectlResponse]] = []
+        self._call_history: List[KubectlCall] = []
+        self._default_response = KubectlResponse(
+            stderr="Error: mock not configured for this command",
+            returncode=1
+        )
+        self._passthrough_non_kubectl = True
+
+    def register(
+        self,
+        pattern: Union[str, Pattern],
+        response: KubectlResponse,
+        priority: int = 0
+    ) -> "KubectlMocker":
+        """
+        Register a response for commands matching the pattern.
+
+        Args:
+            pattern: String (substring match) or regex pattern
+            response: KubectlResponse to return when matched
+            priority: Higher priority patterns are checked first
+
+        Returns:
+            self for chaining
+        """
+        self._responses.append((pattern, response, priority))
+        # Sort by priority (highest first)
+        self._responses.sort(key=lambda x: x[2], reverse=True)
+        return self
+
+    def register_scenario(self, scenario_name: str) -> "KubectlMocker":
+        """
+        Register all responses for a named scenario.
+
+        Scenarios are predefined sets of kubectl responses that simulate
+        common Kubernetes issues.
+
+        Args:
+            scenario_name: One of the predefined scenario names
+
+        Returns:
+            self for chaining
+        """
+        from fixtures.kubectl_scenarios import SCENARIOS
+
+        if scenario_name not in SCENARIOS:
+            raise ValueError(
+                f"Unknown scenario: {scenario_name}. "
+                f"Available: {list(SCENARIOS.keys())}"
+            )
+
+        for pattern, response in SCENARIOS[scenario_name].items():
+            self.register(pattern, response)
+
+        return self
+
+    def set_default_response(self, response: KubectlResponse) -> "KubectlMocker":
+        """Set the default response for unmatched commands."""
+        self._default_response = response
+        return self
+
+    def mock_run(
+        self,
+        cmd: List[str],
+        capture_output: bool = True,
+        text: bool = True,
+        timeout: Optional[int] = None,
+        **kwargs
+    ) -> MagicMock:
+        """
+        Mock implementation of subprocess.run for kubectl commands.
+
+        This method is used as a side_effect for patching subprocess.run.
+        """
+        cmd_str = " ".join(cmd)
+
+        # Only intercept kubectl commands
+        if cmd[0] != "kubectl":
+            if self._passthrough_non_kubectl:
+                return subprocess.run(
+                    cmd,
+                    capture_output=capture_output,
+                    text=text,
+                    timeout=timeout,
+                    **kwargs
+                )
+            else:
+                raise RuntimeError(f"Non-kubectl command blocked: {cmd_str}")
+
+        # Find matching response
+        kubectl_args = " ".join(cmd[1:])
+        matched_pattern = None
+        response = self._default_response
+
+        for pattern, resp, _ in self._responses:
+            if isinstance(pattern, str):
+                if pattern in kubectl_args:
+                    matched_pattern = pattern
+                    response = resp
+                    break
+            else:  # Compiled regex
+                if pattern.search(kubectl_args):
+                    matched_pattern = pattern.pattern
+                    response = resp
+                    break
+
+        # Record the call
+        call = KubectlCall(
+            command=cmd,
+            full_command_str=cmd_str,
+            matched_pattern=matched_pattern,
+            response=response
+        )
+        self._call_history.append(call)
+
+        return response.to_completed_process()
+
+    @property
+    def calls(self) -> List[KubectlCall]:
+        """Get all kubectl calls made during the test."""
+        return self._call_history
+
+    @property
+    def call_count(self) -> int:
+        """Get the number of kubectl calls made."""
+        return len(self._call_history)
+
+    def was_called_with(self, pattern: str) -> bool:
+        """Check if any call contained the given pattern."""
+        return any(pattern in call.full_command_str for call in self._call_history)
+
+    def get_calls_matching(self, pattern: str) -> List[KubectlCall]:
+        """Get all calls containing the given pattern."""
+        return [c for c in self._call_history if pattern in c.full_command_str]
+
+    def reset(self):
+        """Clear call history (but keep registered responses)."""
+        self._call_history = []
+
+    def clear(self):
+        """Clear both responses and call history."""
+        self._responses = []
+        self._call_history = []
+
+
+@pytest.fixture
+def kubectl_mocker():
+    """
+    Fixture that provides a KubectlMocker with subprocess.run patched.
+
+    Usage:
+        def test_something(kubectl_mocker):
+            kubectl_mocker.register("get pods", KubectlResponse(stdout="..."))
+            # Your test code that calls kubectl
+            assert kubectl_mocker.was_called_with("get pods")
+    """
+    mocker = KubectlMocker()
+    with patch("subprocess.run", side_effect=mocker.mock_run):
+        yield mocker
+
+
+@pytest.fixture
+def kubectl_mocker_strict():
+    """
+    Strict kubectl mocker that fails on any unregistered command.
+
+    Use this when you want to ensure all kubectl interactions are
+    explicitly accounted for in your test.
+    """
+    mocker = KubectlMocker()
+    mocker._default_response = KubectlResponse(
+        stderr="STRICT MODE: No mock registered for this command",
+        returncode=127
+    )
+    with patch("subprocess.run", side_effect=mocker.mock_run):
+        yield mocker
+
+
+# =============================================================================
+# Redis Mocking Infrastructure
+# =============================================================================
+
+@pytest.fixture
+def mock_redis():
+    """Create a comprehensive mock Redis client for async operations."""
+    redis = AsyncMock()
+
+    # Basic operations
+    redis.setex = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    redis.set = AsyncMock()
+    redis.delete = AsyncMock(return_value=1)
+    redis.exists = AsyncMock(return_value=0)
+    redis.keys = AsyncMock(return_value=[])
+    redis.expire = AsyncMock()
+    redis.ttl = AsyncMock(return_value=-2)
+
+    # Set operations
+    redis.sadd = AsyncMock()
+    redis.srem = AsyncMock()
+    redis.smembers = AsyncMock(return_value=set())
+    redis.sismember = AsyncMock(return_value=False)
+
+    # List operations
+    redis.lpush = AsyncMock()
+    redis.rpush = AsyncMock()
+    redis.lpop = AsyncMock(return_value=None)
+    redis.rpop = AsyncMock(return_value=None)
+    redis.lrange = AsyncMock(return_value=[])
+    redis.ltrim = AsyncMock()
+    redis.llen = AsyncMock(return_value=0)
+
+    # Hash operations
+    redis.hset = AsyncMock()
+    redis.hget = AsyncMock(return_value=None)
+    redis.hgetall = AsyncMock(return_value={})
+    redis.hdel = AsyncMock()
+
+    # Pub/sub
+    redis.publish = AsyncMock()
+    redis.subscribe = AsyncMock()
+
+    # Pipeline support
+    pipeline = AsyncMock()
+    pipeline.execute = AsyncMock(return_value=[])
+    redis.pipeline = MagicMock(return_value=pipeline)
+
+    return redis
+
+
+@pytest.fixture
+def mock_redis_with_data():
+    """
+    Redis mock with in-memory data storage for more realistic tests.
+
+    This allows testing code that reads back what it writes.
+    """
+    storage = {}
+
+    redis = AsyncMock()
+
+    async def mock_set(key, value, *args, **kwargs):
+        storage[key] = value
+        return True
+
+    async def mock_setex(key, ttl, value):
+        storage[key] = value
+        return True
+
+    async def mock_get(key):
+        return storage.get(key)
+
+    async def mock_delete(*keys):
+        count = 0
+        for key in keys:
+            if key in storage:
+                del storage[key]
+                count += 1
+        return count
+
+    async def mock_exists(*keys):
+        return sum(1 for k in keys if k in storage)
+
+    async def mock_keys(pattern):
+        import fnmatch
+        # Convert Redis glob to fnmatch
+        pattern = pattern.replace("*", "*")
+        return [k for k in storage.keys() if fnmatch.fnmatch(k, pattern)]
+
+    redis.set = mock_set
+    redis.setex = mock_setex
+    redis.get = mock_get
+    redis.delete = mock_delete
+    redis.exists = mock_exists
+    redis.keys = mock_keys
+    redis._storage = storage  # Expose for test assertions
+
+    return redis
+
+
+# =============================================================================
+# Test Markers Configuration
+# =============================================================================
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers", "kubectl_mock: Tests using mocked kubectl subprocess calls"
+    )
+    config.addinivalue_line(
+        "markers", "integration: Integration tests requiring infrastructure"
+    )
+    config.addinivalue_line(
+        "markers", "e2e: End-to-end tests requiring a real cluster"
+    )
+    config.addinivalue_line(
+        "markers", "slow: Tests that take a long time to run"
+    )

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixtures for Kubently."""

--- a/tests/fixtures/kubectl_scenarios.py
+++ b/tests/fixtures/kubectl_scenarios.py
@@ -1,0 +1,616 @@
+"""
+Canned kubectl responses for common Kubernetes scenarios.
+
+These scenarios mirror the real test scenarios in test-automation/scenarios/
+but provide deterministic responses for fast, isolated testing.
+
+Usage:
+    def test_crashloop_diagnosis(kubectl_mocker):
+        kubectl_mocker.register_scenario("crashloopbackoff")
+        # ... test code
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure tests directory is in path for imports
+TESTS_DIR = Path(__file__).parent.parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from conftest import KubectlResponse
+
+# =============================================================================
+# Individual Response Builders
+# =============================================================================
+
+def pod_list_response(
+    name: str,
+    status: str,
+    ready: str = "0/1",
+    restarts: int = 0,
+    age: str = "5m",
+    namespace: str = "default"
+) -> str:
+    """Generate a kubectl get pods output line."""
+    return f"{name}   {ready}   {status}   {restarts}   {age}"
+
+
+def pod_describe_header(name: str, namespace: str = "default") -> str:
+    """Generate pod describe header."""
+    return f"""Name:             {name}
+Namespace:        {namespace}
+Priority:         0
+Service Account:  default
+Node:             kind-control-plane/172.18.0.2
+Start Time:       Mon, 01 Jan 2024 00:00:00 +0000
+Labels:           app={name}
+Annotations:      <none>
+Status:           Running"""
+
+
+def event_line(
+    event_type: str,
+    reason: str,
+    age: str,
+    source: str,
+    message: str
+) -> str:
+    """Generate a kubectl events line."""
+    return f"{age}   {event_type}   {reason}   {source}   {message}"
+
+
+# =============================================================================
+# Scenario: CrashLoopBackOff
+# =============================================================================
+
+CRASHLOOPBACKOFF = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                        READY   STATUS             RESTARTS      AGE
+crashloop-app-7d4f5b6c8d   0/1     CrashLoopBackOff   5 (30s ago)   5m""",
+        returncode=0
+    ),
+    "get pods -o wide": KubectlResponse(
+        stdout="""NAME                        READY   STATUS             RESTARTS      AGE   IP           NODE
+crashloop-app-7d4f5b6c8d   0/1     CrashLoopBackOff   5 (30s ago)   5m    10.244.0.5   kind-control-plane""",
+        returncode=0
+    ),
+    "describe pod crashloop": KubectlResponse(
+        stdout="""Name:             crashloop-app-7d4f5b6c8d
+Namespace:        default
+Priority:         0
+Service Account:  default
+Node:             kind-control-plane/172.18.0.2
+Start Time:       Mon, 01 Jan 2024 00:00:00 +0000
+Labels:           app=crashloop-app
+Status:           Running
+Containers:
+  app:
+    Container ID:   containerd://abc123
+    Image:          myapp:v1
+    State:          Waiting
+      Reason:       CrashLoopBackOff
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    1
+      Started:      Mon, 01 Jan 2024 00:04:30 +0000
+      Finished:     Mon, 01 Jan 2024 00:04:31 +0000
+    Restart Count:  5
+Events:
+  Type     Reason     Age                From               Message
+  ----     ------     ----               ----               -------
+  Normal   Scheduled  5m                 default-scheduler  Successfully assigned default/crashloop-app
+  Normal   Pulled     4m (x5 over 5m)    kubelet            Container image "myapp:v1" already present
+  Normal   Created    4m (x5 over 5m)    kubelet            Created container app
+  Normal   Started    4m (x5 over 5m)    kubelet            Started container app
+  Warning  BackOff    30s (x15 over 4m)  kubelet            Back-off restarting failed container""",
+        returncode=0
+    ),
+    "logs crashloop": KubectlResponse(
+        stdout="""2024-01-01 00:04:30 INFO  Starting application...
+2024-01-01 00:04:30 INFO  Connecting to database at db.default.svc:5432...
+2024-01-01 00:04:31 ERROR Connection refused: db.default.svc:5432
+2024-01-01 00:04:31 FATAL Cannot connect to database. Exiting.""",
+        returncode=0
+    ),
+    "logs crashloop --previous": KubectlResponse(
+        stdout="""2024-01-01 00:04:00 INFO  Starting application...
+2024-01-01 00:04:00 INFO  Connecting to database at db.default.svc:5432...
+2024-01-01 00:04:01 ERROR Connection refused: db.default.svc:5432
+2024-01-01 00:04:01 FATAL Cannot connect to database. Exiting.""",
+        returncode=0
+    ),
+    "get events": KubectlResponse(
+        stdout="""LAST SEEN   TYPE      REASON    OBJECT                          MESSAGE
+30s         Warning   BackOff   pod/crashloop-app-7d4f5b6c8d   Back-off restarting failed container
+4m          Normal    Started   pod/crashloop-app-7d4f5b6c8d   Started container app
+5m          Normal    Scheduled pod/crashloop-app-7d4f5b6c8d   Successfully assigned default/crashloop-app""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: ImagePullBackOff
+# =============================================================================
+
+IMAGEPULLBACKOFF = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                         READY   STATUS             RESTARTS   AGE
+imagepull-app-8f5g6h7i9j    0/1     ImagePullBackOff   0          3m""",
+        returncode=0
+    ),
+    "describe pod imagepull": KubectlResponse(
+        stdout="""Name:             imagepull-app-8f5g6h7i9j
+Namespace:        default
+Priority:         0
+Service Account:  default
+Node:             kind-control-plane/172.18.0.2
+Start Time:       Mon, 01 Jan 2024 00:00:00 +0000
+Labels:           app=imagepull-app
+Status:           Pending
+Containers:
+  app:
+    Container ID:
+    Image:          myregistry.io/myapp:v999
+    State:          Waiting
+      Reason:       ImagePullBackOff
+    Ready:          False
+Events:
+  Type     Reason     Age                From               Message
+  ----     ------     ----               ----               -------
+  Normal   Scheduled  3m                 default-scheduler  Successfully assigned default/imagepull-app
+  Normal   Pulling    2m (x4 over 3m)    kubelet            Pulling image "myregistry.io/myapp:v999"
+  Warning  Failed     2m (x4 over 3m)    kubelet            Failed to pull image "myregistry.io/myapp:v999": rpc error: code = NotFound desc = failed to pull and unpack image: failed to resolve reference: myregistry.io/myapp:v999: not found
+  Warning  Failed     2m (x4 over 3m)    kubelet            Error: ErrImagePull
+  Warning  BackOff    30s (x10 over 3m)  kubelet            Back-off pulling image "myregistry.io/myapp:v999"
+  Warning  Failed     30s (x10 over 3m)  kubelet            Error: ImagePullBackOff""",
+        returncode=0
+    ),
+    "get events": KubectlResponse(
+        stdout="""LAST SEEN   TYPE      REASON      OBJECT                          MESSAGE
+30s         Warning   BackOff     pod/imagepull-app-8f5g6h7i9j   Back-off pulling image "myregistry.io/myapp:v999"
+2m          Warning   Failed      pod/imagepull-app-8f5g6h7i9j   Failed to pull image: not found
+3m          Normal    Scheduled   pod/imagepull-app-8f5g6h7i9j   Successfully assigned default/imagepull-app""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: OOMKilled
+# =============================================================================
+
+OOMKILLED = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                    READY   STATUS      RESTARTS      AGE
+oom-app-3c4d5e6f7g     0/1     OOMKilled   3 (1m ago)    5m""",
+        returncode=0
+    ),
+    "describe pod oom": KubectlResponse(
+        stdout="""Name:             oom-app-3c4d5e6f7g
+Namespace:        default
+Priority:         0
+Service Account:  default
+Node:             kind-control-plane/172.18.0.2
+Labels:           app=oom-app
+Status:           Running
+Containers:
+  app:
+    Container ID:   containerd://def456
+    Image:          memory-hungry:v1
+    State:          Waiting
+      Reason:       CrashLoopBackOff
+    Last State:     Terminated
+      Reason:       OOMKilled
+      Exit Code:    137
+      Started:      Mon, 01 Jan 2024 00:04:00 +0000
+      Finished:     Mon, 01 Jan 2024 00:04:30 +0000
+    Restart Count:  3
+    Limits:
+      memory:  64Mi
+    Requests:
+      memory:  64Mi
+Events:
+  Type     Reason     Age                From               Message
+  ----     ------     ----               ----               -------
+  Normal   Scheduled  5m                 default-scheduler  Successfully assigned default/oom-app
+  Normal   Created    4m (x3 over 5m)    kubelet            Created container app
+  Normal   Started    4m (x3 over 5m)    kubelet            Started container app
+  Warning  BackOff    1m (x8 over 4m)    kubelet            Back-off restarting failed container""",
+        returncode=0
+    ),
+    "logs oom": KubectlResponse(
+        stdout="""Allocating memory...
+Allocated 32MB
+Allocated 64MB
+Killed""",
+        returncode=0
+    ),
+    "top pod oom": KubectlResponse(
+        stdout="""NAME                    CPU(cores)   MEMORY(bytes)
+oom-app-3c4d5e6f7g     100m         64Mi""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: Pending Pod (Insufficient Resources)
+# =============================================================================
+
+PENDING_RESOURCES = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                      READY   STATUS    RESTARTS   AGE
+pending-app-9h8i7j6k5l   0/1     Pending   0          10m""",
+        returncode=0
+    ),
+    "describe pod pending": KubectlResponse(
+        stdout="""Name:             pending-app-9h8i7j6k5l
+Namespace:        default
+Priority:         0
+Service Account:  default
+Node:             <none>
+Labels:           app=pending-app
+Status:           Pending
+Containers:
+  app:
+    Image:      myapp:v1
+    Limits:
+      cpu:     8
+      memory:  64Gi
+    Requests:
+      cpu:     8
+      memory:  64Gi
+Conditions:
+  Type           Status
+  PodScheduled   False
+Events:
+  Type     Reason            Age                From               Message
+  ----     ------            ----               ----               -------
+  Warning  FailedScheduling  10m (x5 over 10m)  default-scheduler  0/1 nodes are available: 1 Insufficient cpu, 1 Insufficient memory. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.""",
+        returncode=0
+    ),
+    "get nodes": KubectlResponse(
+        stdout="""NAME                 STATUS   ROLES           AGE   VERSION
+kind-control-plane   Ready    control-plane   30d   v1.28.0""",
+        returncode=0
+    ),
+    "describe nodes": KubectlResponse(
+        stdout="""Name:               kind-control-plane
+Roles:              control-plane
+Labels:             kubernetes.io/hostname=kind-control-plane
+Capacity:
+  cpu:              4
+  memory:           8Gi
+Allocatable:
+  cpu:              4
+  memory:           7Gi
+Allocated resources:
+  cpu:              2 (50%)
+  memory:           3Gi (43%)""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: Service Selector Mismatch
+# =============================================================================
+
+SERVICE_SELECTOR_MISMATCH = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                    READY   STATUS    RESTARTS   AGE
+webapp-abc123def456    1/1     Running   0          5m""",
+        returncode=0
+    ),
+    "--show-labels": KubectlResponse(
+        stdout="""NAME                    READY   STATUS    RESTARTS   AGE   LABELS
+webapp-abc123def456    1/1     Running   0          5m    app=webapp,version=v2""",
+        returncode=0
+    ),
+    "get svc": KubectlResponse(
+        stdout="""NAME      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
+webapp    ClusterIP   10.96.100.50   <none>        80/TCP    5m""",
+        returncode=0
+    ),
+    "describe svc webapp": KubectlResponse(
+        stdout="""Name:              webapp
+Namespace:         default
+Labels:            <none>
+Annotations:       <none>
+Selector:          app=webapp,version=v1
+Type:              ClusterIP
+IP Family Policy:  SingleStack
+IP Families:       IPv4
+IP:                10.96.100.50
+Port:              http  80/TCP
+TargetPort:        8080/TCP
+Endpoints:         <none>
+Session Affinity:  None
+Events:            <none>""",
+        returncode=0
+    ),
+    "get endpoints webapp": KubectlResponse(
+        stdout="""NAME      ENDPOINTS   AGE
+webapp    <none>      5m""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: Readiness Probe Failure
+# =============================================================================
+
+READINESS_PROBE_FAILURE = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                    READY   STATUS    RESTARTS   AGE
+probe-app-1a2b3c4d5e   0/1     Running   0          5m""",
+        returncode=0
+    ),
+    "describe pod probe": KubectlResponse(
+        stdout="""Name:             probe-app-1a2b3c4d5e
+Namespace:        default
+Priority:         0
+Service Account:  default
+Node:             kind-control-plane/172.18.0.2
+Labels:           app=probe-app
+Status:           Running
+Containers:
+  app:
+    Container ID:   containerd://xyz789
+    Image:          myapp:v1
+    State:          Running
+      Started:      Mon, 01 Jan 2024 00:00:00 +0000
+    Ready:          False
+    Restart Count:  0
+    Readiness:      http-get http://:8080/health delay=5s timeout=1s period=10s #success=1 #failure=3
+Conditions:
+  Type              Status
+  Initialized       True
+  Ready             False
+  ContainersReady   False
+  PodScheduled      True
+Events:
+  Type     Reason     Age               From               Message
+  ----     ------     ----              ----               -------
+  Normal   Scheduled  5m                default-scheduler  Successfully assigned default/probe-app
+  Normal   Pulled     5m                kubelet            Container image "myapp:v1" already present
+  Normal   Created    5m                kubelet            Created container app
+  Normal   Started    5m                kubelet            Started container app
+  Warning  Unhealthy  30s (x20 over 5m) kubelet            Readiness probe failed: HTTP probe failed with statuscode: 503""",
+        returncode=0
+    ),
+    "logs probe": KubectlResponse(
+        stdout="""2024-01-01 00:00:00 INFO  Starting application...
+2024-01-01 00:00:01 INFO  Connecting to cache service...
+2024-01-01 00:00:05 WARN  Cache connection failed, health check will fail
+2024-01-01 00:00:10 INFO  Serving requests (degraded mode)""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: ConfigMap Missing
+# =============================================================================
+
+CONFIGMAP_MISSING = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                      READY   STATUS                       RESTARTS   AGE
+configmap-app-2b3c4d5e6f  0/1     CreateContainerConfigError   0          2m""",
+        returncode=0
+    ),
+    "describe pod configmap": KubectlResponse(
+        stdout="""Name:             configmap-app-2b3c4d5e6f
+Namespace:        default
+Priority:         0
+Service Account:  default
+Node:             kind-control-plane/172.18.0.2
+Labels:           app=configmap-app
+Status:           Pending
+Containers:
+  app:
+    Container ID:
+    Image:          myapp:v1
+    State:          Waiting
+      Reason:       CreateContainerConfigError
+    Ready:          False
+    Environment Variables from:
+      app-config    ConfigMap  Optional: false
+Events:
+  Type     Reason     Age               From               Message
+  ----     ------     ----              ----               -------
+  Normal   Scheduled  2m                default-scheduler  Successfully assigned default/configmap-app
+  Normal   Pulled     2m                kubelet            Container image "myapp:v1" already present
+  Warning  Failed     30s (x8 over 2m)  kubelet            Error: configmap "app-config" not found""",
+        returncode=0
+    ),
+    "get configmaps": KubectlResponse(
+        stdout="""NAME               DATA   AGE
+kube-root-ca.crt   1      30d""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: Secret Missing
+# =============================================================================
+
+SECRET_MISSING = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                     READY   STATUS                       RESTARTS   AGE
+secret-app-3c4d5e6f7g   0/1     CreateContainerConfigError   0          2m""",
+        returncode=0
+    ),
+    "describe pod secret": KubectlResponse(
+        stdout="""Name:             secret-app-3c4d5e6f7g
+Namespace:        default
+Priority:         0
+Service Account:  default
+Node:             kind-control-plane/172.18.0.2
+Labels:           app=secret-app
+Status:           Pending
+Containers:
+  app:
+    Container ID:
+    Image:          myapp:v1
+    State:          Waiting
+      Reason:       CreateContainerConfigError
+    Ready:          False
+    Environment:
+      DB_PASSWORD:  <set to the key 'password' in secret 'db-credentials'>  Optional: false
+Events:
+  Type     Reason     Age               From               Message
+  ----     ------     ----              ----               -------
+  Normal   Scheduled  2m                default-scheduler  Successfully assigned default/secret-app
+  Normal   Pulled     2m                kubelet            Container image "myapp:v1" already present
+  Warning  Failed     30s (x8 over 2m)  kubelet            Error: secret "db-credentials" not found""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: Network Policy Blocking
+# =============================================================================
+
+NETWORK_POLICY_BLOCK = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                    READY   STATUS    RESTARTS   AGE
+backend-1a2b3c4d5e     1/1     Running   0          5m
+frontend-2b3c4d5e6f    1/1     Running   0          5m""",
+        returncode=0
+    ),
+    "get networkpolicies": KubectlResponse(
+        stdout="""NAME           POD-SELECTOR   AGE
+deny-all       <none>         5m
+allow-egress   app=backend    5m""",
+        returncode=0
+    ),
+    "describe networkpolicy deny-all": KubectlResponse(
+        stdout="""Name:         deny-all
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+Spec:
+  PodSelector:     <none> (Coverage: all pods in the namespace)
+  Allowing ingress traffic:
+    <none> (Selected pods are isolated for ingress connectivity)
+  Allowing egress traffic:
+    <none> (Selected pods are isolated for egress connectivity)
+  Policy Types: Ingress, Egress""",
+        returncode=0
+    ),
+    "logs frontend": KubectlResponse(
+        stdout="""2024-01-01 00:00:00 INFO  Starting frontend...
+2024-01-01 00:00:05 ERROR Failed to connect to backend:8080 - Connection timed out
+2024-01-01 00:00:15 ERROR Failed to connect to backend:8080 - Connection timed out""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: RBAC Permission Denied
+# =============================================================================
+
+RBAC_FORBIDDEN = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                    READY   STATUS    RESTARTS   AGE
+rbac-test-4d5e6f7g8h   1/1     Running   0          5m""",
+        returncode=0
+    ),
+    "auth can-i list secrets": KubectlResponse(
+        stdout="no",
+        returncode=1
+    ),
+    "auth can-i get secrets": KubectlResponse(
+        stdout="no",
+        returncode=1
+    ),
+    "auth can-i list pods": KubectlResponse(
+        stdout="yes",
+        returncode=0
+    ),
+    "logs rbac-test": KubectlResponse(
+        stdout="""2024-01-01 00:00:00 INFO  Starting application...
+2024-01-01 00:00:01 INFO  Loading configuration from secrets...
+2024-01-01 00:00:01 ERROR secrets is forbidden: User "system:serviceaccount:default:default" cannot list resource "secrets" in API group "" in the namespace "default"
+2024-01-01 00:00:01 FATAL Unable to load required secrets. Exiting.""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Scenario: Healthy Cluster (Control Case)
+# =============================================================================
+
+HEALTHY_CLUSTER = {
+    "get pods": KubectlResponse(
+        stdout="""NAME                    READY   STATUS    RESTARTS   AGE
+webapp-1a2b3c4d5e      1/1     Running   0          1h
+backend-2b3c4d5e6f     1/1     Running   0          1h
+database-3c4d5e6f7g    1/1     Running   0          1h""",
+        returncode=0
+    ),
+    "get pods -A": KubectlResponse(
+        stdout="""NAMESPACE     NAME                                      READY   STATUS    RESTARTS   AGE
+default       webapp-1a2b3c4d5e                         1/1     Running   0          1h
+default       backend-2b3c4d5e6f                        1/1     Running   0          1h
+default       database-3c4d5e6f7g                       1/1     Running   0          1h
+kube-system   coredns-5d78c9869d-abcde                  1/1     Running   0          30d
+kube-system   etcd-kind-control-plane                   1/1     Running   0          30d
+kube-system   kube-apiserver-kind-control-plane         1/1     Running   0          30d
+kube-system   kube-controller-manager-kind-control-plane 1/1   Running   0          30d
+kube-system   kube-proxy-xyz12                          1/1     Running   0          30d
+kube-system   kube-scheduler-kind-control-plane         1/1     Running   0          30d""",
+        returncode=0
+    ),
+    "get svc": KubectlResponse(
+        stdout="""NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+kubernetes ClusterIP   10.96.0.1      <none>        443/TCP    30d
+webapp     ClusterIP   10.96.100.10   <none>        80/TCP     1h
+backend    ClusterIP   10.96.100.20   <none>        8080/TCP   1h
+database   ClusterIP   10.96.100.30   <none>        5432/TCP   1h""",
+        returncode=0
+    ),
+    "get events": KubectlResponse(
+        stdout="""No events found.""",
+        returncode=0
+    ),
+}
+
+
+# =============================================================================
+# Master Scenario Registry
+# =============================================================================
+
+SCENARIOS = {
+    "crashloopbackoff": CRASHLOOPBACKOFF,
+    "imagepullbackoff": IMAGEPULLBACKOFF,
+    "oomkilled": OOMKILLED,
+    "pending_resources": PENDING_RESOURCES,
+    "service_selector_mismatch": SERVICE_SELECTOR_MISMATCH,
+    "readiness_probe_failure": READINESS_PROBE_FAILURE,
+    "configmap_missing": CONFIGMAP_MISSING,
+    "secret_missing": SECRET_MISSING,
+    "network_policy_block": NETWORK_POLICY_BLOCK,
+    "rbac_forbidden": RBAC_FORBIDDEN,
+    "healthy": HEALTHY_CLUSTER,
+}
+
+
+def get_scenario_names() -> list:
+    """Get list of all available scenario names."""
+    return list(SCENARIOS.keys())
+
+
+def get_scenario(name: str) -> dict:
+    """Get a specific scenario by name."""
+    if name not in SCENARIOS:
+        raise ValueError(f"Unknown scenario: {name}. Available: {get_scenario_names()}")
+    return SCENARIOS[name]

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for Kubently using mocked Kubernetes interactions."""

--- a/tests/integration/test_executor_mocked.py
+++ b/tests/integration/test_executor_mocked.py
@@ -1,0 +1,508 @@
+"""
+Integration tests for executor using mocked kubectl subprocess calls.
+
+These tests verify that the executor correctly interprets kubectl output
+and produces appropriate responses, without requiring a real Kubernetes cluster.
+
+Usage:
+    pytest tests/integration/test_executor_mocked.py -v
+    pytest tests/integration/test_executor_mocked.py -v -k crashloop
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Add kubently root to path for imports
+KUBENTLY_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(KUBENTLY_ROOT))
+
+# Import from conftest (pytest auto-loads conftest.py fixtures)
+# KubectlResponse is defined in our tests/conftest.py
+from conftest import KubectlResponse
+from fixtures.kubectl_scenarios import (
+    SCENARIOS,
+    get_scenario_names,
+)
+
+
+# =============================================================================
+# Test Helpers
+# =============================================================================
+
+class KubectlRunner:
+    """
+    Standalone kubectl runner that mimics the executor's _run_kubectl method.
+
+    This allows testing kubectl execution behavior without importing the full
+    executor module with all its dependencies (sseclient, httpx, etc.).
+
+    The implementation mirrors kubently/modules/executor/sse_executor.py:_run_kubectl
+    """
+
+    def _run_kubectl(self, args: list) -> dict:
+        """
+        Execute kubectl command.
+
+        Args:
+            args: kubectl command arguments
+
+        Returns:
+            Result dictionary with output and status
+        """
+        import subprocess
+
+        try:
+            # Prepend kubectl to args
+            cmd = ["kubectl"] + args
+
+            # Execute command
+            process = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,  # 30 second timeout
+            )
+
+            # Combine stdout and stderr for output
+            output = process.stdout
+            if process.stderr:
+                output += "\n" + process.stderr
+
+            return {
+                "success": process.returncode == 0,
+                "output": output.strip(),
+                "stderr": process.stderr,
+                "status": "SUCCESS" if process.returncode == 0 else "FAILED",
+                "return_code": process.returncode,
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "success": False,
+                "output": "",
+                "stderr": "Command timed out",
+                "status": "TIMEOUT",
+                "return_code": -1,
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "output": "",
+                "stderr": str(e),
+                "status": "ERROR",
+                "return_code": -1,
+            }
+
+
+def create_executor_with_mocks():
+    """
+    Create a KubectlRunner instance for testing.
+
+    This returns a lightweight object that has the same _run_kubectl interface
+    as the real executor, but without all the SSE/HTTP dependencies.
+    """
+    return KubectlRunner()
+
+
+# =============================================================================
+# Basic Executor Tests
+# =============================================================================
+
+class TestExecutorKubectlExecution:
+    """Test executor's kubectl command execution."""
+
+    @pytest.mark.kubectl_mock
+    def test_successful_get_pods(self, kubectl_mocker):
+        """Test successful kubectl get pods execution."""
+        kubectl_mocker.register("get pods", KubectlResponse(
+            stdout="NAME    READY   STATUS    RESTARTS   AGE\napp-1   1/1     Running   0          1h",
+            returncode=0
+        ))
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["get", "pods"])
+
+        assert result["success"] is True
+        assert "app-1" in result["output"]
+        assert result["return_code"] == 0
+        assert kubectl_mocker.was_called_with("get pods")
+
+    @pytest.mark.kubectl_mock
+    def test_failed_kubectl_command(self, kubectl_mocker):
+        """Test handling of failed kubectl commands."""
+        kubectl_mocker.register("get nonexistent", KubectlResponse(
+            stderr='error: the server doesn\'t have a resource type "nonexistent"',
+            returncode=1
+        ))
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["get", "nonexistent"])
+
+        assert result["success"] is False
+        assert result["return_code"] == 1
+
+    @pytest.mark.kubectl_mock
+    def test_kubectl_with_namespace(self, kubectl_mocker):
+        """Test kubectl commands with namespace flag."""
+        kubectl_mocker.register("-n kube-system get pods", KubectlResponse(
+            stdout="NAME                       READY   STATUS    RESTARTS   AGE\ncoredns-abc123   1/1     Running   0          30d",
+            returncode=0
+        ))
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["-n", "kube-system", "get", "pods"])
+
+        assert result["success"] is True
+        assert "coredns" in result["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_call_history_tracking(self, kubectl_mocker):
+        """Test that all kubectl calls are tracked."""
+        kubectl_mocker.register("get", KubectlResponse(stdout="ok"))
+
+        executor = create_executor_with_mocks()
+        executor._run_kubectl(["get", "pods"])
+        executor._run_kubectl(["get", "services"])
+        executor._run_kubectl(["get", "deployments"])
+
+        assert kubectl_mocker.call_count == 3
+        assert kubectl_mocker.was_called_with("get pods")
+        assert kubectl_mocker.was_called_with("get services")
+        assert kubectl_mocker.was_called_with("get deployments")
+
+
+# =============================================================================
+# Scenario-Based Tests
+# =============================================================================
+
+class TestCrashLoopBackOffScenario:
+    """Test executor behavior with CrashLoopBackOff scenario."""
+
+    @pytest.mark.kubectl_mock
+    def test_identifies_crashloop_pods(self, kubectl_mocker):
+        """Test that executor can identify pods in CrashLoopBackOff."""
+        kubectl_mocker.register_scenario("crashloopbackoff")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["get", "pods"])
+
+        assert result["success"] is True
+        assert "CrashLoopBackOff" in result["output"]
+        assert "crashloop-app" in result["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_can_retrieve_crashloop_logs(self, kubectl_mocker):
+        """Test that executor can get logs from crashing pod."""
+        kubectl_mocker.register_scenario("crashloopbackoff")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["logs", "crashloop-app-7d4f5b6c8d"])
+
+        assert result["success"] is True
+        assert "Connection refused" in result["output"]
+        assert "database" in result["output"].lower()
+
+    @pytest.mark.kubectl_mock
+    def test_describe_shows_restart_count(self, kubectl_mocker):
+        """Test that describe shows high restart count."""
+        kubectl_mocker.register_scenario("crashloopbackoff")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["describe", "pod", "crashloop-app"])
+
+        assert result["success"] is True
+        assert "Restart Count:  5" in result["output"]
+        assert "BackOff" in result["output"]
+
+
+class TestImagePullBackOffScenario:
+    """Test executor behavior with ImagePullBackOff scenario."""
+
+    @pytest.mark.kubectl_mock
+    def test_identifies_imagepull_failure(self, kubectl_mocker):
+        """Test identification of ImagePullBackOff issues."""
+        kubectl_mocker.register_scenario("imagepullbackoff")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["get", "pods"])
+
+        assert result["success"] is True
+        assert "ImagePullBackOff" in result["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_describe_shows_image_error(self, kubectl_mocker):
+        """Test that describe reveals image pull error details."""
+        kubectl_mocker.register_scenario("imagepullbackoff")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["describe", "pod", "imagepull-app"])
+
+        assert result["success"] is True
+        assert "myregistry.io/myapp:v999" in result["output"]
+        assert "not found" in result["output"]
+
+
+class TestOOMKilledScenario:
+    """Test executor behavior with OOMKilled scenario."""
+
+    @pytest.mark.kubectl_mock
+    def test_identifies_oom_killed(self, kubectl_mocker):
+        """Test identification of OOMKilled pods."""
+        kubectl_mocker.register_scenario("oomkilled")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["get", "pods"])
+
+        assert result["success"] is True
+        assert "OOMKilled" in result["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_describe_shows_memory_limits(self, kubectl_mocker):
+        """Test that describe shows memory limits."""
+        kubectl_mocker.register_scenario("oomkilled")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["describe", "pod", "oom-app"])
+
+        assert result["success"] is True
+        assert "memory:  64Mi" in result["output"]
+        assert "Exit Code:    137" in result["output"]
+
+
+class TestPendingResourcesScenario:
+    """Test executor behavior with resource-constrained pending pods."""
+
+    @pytest.mark.kubectl_mock
+    def test_identifies_pending_pod(self, kubectl_mocker):
+        """Test identification of pending pods."""
+        kubectl_mocker.register_scenario("pending_resources")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["get", "pods"])
+
+        assert result["success"] is True
+        assert "Pending" in result["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_describe_shows_scheduling_failure(self, kubectl_mocker):
+        """Test that describe reveals scheduling failure reason."""
+        kubectl_mocker.register_scenario("pending_resources")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["describe", "pod", "pending-app"])
+
+        assert result["success"] is True
+        assert "Insufficient cpu" in result["output"]
+        assert "Insufficient memory" in result["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_node_describe_shows_capacity(self, kubectl_mocker):
+        """Test that node describe shows available resources."""
+        kubectl_mocker.register_scenario("pending_resources")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["describe", "nodes"])
+
+        assert result["success"] is True
+        assert "cpu:" in result["output"]
+        assert "memory:" in result["output"]
+
+
+class TestServiceSelectorMismatchScenario:
+    """Test executor behavior with service selector mismatch."""
+
+    @pytest.mark.kubectl_mock
+    def test_service_has_no_endpoints(self, kubectl_mocker):
+        """Test detection of service with no endpoints."""
+        kubectl_mocker.register_scenario("service_selector_mismatch")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["get", "endpoints", "webapp"])
+
+        assert result["success"] is True
+        assert "<none>" in result["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_service_selector_visible(self, kubectl_mocker):
+        """Test that service selector is visible in describe."""
+        kubectl_mocker.register_scenario("service_selector_mismatch")
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["describe", "svc", "webapp"])
+
+        assert result["success"] is True
+        assert "Selector:" in result["output"]
+        assert "version=v1" in result["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_pod_labels_visible(self, kubectl_mocker):
+        """Test that pod labels show version mismatch."""
+        kubectl_mocker.register_scenario("service_selector_mismatch")
+
+        # Register more specific pattern with higher priority
+        kubectl_mocker.register(
+            "get pods --show-labels",
+            KubectlResponse(
+                stdout="""NAME                    READY   STATUS    RESTARTS   AGE   LABELS
+webapp-abc123def456    1/1     Running   0          5m    app=webapp,version=v2"""
+            ),
+            priority=10  # Higher priority than scenario defaults
+        )
+
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["get", "pods", "--show-labels"])
+
+        assert result["success"] is True
+        assert "version=v2" in result["output"]  # Pod has v2, service expects v1
+
+
+# =============================================================================
+# Parameterized Scenario Tests
+# =============================================================================
+
+@pytest.mark.kubectl_mock
+@pytest.mark.parametrize("scenario_name", get_scenario_names())
+def test_scenario_loads_correctly(kubectl_mocker, scenario_name):
+    """Test that all scenarios can be loaded without errors."""
+    kubectl_mocker.register_scenario(scenario_name)
+
+    executor = create_executor_with_mocks()
+    result = executor._run_kubectl(["get", "pods"])
+
+    # All scenarios should have valid get pods response
+    assert result["success"] is True
+    assert len(result["output"]) > 0
+
+
+@pytest.mark.kubectl_mock
+@pytest.mark.parametrize("scenario_name,expected_status", [
+    ("crashloopbackoff", "CrashLoopBackOff"),
+    ("imagepullbackoff", "ImagePullBackOff"),
+    ("oomkilled", "OOMKilled"),
+    ("pending_resources", "Pending"),
+    ("healthy", "Running"),
+])
+def test_scenario_status_detection(kubectl_mocker, scenario_name, expected_status):
+    """Test that scenarios produce expected pod statuses."""
+    kubectl_mocker.register_scenario(scenario_name)
+
+    executor = create_executor_with_mocks()
+    result = executor._run_kubectl(["get", "pods"])
+
+    assert expected_status in result["output"]
+
+
+# =============================================================================
+# Advanced Mock Patterns
+# =============================================================================
+
+class TestCustomMockPatterns:
+    """Test advanced mocking patterns."""
+
+    @pytest.mark.kubectl_mock
+    def test_regex_pattern_matching(self, kubectl_mocker):
+        """Test regex pattern matching for flexible mocking."""
+        import re
+
+        kubectl_mocker.register(
+            re.compile(r"get pods -n \w+"),
+            KubectlResponse(stdout="NAME  STATUS\nregex-pod  Running")
+        )
+
+        executor = create_executor_with_mocks()
+
+        # Should match any namespace
+        result1 = executor._run_kubectl(["get", "pods", "-n", "default"])
+        result2 = executor._run_kubectl(["get", "pods", "-n", "kube-system"])
+
+        assert "regex-pod" in result1["output"]
+        assert "regex-pod" in result2["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_strict_mode_catches_unregistered(self, kubectl_mocker_strict):
+        """Test strict mode fails on unregistered commands."""
+        executor = create_executor_with_mocks()
+        result = executor._run_kubectl(["get", "unregistered-resource"])
+
+        assert result["success"] is False
+        assert result["return_code"] == 127
+
+    @pytest.mark.kubectl_mock
+    def test_multiple_scenarios_combined(self, kubectl_mocker):
+        """Test combining responses from multiple scenarios."""
+        # Register specific responses from different scenarios
+        from fixtures.kubectl_scenarios import CRASHLOOPBACKOFF, OOMKILLED
+
+        kubectl_mocker.register("crashloop", CRASHLOOPBACKOFF["describe pod crashloop"])
+        kubectl_mocker.register("oom", OOMKILLED["describe pod oom"])
+
+        executor = create_executor_with_mocks()
+
+        # Can query both
+        result1 = executor._run_kubectl(["describe", "pod", "crashloop-app"])
+        result2 = executor._run_kubectl(["describe", "pod", "oom-app"])
+
+        assert "CrashLoopBackOff" in result1["output"]
+        assert "OOMKilled" in result2["output"]
+
+    @pytest.mark.kubectl_mock
+    def test_sequential_responses(self, kubectl_mocker):
+        """Test simulating state changes across multiple calls."""
+        # First call: pod is pending
+        kubectl_mocker.register("get pods", KubectlResponse(
+            stdout="NAME    READY   STATUS    RESTARTS   AGE\napp-1   0/1     Pending   0          1m"
+        ))
+
+        executor = create_executor_with_mocks()
+        result1 = executor._run_kubectl(["get", "pods"])
+        assert "Pending" in result1["output"]
+
+        # Clear and re-register with new state
+        kubectl_mocker.clear()
+        kubectl_mocker.register("get pods", KubectlResponse(
+            stdout="NAME    READY   STATUS    RESTARTS   AGE\napp-1   1/1     Running   0          2m"
+        ))
+
+        result2 = executor._run_kubectl(["get", "pods"])
+        assert "Running" in result2["output"]
+
+
+# =============================================================================
+# Command Parsing Tests
+# =============================================================================
+
+class TestCommandParsing:
+    """Test that commands are correctly parsed and tracked."""
+
+    @pytest.mark.kubectl_mock
+    def test_tracks_full_command(self, kubectl_mocker):
+        """Test that full command strings are tracked."""
+        kubectl_mocker.register("get", KubectlResponse(stdout="ok"))
+
+        executor = create_executor_with_mocks()
+        executor._run_kubectl(["get", "pods", "-n", "production", "-o", "wide"])
+
+        calls = kubectl_mocker.get_calls_matching("get pods")
+        assert len(calls) == 1
+        assert "-n" in calls[0].full_command_str
+        assert "production" in calls[0].full_command_str
+        assert "-o wide" in calls[0].full_command_str
+
+    @pytest.mark.kubectl_mock
+    def test_distinguishes_similar_commands(self, kubectl_mocker):
+        """Test that similar commands are tracked separately."""
+        kubectl_mocker.register("get pods", KubectlResponse(stdout="pods"))
+        kubectl_mocker.register("get services", KubectlResponse(stdout="services"))
+
+        executor = create_executor_with_mocks()
+        executor._run_kubectl(["get", "pods"])
+        executor._run_kubectl(["get", "services"])
+
+        pod_calls = kubectl_mocker.get_calls_matching("get pods")
+        svc_calls = kubectl_mocker.get_calls_matching("get services")
+
+        assert len(pod_calls) == 1
+        assert len(svc_calls) == 1

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -1,0 +1,606 @@
+"""
+Unit tests for the Capability Module.
+
+Tests cover:
+- ExecutorCapabilities dataclass serialization/deserialization
+- CapabilityModule Redis operations (store, get, refresh, delete)
+- Cluster detail aggregation
+- Error handling and edge cases
+"""
+
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from kubently.modules.capability import CapabilityModule, ExecutorCapabilities
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock Redis client with all required methods."""
+    redis = AsyncMock()
+    redis.setex = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    redis.exists = AsyncMock(return_value=0)
+    redis.delete = AsyncMock(return_value=1)
+    redis.keys = AsyncMock(return_value=[])
+    redis.ttl = AsyncMock(return_value=3600)
+    return redis
+
+
+@pytest.fixture
+def capability_module(mock_redis):
+    """Create a CapabilityModule instance with mock Redis."""
+    return CapabilityModule(mock_redis, default_ttl=3600)
+
+
+@pytest.fixture
+def sample_capabilities():
+    """Create a sample ExecutorCapabilities object."""
+    return ExecutorCapabilities(
+        cluster_id="test-cluster",
+        mode="readOnly",
+        allowed_verbs=["get", "describe", "logs"],
+        restricted_resources=["secrets", "configmaps"],
+        allowed_flags=["--namespace", "--all-namespaces"],
+        executor_version="1.0.0",
+        executor_pod="executor-pod-abc123",
+        features={"exec": False, "port_forward": False, "proxy": False, "cp": False},
+    )
+
+
+@pytest.fixture
+def sample_capabilities_extended():
+    """Create an ExtendedReadOnly mode capabilities object."""
+    return ExecutorCapabilities(
+        cluster_id="dev-cluster",
+        mode="extendedReadOnly",
+        allowed_verbs=["get", "describe", "logs", "exec", "port-forward"],
+        restricted_resources=["secrets"],
+        allowed_flags=["--namespace", "--all-namespaces", "--container"],
+        executor_version="1.1.0",
+        executor_pod="executor-dev-xyz",
+        features={"exec": True, "port_forward": True, "proxy": False, "cp": False},
+    )
+
+
+# =============================================================================
+# ExecutorCapabilities Dataclass Tests
+# =============================================================================
+
+
+class TestExecutorCapabilities:
+    """Tests for the ExecutorCapabilities dataclass."""
+
+    def test_to_dict(self, sample_capabilities):
+        """Test serialization to dictionary."""
+        result = sample_capabilities.to_dict()
+
+        assert result["cluster_id"] == "test-cluster"
+        assert result["mode"] == "readOnly"
+        assert result["allowed_verbs"] == ["get", "describe", "logs"]
+        assert result["restricted_resources"] == ["secrets", "configmaps"]
+        assert result["executor_version"] == "1.0.0"
+        assert result["features"]["exec"] is False
+
+    def test_from_dict(self):
+        """Test deserialization from dictionary."""
+        data = {
+            "cluster_id": "prod-cluster",
+            "mode": "fullAccess",
+            "allowed_verbs": ["get", "describe", "apply", "delete"],
+            "restricted_resources": [],
+            "allowed_flags": ["--all"],
+            "executor_version": "2.0.0",
+            "executor_pod": "prod-executor",
+            "reported_at": "2025-01-01T00:00:00Z",
+            "expires_at": "2025-01-01T01:00:00Z",
+            "features": {"exec": True, "port_forward": True, "proxy": True, "cp": True},
+        }
+
+        caps = ExecutorCapabilities.from_dict(data)
+
+        assert caps.cluster_id == "prod-cluster"
+        assert caps.mode == "fullAccess"
+        assert "apply" in caps.allowed_verbs
+        assert caps.features["proxy"] is True
+
+    def test_from_dict_with_defaults(self):
+        """Test deserialization with missing optional fields."""
+        data = {
+            "cluster_id": "minimal-cluster",
+            "mode": "readOnly",
+        }
+
+        caps = ExecutorCapabilities.from_dict(data)
+
+        assert caps.cluster_id == "minimal-cluster"
+        assert caps.allowed_verbs == []
+        assert caps.restricted_resources == []
+        assert caps.executor_version is None
+        assert caps.features == {}
+
+    def test_from_whitelist_summary_readonly(self):
+        """Test creation from DynamicCommandWhitelist summary (readOnly mode)."""
+        summary = {
+            "mode": "readOnly",
+            "allowed_verbs": ["get", "describe", "logs", "top"],
+            "restricted_resources": {"secrets", "configmaps"},  # Note: set, not list
+            "allowed_flags": {"--namespace", "--output"},  # Note: set, not list
+        }
+
+        caps = ExecutorCapabilities.from_whitelist_summary(
+            cluster_id="ro-cluster",
+            summary=summary,
+            executor_version="1.0.0",
+            executor_pod="executor-ro",
+        )
+
+        assert caps.cluster_id == "ro-cluster"
+        assert caps.mode == "readOnly"
+        assert caps.features["exec"] is False
+        assert caps.features["port_forward"] is False
+        assert caps.features["proxy"] is False
+        assert caps.features["cp"] is False
+        # Sets should be converted to lists
+        assert isinstance(caps.restricted_resources, list)
+
+    def test_from_whitelist_summary_extended(self):
+        """Test creation from DynamicCommandWhitelist summary (extendedReadOnly mode)."""
+        summary = {
+            "mode": "extendedReadOnly",
+            "allowed_verbs": ["get", "describe", "logs", "exec", "port-forward"],
+            "restricted_resources": set(),
+            "allowed_flags": set(),
+        }
+
+        caps = ExecutorCapabilities.from_whitelist_summary(
+            cluster_id="ext-cluster",
+            summary=summary,
+        )
+
+        assert caps.features["exec"] is True
+        assert caps.features["port_forward"] is True
+        assert caps.features["proxy"] is False
+        assert caps.features["cp"] is False
+
+    def test_from_whitelist_summary_fullaccess(self):
+        """Test creation from DynamicCommandWhitelist summary (fullAccess mode)."""
+        summary = {
+            "mode": "fullAccess",
+            "allowed_verbs": ["get", "describe", "apply", "delete", "exec", "cp"],
+            "restricted_resources": set(),
+            "allowed_flags": set(),
+        }
+
+        caps = ExecutorCapabilities.from_whitelist_summary(
+            cluster_id="full-cluster",
+            summary=summary,
+        )
+
+        assert caps.features["exec"] is True
+        assert caps.features["port_forward"] is True
+        assert caps.features["proxy"] is True
+        assert caps.features["cp"] is True
+
+    def test_roundtrip_serialization(self, sample_capabilities):
+        """Test that to_dict -> from_dict preserves all data."""
+        dict_data = sample_capabilities.to_dict()
+        restored = ExecutorCapabilities.from_dict(dict_data)
+
+        assert restored.cluster_id == sample_capabilities.cluster_id
+        assert restored.mode == sample_capabilities.mode
+        assert restored.allowed_verbs == sample_capabilities.allowed_verbs
+        assert restored.executor_version == sample_capabilities.executor_version
+
+
+# =============================================================================
+# CapabilityModule Tests
+# =============================================================================
+
+
+class TestCapabilityModuleStore:
+    """Tests for storing capabilities."""
+
+    @pytest.mark.asyncio
+    async def test_store_capabilities_success(
+        self, capability_module, mock_redis, sample_capabilities
+    ):
+        """Test successful capability storage."""
+        result = await capability_module.store_capabilities(sample_capabilities)
+
+        assert result is True
+        mock_redis.setex.assert_called_once()
+
+        # Verify key format
+        call_args = mock_redis.setex.call_args[0]
+        assert call_args[0] == "cluster:test-cluster:capabilities"
+        assert call_args[1] == 3600  # TTL
+
+        # Verify stored data
+        stored_data = json.loads(call_args[2])
+        assert stored_data["cluster_id"] == "test-cluster"
+        assert stored_data["mode"] == "readOnly"
+        assert stored_data["reported_at"] is not None
+        assert stored_data["expires_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_store_capabilities_adds_timestamps(
+        self, capability_module, mock_redis, sample_capabilities
+    ):
+        """Test that timestamps are added on store."""
+        # Ensure original has no timestamps
+        sample_capabilities.reported_at = None
+        sample_capabilities.expires_at = None
+
+        await capability_module.store_capabilities(sample_capabilities)
+
+        # Verify timestamps were added
+        call_args = mock_redis.setex.call_args[0]
+        stored_data = json.loads(call_args[2])
+
+        assert stored_data["reported_at"] is not None
+        assert stored_data["expires_at"] is not None
+
+        # Verify expires_at is ~1 hour after reported_at
+        reported = datetime.fromisoformat(stored_data["reported_at"].replace("Z", "+00:00"))
+        expires = datetime.fromisoformat(stored_data["expires_at"].replace("Z", "+00:00"))
+        delta = expires - reported
+        assert 3590 < delta.total_seconds() < 3610  # ~1 hour
+
+    @pytest.mark.asyncio
+    async def test_store_capabilities_redis_error(
+        self, capability_module, mock_redis, sample_capabilities
+    ):
+        """Test graceful handling of Redis errors on store."""
+        mock_redis.setex.side_effect = Exception("Redis connection lost")
+
+        result = await capability_module.store_capabilities(sample_capabilities)
+
+        assert result is False
+
+
+class TestCapabilityModuleGet:
+    """Tests for retrieving capabilities."""
+
+    @pytest.mark.asyncio
+    async def test_get_capabilities_found(self, capability_module, mock_redis):
+        """Test successful capability retrieval."""
+        stored_data = {
+            "cluster_id": "test-cluster",
+            "mode": "readOnly",
+            "allowed_verbs": ["get", "describe"],
+            "restricted_resources": [],
+            "allowed_flags": [],
+            "executor_version": "1.0.0",
+            "executor_pod": "pod-123",
+            "reported_at": "2025-01-01T00:00:00Z",
+            "expires_at": "2025-01-01T01:00:00Z",
+            "features": {},
+        }
+        mock_redis.get.return_value = json.dumps(stored_data)
+
+        result = await capability_module.get_capabilities("test-cluster")
+
+        assert result is not None
+        assert result.cluster_id == "test-cluster"
+        assert result.mode == "readOnly"
+        assert result.executor_version == "1.0.0"
+        mock_redis.get.assert_called_once_with("cluster:test-cluster:capabilities")
+
+    @pytest.mark.asyncio
+    async def test_get_capabilities_handles_bytes(self, capability_module, mock_redis):
+        """Test that bytes response from Redis is handled correctly."""
+        stored_data = {
+            "cluster_id": "bytes-cluster",
+            "mode": "extendedReadOnly",
+            "allowed_verbs": [],
+            "restricted_resources": [],
+            "allowed_flags": [],
+            "features": {},
+        }
+        # Redis often returns bytes
+        mock_redis.get.return_value = json.dumps(stored_data).encode("utf-8")
+
+        result = await capability_module.get_capabilities("bytes-cluster")
+
+        assert result is not None
+        assert result.cluster_id == "bytes-cluster"
+        assert result.mode == "extendedReadOnly"
+
+    @pytest.mark.asyncio
+    async def test_get_capabilities_not_found(self, capability_module, mock_redis):
+        """Test handling of missing capabilities."""
+        mock_redis.get.return_value = None
+
+        result = await capability_module.get_capabilities("nonexistent-cluster")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_capabilities_redis_error(self, capability_module, mock_redis):
+        """Test graceful handling of Redis errors on get."""
+        mock_redis.get.side_effect = Exception("Redis timeout")
+
+        result = await capability_module.get_capabilities("error-cluster")
+
+        assert result is None
+
+
+class TestCapabilityModuleRefreshTTL:
+    """Tests for TTL refresh on heartbeat."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_ttl_success(self, capability_module, mock_redis):
+        """Test successful TTL refresh."""
+        stored_data = {
+            "cluster_id": "refresh-cluster",
+            "mode": "readOnly",
+            "allowed_verbs": [],
+            "restricted_resources": [],
+            "allowed_flags": [],
+            "expires_at": "2025-01-01T00:00:00Z",
+            "features": {},
+        }
+        mock_redis.exists.return_value = 1
+        mock_redis.get.return_value = json.dumps(stored_data)
+
+        result = await capability_module.refresh_ttl("refresh-cluster")
+
+        assert result is True
+        mock_redis.exists.assert_called_once_with("cluster:refresh-cluster:capabilities")
+        mock_redis.setex.assert_called_once()
+
+        # Verify expires_at was updated
+        call_args = mock_redis.setex.call_args[0]
+        updated_data = json.loads(call_args[2])
+        assert updated_data["expires_at"] != stored_data["expires_at"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_ttl_key_not_found(self, capability_module, mock_redis):
+        """Test TTL refresh when key doesn't exist."""
+        mock_redis.exists.return_value = 0
+
+        result = await capability_module.refresh_ttl("missing-cluster")
+
+        assert result is False
+        mock_redis.setex.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refresh_ttl_redis_error(self, capability_module, mock_redis):
+        """Test graceful handling of Redis errors on refresh."""
+        mock_redis.exists.side_effect = Exception("Redis error")
+
+        result = await capability_module.refresh_ttl("error-cluster")
+
+        assert result is False
+
+
+class TestCapabilityModuleDelete:
+    """Tests for capability deletion."""
+
+    @pytest.mark.asyncio
+    async def test_delete_capabilities_success(self, capability_module, mock_redis):
+        """Test successful capability deletion."""
+        mock_redis.delete.return_value = 1
+
+        result = await capability_module.delete_capabilities("delete-cluster")
+
+        assert result is True
+        mock_redis.delete.assert_called_once_with("cluster:delete-cluster:capabilities")
+
+    @pytest.mark.asyncio
+    async def test_delete_capabilities_not_found(self, capability_module, mock_redis):
+        """Test deletion when key doesn't exist."""
+        mock_redis.delete.return_value = 0
+
+        result = await capability_module.delete_capabilities("nonexistent")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_capabilities_redis_error(self, capability_module, mock_redis):
+        """Test graceful handling of Redis errors on delete."""
+        mock_redis.delete.side_effect = Exception("Redis error")
+
+        result = await capability_module.delete_capabilities("error-cluster")
+
+        assert result is False
+
+
+class TestCapabilityModuleListAll:
+    """Tests for listing all capabilities."""
+
+    @pytest.mark.asyncio
+    async def test_list_all_capabilities_multiple(self, capability_module, mock_redis):
+        """Test listing capabilities from multiple clusters."""
+        # Mock keys response
+        mock_redis.keys.return_value = [
+            b"cluster:cluster-1:capabilities",
+            b"cluster:cluster-2:capabilities",
+        ]
+
+        # Mock get responses for each cluster
+        cluster_1_data = {
+            "cluster_id": "cluster-1",
+            "mode": "readOnly",
+            "allowed_verbs": [],
+            "restricted_resources": [],
+            "allowed_flags": [],
+            "features": {},
+        }
+        cluster_2_data = {
+            "cluster_id": "cluster-2",
+            "mode": "fullAccess",
+            "allowed_verbs": [],
+            "restricted_resources": [],
+            "allowed_flags": [],
+            "features": {},
+        }
+
+        mock_redis.get.side_effect = [
+            json.dumps(cluster_1_data),
+            json.dumps(cluster_2_data),
+        ]
+
+        result = await capability_module.list_all_capabilities()
+
+        assert len(result) == 2
+        assert result[0].cluster_id == "cluster-1"
+        assert result[1].cluster_id == "cluster-2"
+
+    @pytest.mark.asyncio
+    async def test_list_all_capabilities_empty(self, capability_module, mock_redis):
+        """Test listing when no capabilities exist."""
+        mock_redis.keys.return_value = []
+
+        result = await capability_module.list_all_capabilities()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_all_capabilities_handles_stale(self, capability_module, mock_redis):
+        """Test that stale keys (with no data) are handled gracefully."""
+        mock_redis.keys.return_value = [
+            b"cluster:stale-cluster:capabilities",
+        ]
+        mock_redis.get.return_value = None  # Key exists but data is gone
+
+        result = await capability_module.list_all_capabilities()
+
+        assert result == []
+
+
+class TestCapabilityModuleClusterDetail:
+    """Tests for the get_cluster_detail aggregation method."""
+
+    @pytest.mark.asyncio
+    async def test_get_cluster_detail_full(self, capability_module, mock_redis):
+        """Test cluster detail with all data present."""
+        # Setup mocks
+        mock_redis.exists.side_effect = [1, 1]  # has token, has session
+        mock_redis.ttl.return_value = 1800
+
+        capabilities_data = {
+            "cluster_id": "detail-cluster",
+            "mode": "readOnly",
+            "allowed_verbs": ["get", "describe"],
+            "restricted_resources": [],
+            "allowed_flags": [],
+            "executor_version": "1.0.0",
+            "executor_pod": "pod-123",
+            "features": {},
+        }
+        mock_redis.get.return_value = json.dumps(capabilities_data)
+
+        result = await capability_module.get_cluster_detail("detail-cluster")
+
+        assert result["clusterId"] == "detail-cluster"
+        assert result["status"]["hasToken"] is True
+        assert result["status"]["hasActiveSession"] is True
+        assert result["status"]["executorReporting"] is True
+        assert result["capabilities"]["mode"] == "readOnly"
+        assert result["ttlRemaining"] == 1800
+
+    @pytest.mark.asyncio
+    async def test_get_cluster_detail_no_capabilities(self, capability_module, mock_redis):
+        """Test cluster detail when no capabilities are reported."""
+        mock_redis.exists.side_effect = [1, 0]  # has token, no session
+        mock_redis.get.return_value = None  # no capabilities
+
+        result = await capability_module.get_cluster_detail("no-caps-cluster")
+
+        assert result["clusterId"] == "no-caps-cluster"
+        assert result["status"]["hasToken"] is True
+        assert result["status"]["hasActiveSession"] is False
+        assert result["status"]["executorReporting"] is False
+        assert result["capabilities"] is None
+        assert result["ttlRemaining"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_cluster_detail_redis_error(self, capability_module, mock_redis):
+        """Test cluster detail with Redis error."""
+        mock_redis.exists.side_effect = Exception("Redis error")
+
+        result = await capability_module.get_cluster_detail("error-cluster")
+
+        assert result["clusterId"] == "error-cluster"
+        assert "error" in result["status"]
+        assert result["capabilities"] is None
+
+
+# =============================================================================
+# Edge Cases and Security Tests
+# =============================================================================
+
+
+class TestCapabilityModuleEdgeCases:
+    """Edge cases and security considerations."""
+
+    @pytest.mark.asyncio
+    async def test_special_characters_in_cluster_id(
+        self, capability_module, mock_redis, sample_capabilities
+    ):
+        """Test handling of special characters in cluster IDs."""
+        sample_capabilities.cluster_id = "prod-us-west-1"
+
+        await capability_module.store_capabilities(sample_capabilities)
+
+        call_args = mock_redis.setex.call_args[0]
+        assert call_args[0] == "cluster:prod-us-west-1:capabilities"
+
+    @pytest.mark.asyncio
+    async def test_empty_arrays_handled(self, capability_module, mock_redis):
+        """Test that empty arrays are handled correctly."""
+        caps = ExecutorCapabilities(
+            cluster_id="empty-cluster",
+            mode="readOnly",
+            allowed_verbs=[],
+            restricted_resources=[],
+            allowed_flags=[],
+        )
+
+        result = await capability_module.store_capabilities(caps)
+
+        assert result is True
+        call_args = mock_redis.setex.call_args[0]
+        stored_data = json.loads(call_args[2])
+        assert stored_data["allowed_verbs"] == []
+
+    @pytest.mark.asyncio
+    async def test_custom_ttl(self, mock_redis):
+        """Test custom TTL configuration."""
+        custom_ttl = 7200  # 2 hours
+        module = CapabilityModule(mock_redis, default_ttl=custom_ttl)
+
+        caps = ExecutorCapabilities(
+            cluster_id="custom-ttl-cluster",
+            mode="readOnly",
+            allowed_verbs=[],
+        )
+
+        await module.store_capabilities(caps)
+
+        call_args = mock_redis.setex.call_args[0]
+        assert call_args[1] == custom_ttl
+
+    def test_key_generation(self, capability_module):
+        """Test Redis key format."""
+        key = capability_module._key("my-cluster")
+        assert key == "cluster:my-cluster:capabilities"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_capability_api.py
+++ b/tests/test_capability_api.py
@@ -1,0 +1,540 @@
+"""
+API Endpoint tests for Capability Reporting feature.
+
+Tests cover:
+- POST /executor/capabilities - Executor capability reporting
+- POST /executor/heartbeat - TTL refresh
+- GET /api/v1/clusters/{cluster_id}/capabilities - Client capability lookup
+- GET /debug/clusters/{cluster_id} - Admin cluster detail
+
+These tests use FastAPI TestClient with mocked dependencies to test
+the endpoints in isolation.
+"""
+
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.testclient import TestClient
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from kubently.modules.capability import CapabilityModule, ExecutorCapabilities
+
+
+# =============================================================================
+# Test App Setup
+# =============================================================================
+
+
+def create_test_app():
+    """
+    Create a minimal test FastAPI app with capability endpoints.
+
+    This isolates the capability endpoints from the full application,
+    making tests faster and more focused.
+    """
+    app = FastAPI()
+
+    # Mock modules
+    mock_redis = AsyncMock()
+    mock_capability_module = AsyncMock(spec=CapabilityModule)
+    mock_capability_module.default_ttl = 3600
+
+    # Store in app state for access
+    app.state.capability_module = mock_capability_module
+    app.state.redis_client = mock_redis
+
+    # Mock auth dependencies
+    async def mock_verify_executor_auth() -> str:
+        """Mock executor authentication - returns cluster_id."""
+        return "test-cluster"
+
+    async def mock_verify_api_key():
+        """Mock API key authentication."""
+        return (True, "test-service")
+
+    # Endpoints (copied from main.py with simplified auth)
+    from pydantic import BaseModel, Field
+    from typing import Optional
+
+    class CapabilityReport(BaseModel):
+        mode: str = Field(..., pattern=r"^(readOnly|extendedReadOnly|fullAccess)$")
+        allowed_verbs: list[str] = Field(default_factory=list, max_length=50)
+        restricted_resources: list[str] = Field(default_factory=list, max_length=50)
+        allowed_flags: list[str] = Field(default_factory=list, max_length=100)
+        executor_version: Optional[str] = Field(None, max_length=50)
+        executor_pod: Optional[str] = Field(None, max_length=253)
+
+    @app.post("/executor/capabilities")
+    async def report_capabilities(
+        report: CapabilityReport,
+        cluster_id: str = Depends(mock_verify_executor_auth),
+    ):
+        capability_module = app.state.capability_module
+        if not capability_module:
+            raise HTTPException(503, "Service not initialized")
+
+        capabilities = ExecutorCapabilities(
+            cluster_id=cluster_id,
+            mode=report.mode,
+            allowed_verbs=report.allowed_verbs,
+            restricted_resources=report.restricted_resources,
+            allowed_flags=report.allowed_flags,
+            executor_version=report.executor_version,
+            executor_pod=report.executor_pod,
+            features={
+                "exec": report.mode in ["extendedReadOnly", "fullAccess"],
+                "port_forward": report.mode in ["extendedReadOnly", "fullAccess"],
+                "proxy": report.mode == "fullAccess",
+            },
+        )
+
+        success = await capability_module.store_capabilities(capabilities)
+        if not success:
+            raise HTTPException(500, "Failed to store capabilities")
+
+        return {
+            "status": "success",
+            "message": f"Capabilities stored for cluster {cluster_id}",
+            "mode": report.mode,
+            "ttl_seconds": capability_module.default_ttl,
+        }
+
+    @app.post("/executor/heartbeat")
+    async def executor_heartbeat(
+        cluster_id: str = Depends(mock_verify_executor_auth),
+    ):
+        capability_module = app.state.capability_module
+        if not capability_module:
+            raise HTTPException(503, "Service not initialized")
+
+        success = await capability_module.refresh_ttl(cluster_id)
+        if not success:
+            return {
+                "status": "not_found",
+                "message": f"No capabilities found for cluster {cluster_id}. Consider re-reporting.",
+            }
+
+        return {
+            "status": "success",
+            "message": f"TTL refreshed for cluster {cluster_id}",
+        }
+
+    @app.get("/api/v1/clusters/{cluster_id}/capabilities")
+    async def get_cluster_capabilities(
+        cluster_id: str,
+        auth_info = Depends(mock_verify_api_key),
+    ):
+        capability_module = app.state.capability_module
+        if not capability_module:
+            raise HTTPException(503, "Service not initialized")
+
+        capabilities = await capability_module.get_capabilities(cluster_id)
+
+        return {
+            "clusterId": cluster_id,
+            "capabilities": capabilities.to_dict() if capabilities else None,
+            "available": capabilities is not None,
+        }
+
+    @app.get("/debug/clusters/{cluster_id}")
+    async def get_cluster_detail(
+        cluster_id: str,
+        auth_info = Depends(mock_verify_api_key),
+    ):
+        capability_module = app.state.capability_module
+        if not capability_module:
+            raise HTTPException(503, "Service not initialized")
+
+        detail = await capability_module.get_cluster_detail(cluster_id)
+        return detail
+
+    return app
+
+
+@pytest.fixture
+def test_app():
+    """Create test app fixture."""
+    return create_test_app()
+
+
+@pytest.fixture
+def client(test_app):
+    """Create test client fixture."""
+    return TestClient(test_app)
+
+
+@pytest.fixture
+def capability_module(test_app):
+    """Get the mock capability module from app state."""
+    return test_app.state.capability_module
+
+
+# =============================================================================
+# POST /executor/capabilities Tests
+# =============================================================================
+
+
+class TestReportCapabilities:
+    """Tests for the capability reporting endpoint."""
+
+    def test_report_capabilities_success(self, client, capability_module):
+        """Test successful capability reporting."""
+        capability_module.store_capabilities.return_value = True
+
+        response = client.post(
+            "/executor/capabilities",
+            json={
+                "mode": "readOnly",
+                "allowed_verbs": ["get", "describe", "logs"],
+                "restricted_resources": ["secrets"],
+                "allowed_flags": ["--namespace"],
+                "executor_version": "1.0.0",
+                "executor_pod": "executor-abc123",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["mode"] == "readOnly"
+        assert data["ttl_seconds"] == 3600
+
+        # Verify store was called
+        capability_module.store_capabilities.assert_called_once()
+        call_arg = capability_module.store_capabilities.call_args[0][0]
+        assert call_arg.cluster_id == "test-cluster"
+        assert call_arg.mode == "readOnly"
+
+    def test_report_capabilities_minimal(self, client, capability_module):
+        """Test capability reporting with minimal required fields."""
+        capability_module.store_capabilities.return_value = True
+
+        response = client.post(
+            "/executor/capabilities",
+            json={"mode": "readOnly"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+
+    def test_report_capabilities_extended_readonly(self, client, capability_module):
+        """Test extendedReadOnly mode sets correct features."""
+        capability_module.store_capabilities.return_value = True
+
+        response = client.post(
+            "/executor/capabilities",
+            json={"mode": "extendedReadOnly"},
+        )
+
+        assert response.status_code == 200
+
+        # Verify features were set correctly
+        call_arg = capability_module.store_capabilities.call_args[0][0]
+        assert call_arg.features["exec"] is True
+        assert call_arg.features["port_forward"] is True
+        assert call_arg.features["proxy"] is False
+
+    def test_report_capabilities_full_access(self, client, capability_module):
+        """Test fullAccess mode sets all features."""
+        capability_module.store_capabilities.return_value = True
+
+        response = client.post(
+            "/executor/capabilities",
+            json={"mode": "fullAccess"},
+        )
+
+        assert response.status_code == 200
+
+        # Verify features were set correctly
+        call_arg = capability_module.store_capabilities.call_args[0][0]
+        assert call_arg.features["exec"] is True
+        assert call_arg.features["port_forward"] is True
+        assert call_arg.features["proxy"] is True
+
+    def test_report_capabilities_invalid_mode(self, client, capability_module):
+        """Test validation rejects invalid mode values."""
+        response = client.post(
+            "/executor/capabilities",
+            json={"mode": "invalidMode"},
+        )
+
+        assert response.status_code == 422  # Validation error
+        capability_module.store_capabilities.assert_not_called()
+
+    def test_report_capabilities_storage_failure(self, client, capability_module):
+        """Test handling of storage failure."""
+        capability_module.store_capabilities.return_value = False
+
+        response = client.post(
+            "/executor/capabilities",
+            json={"mode": "readOnly"},
+        )
+
+        assert response.status_code == 500
+        assert "Failed to store" in response.json()["detail"]
+
+    def test_report_capabilities_missing_mode(self, client, capability_module):
+        """Test validation rejects missing required mode field."""
+        response = client.post(
+            "/executor/capabilities",
+            json={"allowed_verbs": ["get"]},
+        )
+
+        assert response.status_code == 422
+
+    def test_report_capabilities_version_too_long(self, client, capability_module):
+        """Test validation rejects overly long executor_version."""
+        response = client.post(
+            "/executor/capabilities",
+            json={
+                "mode": "readOnly",
+                "executor_version": "x" * 51,  # Max is 50
+            },
+        )
+
+        assert response.status_code == 422
+
+
+# =============================================================================
+# POST /executor/heartbeat Tests
+# =============================================================================
+
+
+class TestExecutorHeartbeat:
+    """Tests for the heartbeat endpoint."""
+
+    def test_heartbeat_success(self, client, capability_module):
+        """Test successful heartbeat refreshes TTL."""
+        capability_module.refresh_ttl.return_value = True
+
+        response = client.post("/executor/heartbeat")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert "TTL refreshed" in data["message"]
+
+        capability_module.refresh_ttl.assert_called_once_with("test-cluster")
+
+    def test_heartbeat_no_capabilities(self, client, capability_module):
+        """Test heartbeat when no capabilities exist (graceful degradation)."""
+        capability_module.refresh_ttl.return_value = False
+
+        response = client.post("/executor/heartbeat")
+
+        assert response.status_code == 200  # Not an error!
+        data = response.json()
+        assert data["status"] == "not_found"
+        assert "re-reporting" in data["message"]
+
+
+# =============================================================================
+# GET /api/v1/clusters/{cluster_id}/capabilities Tests
+# =============================================================================
+
+
+class TestGetClusterCapabilities:
+    """Tests for the capability lookup endpoint."""
+
+    def test_get_capabilities_found(self, client, capability_module):
+        """Test successful capability retrieval."""
+        mock_caps = ExecutorCapabilities(
+            cluster_id="prod-cluster",
+            mode="readOnly",
+            allowed_verbs=["get", "describe"],
+            restricted_resources=["secrets"],
+            allowed_flags=["--namespace"],
+            features={"exec": False},
+        )
+        capability_module.get_capabilities.return_value = mock_caps
+
+        response = client.get("/api/v1/clusters/prod-cluster/capabilities")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["clusterId"] == "prod-cluster"
+        assert data["available"] is True
+        assert data["capabilities"]["mode"] == "readOnly"
+
+    def test_get_capabilities_not_found(self, client, capability_module):
+        """Test capability lookup when not stored (graceful degradation)."""
+        capability_module.get_capabilities.return_value = None
+
+        response = client.get("/api/v1/clusters/unknown-cluster/capabilities")
+
+        assert response.status_code == 200  # Not an error!
+        data = response.json()
+        assert data["clusterId"] == "unknown-cluster"
+        assert data["available"] is False
+        assert data["capabilities"] is None
+
+
+# =============================================================================
+# GET /debug/clusters/{cluster_id} Tests
+# =============================================================================
+
+
+class TestGetClusterDetail:
+    """Tests for the admin cluster detail endpoint."""
+
+    def test_get_cluster_detail_full(self, client, capability_module):
+        """Test cluster detail with all data present."""
+        mock_detail = {
+            "clusterId": "detail-cluster",
+            "status": {
+                "hasToken": True,
+                "hasActiveSession": True,
+                "executorReporting": True,
+            },
+            "capabilities": {
+                "mode": "readOnly",
+                "allowed_verbs": ["get", "describe"],
+                "cluster_id": "detail-cluster",
+            },
+            "ttlRemaining": 1800,
+        }
+        capability_module.get_cluster_detail.return_value = mock_detail
+
+        response = client.get("/debug/clusters/detail-cluster")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["clusterId"] == "detail-cluster"
+        assert data["status"]["hasToken"] is True
+        assert data["status"]["executorReporting"] is True
+        assert data["capabilities"]["mode"] == "readOnly"
+        assert data["ttlRemaining"] == 1800
+
+    def test_get_cluster_detail_no_capabilities(self, client, capability_module):
+        """Test cluster detail when no capabilities are reported."""
+        mock_detail = {
+            "clusterId": "no-caps-cluster",
+            "status": {
+                "hasToken": True,
+                "hasActiveSession": False,
+                "executorReporting": False,
+            },
+            "capabilities": None,
+            "ttlRemaining": None,
+        }
+        capability_module.get_cluster_detail.return_value = mock_detail
+
+        response = client.get("/debug/clusters/no-caps-cluster")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"]["executorReporting"] is False
+        assert data["capabilities"] is None
+
+
+# =============================================================================
+# Pydantic Validation Tests
+# =============================================================================
+
+
+class TestCapabilityReportValidation:
+    """Tests for CapabilityReport Pydantic model validation."""
+
+    def test_mode_enum_validation(self, client, capability_module):
+        """Test mode field only accepts valid enum values."""
+        # Valid modes
+        for mode in ["readOnly", "extendedReadOnly", "fullAccess"]:
+            capability_module.store_capabilities.return_value = True
+            response = client.post(
+                "/executor/capabilities",
+                json={"mode": mode},
+            )
+            assert response.status_code == 200, f"Mode {mode} should be valid"
+
+        # Invalid modes
+        for invalid_mode in ["readonly", "READONLY", "read-only", "admin", ""]:
+            response = client.post(
+                "/executor/capabilities",
+                json={"mode": invalid_mode},
+            )
+            assert response.status_code == 422, f"Mode {invalid_mode} should be invalid"
+
+    def test_array_length_limits(self, client, capability_module):
+        """Test that array fields respect max_length constraints."""
+        # allowed_verbs max is 50
+        response = client.post(
+            "/executor/capabilities",
+            json={
+                "mode": "readOnly",
+                "allowed_verbs": ["verb"] * 51,  # Exceeds max
+            },
+        )
+        assert response.status_code == 422
+
+    def test_pod_name_length_limit(self, client, capability_module):
+        """Test executor_pod respects K8s max pod name length."""
+        response = client.post(
+            "/executor/capabilities",
+            json={
+                "mode": "readOnly",
+                "executor_pod": "x" * 254,  # Max is 253
+            },
+        )
+        assert response.status_code == 422
+
+
+# =============================================================================
+# Integration-style Tests
+# =============================================================================
+
+
+class TestCapabilityWorkflow:
+    """Tests for complete capability reporting workflows."""
+
+    def test_report_then_heartbeat_workflow(self, client, capability_module):
+        """Test typical executor workflow: report capabilities then heartbeat."""
+        # Step 1: Report capabilities on startup
+        capability_module.store_capabilities.return_value = True
+
+        response = client.post(
+            "/executor/capabilities",
+            json={
+                "mode": "readOnly",
+                "allowed_verbs": ["get", "describe", "logs"],
+                "executor_version": "1.0.0",
+            },
+        )
+        assert response.status_code == 200
+
+        # Step 2: Send heartbeat to refresh TTL
+        capability_module.refresh_ttl.return_value = True
+
+        response = client.post("/executor/heartbeat")
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+
+    def test_expired_capabilities_re_report(self, client, capability_module):
+        """Test workflow when capabilities expire and need re-reporting."""
+        # Heartbeat fails (capabilities expired)
+        capability_module.refresh_ttl.return_value = False
+
+        response = client.post("/executor/heartbeat")
+        assert response.status_code == 200
+        assert response.json()["status"] == "not_found"
+
+        # Re-report capabilities
+        capability_module.store_capabilities.return_value = True
+
+        response = client.post(
+            "/executor/capabilities",
+            json={"mode": "readOnly"},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "a2a-python"
@@ -96,20 +100,21 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.66.0"
+version = "0.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
+    { name = "docstring-parser" },
     { name = "httpx" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/50/daa51c035e6a941f7b8034705796c7643443a85f5381cb41a797757fc6d3/anthropic-0.66.0.tar.gz", hash = "sha256:5aa8b18da57dc27d83fc1d82c9fb860977e5adfae3e0c215d7ab2ebd70afb9cb", size = 436933, upload-time = "2025-09-03T14:55:40.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/1f/08e95f4b7e2d35205ae5dcbb4ae97e7d477fc521c275c02609e2931ece2d/anthropic-0.75.0.tar.gz", hash = "sha256:e8607422f4ab616db2ea5baacc215dd5f028da99ce2f022e33c7c535b29f3dfb", size = 439565, upload-time = "2025-11-24T20:41:45.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/6a/d4ec7de9cc88b9a39c74dab1db259203b29b17fc564ecd1f92991678bd1e/anthropic-0.66.0-py3-none-any.whl", hash = "sha256:67b8cd4486f3cdd09211598dc5325cc8e4e349c106a03041231d551603551c06", size = 308035, upload-time = "2025-09-03T14:55:39.109Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1c/1cd02b7ae64302a6e06724bf80a96401d5313708651d277b1458504a1730/anthropic-0.75.0-py3-none-any.whl", hash = "sha256:ea8317271b6c15d80225a9f3c670152746e88805a7a61e14d4a374577164965b", size = 388164, upload-time = "2025-11-24T20:41:43.587Z" },
 ]
 
 [[package]]
@@ -365,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "cnoe-agent-utils"
-version = "0.3.0"
+version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -376,16 +381,20 @@ dependencies = [
     { name = "langchain-aws" },
     { name = "langchain-google-genai" },
     { name = "langchain-google-vertexai" },
+    { name = "langchain-groq" },
     { name = "langchain-openai" },
     { name = "langfuse" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/b8/9155bf6929a3e2846847c6c7f343f495881d85af38a8c670852701e18411/cnoe_agent_utils-0.3.0.tar.gz", hash = "sha256:f18a467eb8a919a4d7610906831d6ef6200589c4e930688339f6a4d7a68dc252", size = 126298, upload-time = "2025-08-18T03:14:51.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/1e/07378434d156407cfe38d00f9b33aec73b3a0895a59efc9a7195e6146d6f/cnoe_agent_utils-0.3.7.tar.gz", hash = "sha256:9613e12416431e67e86a58227da7aeb8c1e2e54617dac8a5c2024451d737078b", size = 191362, upload-time = "2025-11-10T19:01:11.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/b6/5b8802b4159982ccf26ca774b621e9f0d8eb7e84b5887bb3c62b287d79ec/cnoe_agent_utils-0.3.0-py3-none-any.whl", hash = "sha256:39c75d16c3fff589f7714c78a1e55abf6b183edd9963f1556f6ee48f42d8153e", size = 23595, upload-time = "2025-08-18T03:14:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ea/0d662597ca3de46c145a1d3877e502b440865fec3a3ab48bf510d1101a00/cnoe_agent_utils-0.3.7-py3-none-any.whl", hash = "sha256:ce24a363f21b889b487b7e99205a41b68e49ab65077a5ad60f99ee65d2957295", size = 55522, upload-time = "2025-11-10T19:01:10.379Z" },
 ]
 
 [[package]]
@@ -644,17 +653,19 @@ wheels = [
 
 [[package]]
 name = "google-ai-generativelanguage"
-version = "0.6.18"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
+    { name = "grpcio", version = "1.74.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/77/3e89a4c4200135eac74eca2f6c9153127e3719a825681ad55f5a4a58b422/google_ai_generativelanguage-0.6.18.tar.gz", hash = "sha256:274ba9fcf69466ff64e971d565884434388e523300afd468fc8e3033cd8e606e", size = 1444757, upload-time = "2025-04-29T15:45:45.527Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/7e/67fdc46187541ead599e77f259d915f129c2f49568ebf5cadb322130712b/google_ai_generativelanguage-0.9.0.tar.gz", hash = "sha256:2524748f413917446febc8e0879dc0d4f026a064f89f17c42b81bea77ab76c84", size = 1481662, upload-time = "2025-10-20T14:56:23.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/77/ca2889903a2d93b3072a49056d48b3f55410219743e338a1d7f94dc6455e/google_ai_generativelanguage-0.6.18-py3-none-any.whl", hash = "sha256:13d8174fea90b633f520789d32df7b422058fd5883b022989c349f1017db7fcf", size = 1372256, upload-time = "2025-04-29T15:45:43.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/91/c2d39ad5d77813afadb0f0b8789d882d15c191710b6b6f7cb158376342ff/google_ai_generativelanguage-0.9.0-py3-none-any.whl", hash = "sha256:59f61e54cb341e602073098389876594c4d12e458617727558bb2628a86f3eb2", size = 1401288, upload-time = "2025-10-20T14:52:58.403Z" },
 ]
 
 [[package]]
@@ -675,7 +686,8 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio" },
+    { name = "grpcio", version = "1.74.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "grpcio-status" },
 ]
 
@@ -841,7 +853,8 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio" },
+    { name = "grpcio", version = "1.74.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 
 [[package]]
@@ -858,6 +871,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
@@ -865,6 +880,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/da/343cd760ab2f92bac1845ca07ee3faea9fe52bee65f7bcb19f16ad7de08b/greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681", size = 1680760, upload-time = "2025-11-04T12:42:25.341Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
 ]
 
@@ -881,12 +898,30 @@ wheels = [
 ]
 
 [[package]]
+name = "groq"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/d6/97a982de7bcddbec3b8f57c20af395fe45a858314f132087e1ab2e9c95f0/groq-0.37.0.tar.gz", hash = "sha256:5b914f8bb13ca5097f8d3737deeed45453de1bef023ba896e8dfb167bd644452", size = 145106, upload-time = "2025-12-01T18:32:43.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/3c/27e981ee05d647cd55db65349508db2d9b0ee3857db680a617201ca820fa/groq-0.37.0-py3-none-any.whl", hash = "sha256:1403bf1a14a725f9240bed10501ca1ba42cfc9f73113d91ff3182d3bb6008a4c", size = 137522, upload-time = "2025-12-01T18:32:42.302Z" },
+]
+
+[[package]]
 name = "grpc-google-iam-v1"
 version = "0.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos", extra = ["grpc"] },
-    { name = "grpcio" },
+    { name = "grpcio", version = "1.74.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/4e/8d0ca3b035e41fe0b3f31ebbb638356af720335e5a11154c330169b40777/grpc_google_iam_v1-0.14.2.tar.gz", hash = "sha256:b3e1fc387a1a329e41672197d0ace9de22c78dd7d215048c4c78712073f7bd20", size = 16259, upload-time = "2025-03-17T11:40:23.586Z" }
@@ -898,6 +933,9 @@ wheels = [
 name = "grpcio"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.14'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/38/b4/35feb8f7cab7239c5b94bd2db71abb3d6adb5f335ad8f131abb6060840b6/grpcio-1.74.0.tar.gz", hash = "sha256:80d1f4fbb35b0742d3e3d3bb654b7381cd5f015f8497279a1e9c21ba623e01b1", size = 12756048, upload-time = "2025-07-24T18:54:23.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/d8/1004a5f468715221450e66b051c839c2ce9a985aa3ee427422061fcbb6aa/grpcio-1.74.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:2bc2d7d8d184e2362b53905cb1708c84cb16354771c04b490485fa07ce3a1d89", size = 5449488, upload-time = "2025-07-24T18:53:41.174Z" },
@@ -913,12 +951,47 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.76.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/e0/318c1ce3ae5a17894d5791e87aea147587c9e702f24122cc7a5c8bbaeeb1/grpcio-1.76.0.tar.gz", hash = "sha256:7be78388d6da1a25c0d5ec506523db58b18be22d9c37d8d3a32c08be4987bd73", size = 12785182, upload-time = "2025-10-21T16:23:12.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/ed/71467ab770effc9e8cef5f2e7388beb2be26ed642d567697bb103a790c72/grpcio-1.76.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:26ef06c73eb53267c2b319f43e6634c7556ea37672029241a056629af27c10e2", size = 5807716, upload-time = "2025-10-21T16:21:48.475Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/85/c6ed56f9817fab03fa8a111ca91469941fb514e3e3ce6d793cb8f1e1347b/grpcio-1.76.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:45e0111e73f43f735d70786557dc38141185072d7ff8dc1829d6a77ac1471468", size = 11821522, upload-time = "2025-10-21T16:21:51.142Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/2b8a235ab40c39cbc141ef647f8a6eb7b0028f023015a4842933bc0d6831/grpcio-1.76.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83d57312a58dcfe2a3a0f9d1389b299438909a02db60e2f2ea2ae2d8034909d3", size = 6362558, upload-time = "2025-10-21T16:21:54.213Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/64/9784eab483358e08847498ee56faf8ff6ea8e0a4592568d9f68edc97e9e9/grpcio-1.76.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3e2a27c89eb9ac3d81ec8835e12414d73536c6e620355d65102503064a4ed6eb", size = 7049990, upload-time = "2025-10-21T16:21:56.476Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/8c12319a6369434e7a184b987e8e9f3b49a114c489b8315f029e24de4837/grpcio-1.76.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61f69297cba3950a524f61c7c8ee12e55c486cb5f7db47ff9dcee33da6f0d3ae", size = 6575387, upload-time = "2025-10-21T16:21:59.051Z" },
+    { url = "https://files.pythonhosted.org/packages/15/0f/f12c32b03f731f4a6242f771f63039df182c8b8e2cf8075b245b409259d4/grpcio-1.76.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a15c17af8839b6801d554263c546c69c4d7718ad4321e3166175b37eaacca77", size = 7166668, upload-time = "2025-10-21T16:22:02.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/2d/3ec9ce0c2b1d92dd59d1c3264aaec9f0f7c817d6e8ac683b97198a36ed5a/grpcio-1.76.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:25a18e9810fbc7e7f03ec2516addc116a957f8cbb8cbc95ccc80faa072743d03", size = 8124928, upload-time = "2025-10-21T16:22:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/74/fd3317be5672f4856bcdd1a9e7b5e17554692d3db9a3b273879dc02d657d/grpcio-1.76.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:931091142fd8cc14edccc0845a79248bc155425eee9a98b2db2ea4f00a235a42", size = 7589983, upload-time = "2025-10-21T16:22:07.881Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/ca038cf420f405971f19821c8c15bcbc875505f6ffadafe9ffd77871dc4c/grpcio-1.76.0-cp313-cp313-win32.whl", hash = "sha256:5e8571632780e08526f118f74170ad8d50fb0a48c23a746bef2a6ebade3abd6f", size = 3984727, upload-time = "2025-10-21T16:22:10.032Z" },
+    { url = "https://files.pythonhosted.org/packages/41/80/84087dc56437ced7cdd4b13d7875e7439a52a261e3ab4e06488ba6173b0a/grpcio-1.76.0-cp313-cp313-win_amd64.whl", hash = "sha256:f9f7bd5faab55f47231ad8dba7787866b69f5e93bc306e3915606779bbfb4ba8", size = 4702799, upload-time = "2025-10-21T16:22:12.709Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/46/39adac80de49d678e6e073b70204091e76631e03e94928b9ea4ecf0f6e0e/grpcio-1.76.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:ff8a59ea85a1f2191a0ffcc61298c571bc566332f82e5f5be1b83c9d8e668a62", size = 5808417, upload-time = "2025-10-21T16:22:15.02Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f5/a4531f7fb8b4e2a60b94e39d5d924469b7a6988176b3422487be61fe2998/grpcio-1.76.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:06c3d6b076e7b593905d04fdba6a0525711b3466f43b3400266f04ff735de0cd", size = 11828219, upload-time = "2025-10-21T16:22:17.954Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/1c/de55d868ed7a8bd6acc6b1d6ddc4aa36d07a9f31d33c912c804adb1b971b/grpcio-1.76.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd5ef5932f6475c436c4a55e4336ebbe47bd3272be04964a03d316bbf4afbcbc", size = 6367826, upload-time = "2025-10-21T16:22:20.721Z" },
+    { url = "https://files.pythonhosted.org/packages/59/64/99e44c02b5adb0ad13ab3adc89cb33cb54bfa90c74770f2607eea629b86f/grpcio-1.76.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b331680e46239e090f5b3cead313cc772f6caa7d0fc8de349337563125361a4a", size = 7049550, upload-time = "2025-10-21T16:22:23.637Z" },
+    { url = "https://files.pythonhosted.org/packages/43/28/40a5be3f9a86949b83e7d6a2ad6011d993cbe9b6bd27bea881f61c7788b6/grpcio-1.76.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2229ae655ec4e8999599469559e97630185fdd53ae1e8997d147b7c9b2b72cba", size = 6575564, upload-time = "2025-10-21T16:22:26.016Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a9/1be18e6055b64467440208a8559afac243c66a8b904213af6f392dc2212f/grpcio-1.76.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:490fa6d203992c47c7b9e4a9d39003a0c2bcc1c9aa3c058730884bbbb0ee9f09", size = 7176236, upload-time = "2025-10-21T16:22:28.362Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/55/dba05d3fcc151ce6e81327541d2cc8394f442f6b350fead67401661bf041/grpcio-1.76.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:479496325ce554792dba6548fae3df31a72cef7bad71ca2e12b0e58f9b336bfc", size = 8125795, upload-time = "2025-10-21T16:22:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/45/122df922d05655f63930cf42c9e3f72ba20aadb26c100ee105cad4ce4257/grpcio-1.76.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c9b93f79f48b03ada57ea24725d83a30284a012ec27eab2cf7e50a550cbbbcc", size = 7592214, upload-time = "2025-10-21T16:22:33.831Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/6e/0b899b7f6b66e5af39e377055fb4a6675c9ee28431df5708139df2e93233/grpcio-1.76.0-cp314-cp314-win32.whl", hash = "sha256:747fa73efa9b8b1488a95d0ba1039c8e2dca0f741612d80415b1e1c560febf4e", size = 4062961, upload-time = "2025-10-21T16:22:36.468Z" },
+    { url = "https://files.pythonhosted.org/packages/19/41/0b430b01a2eb38ee887f88c1f07644a1df8e289353b78e82b37ef988fb64/grpcio-1.76.0-cp314-cp314-win_amd64.whl", hash = "sha256:922fa70ba549fce362d2e2871ab542082d66e2aaf0c19480ea453905b01f384e", size = 4834462, upload-time = "2025-10-21T16:22:39.772Z" },
+]
+
+[[package]]
 name = "grpcio-status"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
-    { name = "grpcio" },
+    { name = "grpcio", version = "1.74.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/93/22/238c5f01e6837df54494deb08d5c772bc3f5bf5fb80a15dce254892d1a81/grpcio_status-1.74.0.tar.gz", hash = "sha256:c58c1b24aa454e30f1fc6a7e0dbbc194c54a408143971a94b5f4e40bb5831432", size = 13662, upload-time = "2025-07-24T19:01:56.874Z" }
@@ -1235,6 +1308,7 @@ a2a = [
     { name = "langchain-openai" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-redis" },
+    { name = "langsmith" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -1285,13 +1359,14 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27.0" },
     { name = "langchain", marker = "extra == 'a2a'", specifier = ">=0.3.0" },
-    { name = "langchain-anthropic", marker = "extra == 'a2a'", specifier = ">=0.3.0" },
+    { name = "langchain-anthropic", marker = "extra == 'a2a'", specifier = ">=0.3.21" },
     { name = "langchain-community", marker = "extra == 'a2a'", specifier = ">=0.3.0" },
     { name = "langchain-core", marker = "extra == 'a2a'", specifier = ">=0.3.0" },
     { name = "langchain-mcp-adapters", marker = "extra == 'a2a'", specifier = ">=0.1.0" },
     { name = "langchain-openai", marker = "extra == 'a2a'", specifier = ">=0.2.0" },
     { name = "langgraph", marker = "extra == 'a2a'", specifier = ">=0.2.0" },
     { name = "langgraph-checkpoint-redis", marker = "extra == 'a2a'", specifier = ">=0.1.0" },
+    { name = "langsmith", marker = "extra == 'a2a'", specifier = ">=0.1.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27.0" },
@@ -1329,39 +1404,35 @@ dev = [
 
 [[package]]
 name = "langchain"
-version = "0.3.27"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
-    { name = "langchain-text-splitters" },
-    { name = "langsmith" },
+    { name = "langgraph" },
     { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/f6/f4f7f3a56626fe07e2bb330feb61254dbdf06c506e6b59a536a337da51cf/langchain-0.3.27.tar.gz", hash = "sha256:aa6f1e6274ff055d0fd36254176770f356ed0a8994297d1df47df341953cec62", size = 10233809, upload-time = "2025-07-24T14:42:32.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/06/be7273c6c15f5a7e64788ed2aa6329dd019170a176977acff7bcde2cdea2/langchain-1.1.0.tar.gz", hash = "sha256:583c892f59873c0329dbe04169fb3234ac794c50780e7c6fb62a61c7b86a981b", size = 528416, upload-time = "2025-11-24T15:31:24.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/d5/4861816a95b2f6993f1360cfb605aacb015506ee2090433a71de9cca8477/langchain-0.3.27-py3-none-any.whl", hash = "sha256:7b20c4f338826acb148d885b20a73a16e410ede9ee4f19bb02011852d5f98798", size = 1018194, upload-time = "2025-07-24T14:42:30.23Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/6f/889c01d22c84934615fa3f2dcf94c2fe76fd0afa7a7d01f9b798059f0ecc/langchain-1.1.0-py3-none-any.whl", hash = "sha256:af080f3a4a779bfa5925de7aacb6dfab83249d4aab9a08f7aa7b9bec3766d8ea", size = 101797, upload-time = "2025-11-24T15:31:23.401Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "0.3.19"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/ab/bdaefa42fdab238efff45eb28c6cd74c011979092408decdae22c0bf7e66/langchain_anthropic-0.3.19.tar.gz", hash = "sha256:e62259382586ee5c44e9a9459d00b74a7e191550e5fadfad28f0daa5d143d745", size = 281502, upload-time = "2025-08-18T18:33:36.811Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f2/717dcadf0c96960154594409b68bdd5953ab95439e0b65de13cdd5c08785/langchain_anthropic-1.2.0.tar.gz", hash = "sha256:3f3cfad8c519ead2deb21c30dc538b18f4c094704c7874784320cbed7a199453", size = 688803, upload-time = "2025-11-24T14:17:17.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/69/64473db52d02715f3815df3b25c9816b5801a58762a5ae62a3e5b84169a0/langchain_anthropic-0.3.19-py3-none-any.whl", hash = "sha256:5b5372ef7e10ee32b4308b4d9e1ed623c360b7d0a233c017e5209ad8118d5ab7", size = 31775, upload-time = "2025-08-18T18:33:35.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f4/f684725bd375208130ff3e9878ff3e671d888eec89a834617f3d7bcc14c9/langchain_anthropic-1.2.0-py3-none-any.whl", hash = "sha256:f489df97833e12ca0360a098eb9d04e410752840416be87ab60b0a3e120a99fe", size = 49512, upload-time = "2025-11-24T14:17:16.048Z" },
 ]
 
 [[package]]
 name = "langchain-aws"
-version = "0.2.31"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -1369,9 +1440,9 @@ dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/2f/ba63c0af3050d5efae731d82172548937385ad554d6cceca1f45a81764a6/langchain_aws-0.2.31.tar.gz", hash = "sha256:7e0257d50b05d0fc2f2763c50f93151fd06326e2f55286673289b0ddfc83e52b", size = 116939, upload-time = "2025-08-19T22:42:23.797Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/1d/bb306951b1c394b7a27effb8eb6c9ee65dd77fcc4be7c20f76e3299a9e1e/langchain_aws-1.1.0.tar.gz", hash = "sha256:1e2f8570328eae4907c3cf7e900dc68d8034ddc865d9dc96823c9f9d8cccb901", size = 393899, upload-time = "2025-11-24T14:35:24.216Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/08/5ceef1c48a9da68881a4e37cab4f0a7bf88836dc4c94639736ed840e3270/langchain_aws-0.2.31-py3-none-any.whl", hash = "sha256:dc46bd7e198f0a3c119bb26a9329a572e7898108aa00057198be3916f477e988", size = 141765, upload-time = "2025-08-19T22:42:22.308Z" },
+    { url = "https://files.pythonhosted.org/packages/26/33/91b8d2a7570657b371382b45054142c54165a51706990a5c1b4cc40c0e9a/langchain_aws-1.1.0-py3-none-any.whl", hash = "sha256:8ec074615b42839e035354063717374c32c63f5028ef5221ba073fd5f3ef5e37", size = 152432, upload-time = "2025-11-24T14:35:23.004Z" },
 ]
 
 [[package]]
@@ -1399,7 +1470,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.75"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1410,14 +1481,14 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/63/270b71a23e849984505ddc7c5c9fd3f4bd9cb14b1a484ee44c4e51c33cc2/langchain_core-0.3.75.tar.gz", hash = "sha256:ab0eb95a06ed6043f76162e6086b45037690cb70b7f090bd83b5ebb8a05b70ed", size = 570876, upload-time = "2025-08-26T15:24:12.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/17/67c1cc2ace919e2b02dd9d783154d7fb3f1495a4ef835d9cd163b7855ac2/langchain_core-1.1.0.tar.gz", hash = "sha256:2b76a82d427922c8bc51c08404af4fc2a29e9f161dfe2297cb05091e810201e7", size = 781995, upload-time = "2025-11-21T21:01:26.958Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/42/0d0221cce6f168f644d7d96cb6c87c4e42fc55d2941da7a36e970e3ab8ab/langchain_core-0.3.75-py3-none-any.whl", hash = "sha256:03ca1fadf955ee3c7d5806a841f4b3a37b816acea5e61a7e6ba1298c05eea7f5", size = 443986, upload-time = "2025-08-26T15:24:10.883Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/e129fc471a2d2a7b3804480a937b5ab9319cab9f4142624fcb115f925501/langchain_core-1.1.0-py3-none-any.whl", hash = "sha256:2c9f27dadc6d21ed4aa46506a37a56e6a7e2d2f9141922dc5c251ba921822ee6", size = 473752, upload-time = "2025-11-21T21:01:25.841Z" },
 ]
 
 [[package]]
 name = "langchain-google-genai"
-version = "2.1.10"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filetype" },
@@ -1425,14 +1496,14 @@ dependencies = [
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/c9/1808edc6e4835a4f596701d84b4a6b6c295e6875186adfbbeeeba9004469/langchain_google_genai-2.1.10.tar.gz", hash = "sha256:3d091aa61284d7256b2887966e806689adce35e55bc46f705162e5ede8aacda9", size = 45898, upload-time = "2025-08-27T06:15:11.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/27/f3c8f47b7c194c42a7ea38e5b91b412c4bd45f97e702a96edad659312437/langchain_google_genai-3.2.0.tar.gz", hash = "sha256:1fa620ea9c655a37537e95438857c423e1a3599b5a665b8dd87064c76ee95b72", size = 242146, upload-time = "2025-11-24T14:33:11.205Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/ed/957c7e6c362b7cdf1d709c0190035c0c843a3d2e225e40a2b80cca75fd3c/langchain_google_genai-2.1.10-py3-none-any.whl", hash = "sha256:247e38908d6b37fb4c4892ca09ae224c7510158b54b0582a9f39a7ddf37a0e2c", size = 49408, upload-time = "2025-08-27T06:15:10.458Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9d/c79a367e3379cf6b7d0cc43d558a411a5097d55291f2ce2f573420adb523/langchain_google_genai-3.2.0-py3-none-any.whl", hash = "sha256:689fc159d4623a184678e24771f6d52373e983a8fc8d342e44352aaf28e9445d", size = 57604, upload-time = "2025-11-24T14:33:10.112Z" },
 ]
 
 [[package]]
 name = "langchain-google-vertexai"
-version = "2.0.28"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bottleneck" },
@@ -1446,49 +1517,50 @@ dependencies = [
     { name = "pydantic" },
     { name = "validators" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/cf/0f19c7f6bf336f4681ee63e9ba91d94f112ced688825ac22584a3b72b6f8/langchain_google_vertexai-2.0.28.tar.gz", hash = "sha256:35fcd366752b6a5b8fa490c80816b9e8d372edc39fb5b3ad177b1d4f269781f2", size = 88116, upload-time = "2025-08-04T17:20:56.669Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/eb/1205661549de501110b47db030ab4b91537537828b805c7a43867b1436ac/langchain_google_vertexai-3.1.1.tar.gz", hash = "sha256:76a8851274903e0f1d402669d3ccd6b8aca9486e43db36b0e2838b9452ca4051", size = 357638, upload-time = "2025-12-02T20:45:36.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/34/ee3d5aec5b1fed6961d2584ecb8d366849edf44ba983824320705658c2cb/langchain_google_vertexai-2.0.28-py3-none-any.whl", hash = "sha256:8dc7a5cfb50b19fa455a284bed9f4f330e0eb462f3251773576b207780eb7709", size = 103964, upload-time = "2025-08-04T17:20:55.469Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e8/c26fd63947f91f4ef6cd66cc80e1666fd0b1325c6a484c0850444497bf58/langchain_google_vertexai-3.1.1-py3-none-any.whl", hash = "sha256:100587669ab38330e9b1cac0035f8f341b5df65e70ddbec73efa9e8d45a3bf96", size = 103092, upload-time = "2025-12-02T20:45:35.783Z" },
+]
+
+[[package]]
+name = "langchain-groq"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "groq" },
+    { name = "langchain-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/c7/eca8b5257e7cd0db673d9ffa5c165f0b203407b1d5ac1cc6f28a0e12f852/langchain_groq-1.1.0.tar.gz", hash = "sha256:5c5f7b43f08b80a9dfcd7f3c0bdc22261039b93d84d1909789453e0f307c3cae", size = 200678, upload-time = "2025-11-24T14:21:28.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/cb/713897071ffb89b3085e91330b48b59629826e5ed64be136fb9d34459be5/langchain_groq-1.1.0-py3-none-any.whl", hash = "sha256:f6c9a7bfe46a3d6e7e0cdc3888ba9c5443b6e1ed674894a090c4b20b36465a3b", size = 19038, upload-time = "2025-11-24T14:21:27.35Z" },
 ]
 
 [[package]]
 name = "langchain-mcp-adapters"
-version = "0.1.9"
+version = "0.1.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "mcp" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/74/e36003a43136f9095a5f968c730fbfe894f94284ebe6d2b50bb17d41b8b5/langchain_mcp_adapters-0.1.9.tar.gz", hash = "sha256:0018cf7b5f7bc4c044e05ec20fcb9ebe345311c8d1060c61d411188001ab3aab", size = 22101, upload-time = "2025-07-09T15:56:14.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/36/0179462acf344ad18cf6d7190b7a6797e015386a3b4518fcd960bb831c61/langchain_mcp_adapters-0.1.14.tar.gz", hash = "sha256:36f8131d0b3b5ca28df03440be4dc2a3636e2f73e3e4a0a266d606ffaa12adda", size = 31119, upload-time = "2025-11-24T15:00:54.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/eb/9e98822d3db22beff44449a8f61fca208d4f59d592a7ce67ce4c400b8f8f/langchain_mcp_adapters-0.1.9-py3-none-any.whl", hash = "sha256:fd131009c60c9e5a864f96576bbe757fc1809abd604891cb2e5d6e8aebd6975c", size = 15300, upload-time = "2025-07-09T15:56:13.316Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e0/eee23ea4d651d2b2dd5b1a5e1b7f66ee212940a595917a280663d5f745b9/langchain_mcp_adapters-0.1.14-py3-none-any.whl", hash = "sha256:b900d37d1a82261e408e663b7176a1a74cf0072e17ae9e4241c068093912394a", size = 21133, upload-time = "2025-11-24T15:00:53.569Z" },
 ]
 
 [[package]]
 name = "langchain-openai"
-version = "0.3.32"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/19/167d9ad1b6bb75406c4acceda01ef0dc1101c7f629f74441fe8a787fb190/langchain_openai-0.3.32.tar.gz", hash = "sha256:782ad669bd1bdb964456d8882c5178717adcfceecb482cc20005f770e43d346d", size = 782982, upload-time = "2025-08-26T14:25:27.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/29/cc7a7d1c42d19c903efa3ef9c9f00042942d28a00da1af12be5b7035375d/langchain_openai-1.1.0.tar.gz", hash = "sha256:9a33280c2e8315d013d64e6b15e583be347beb0d0f281755c335ae504ad0c184", size = 1034339, upload-time = "2025-11-24T14:20:48.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/3d/e22ee65fff79afe7bdfbd67844243eb279b440c882dad9e4262dcc87131f/langchain_openai-0.3.32-py3-none-any.whl", hash = "sha256:3354f76822f7cc76d8069831fe2a77f9bc7ff3b4f13af788bd94e4c6e853b400", size = 74531, upload-time = "2025-08-26T14:25:26.542Z" },
-]
-
-[[package]]
-name = "langchain-text-splitters"
-version = "0.3.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "langchain-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/43/dcda8fd25f0b19cb2835f2f6bb67f26ad58634f04ac2d8eae00526b0fa55/langchain_text_splitters-0.3.11.tar.gz", hash = "sha256:7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc", size = 46458, upload-time = "2025-08-31T23:02:58.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/0d/41a51b40d24ff0384ec4f7ab8dd3dcea8353c05c973836b5e289f1465d4f/langchain_text_splitters-0.3.11-py3-none-any.whl", hash = "sha256:cf079131166a487f1372c8ab5d0bfaa6c0a4291733d9c43a34a16ac9bcd6a393", size = 33845, upload-time = "2025-08-31T23:02:57.195Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ff/82699ef76f36818d86571a0b086ce07af5503a63d7430fc49e7d6aeb5dc1/langchain_openai-1.1.0-py3-none-any.whl", hash = "sha256:243bb345d0260ea1326c2b6ac2237ec29f082ab457c59e9306bac349df4577e8", size = 84282, upload-time = "2025-11-24T14:20:47.717Z" },
 ]
 
 [[package]]
@@ -1513,7 +1585,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "0.6.6"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1523,9 +1595,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/2b/59f0b2985467ec84b006dd41ec31c0aae43a7f16722d5514292500b871c9/langgraph-0.6.6.tar.gz", hash = "sha256:e7d3cefacf356f8c01721b166b67b3bf581659d5361a3530f59ecd9b8448eca7", size = 465452, upload-time = "2025-08-20T04:02:13.915Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/3c/af87902d300c1f467165558c8966d8b1e1f896dace271d3f35a410a5c26a/langgraph-1.0.4.tar.gz", hash = "sha256:86d08e25d7244340f59c5200fa69fdd11066aa999b3164b531e2a20036fac156", size = 484397, upload-time = "2025-11-25T20:31:48.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/ef/81fce0a80925cd89987aa641ff01573e3556a24f2d205112862a69df7fd3/langgraph-0.6.6-py3-none-any.whl", hash = "sha256:a2283a5236abba6c8307c1a485c04e8a0f0ffa2be770878782a7bf2deb8d7954", size = 153274, upload-time = "2025-08-20T04:02:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/14/52/4eb25a3f60399da34ba34adff1b3e324cf0d87eb7a08cebf1882a9b5e0d5/langgraph-1.0.4-py3-none-any.whl", hash = "sha256:b1a835ceb0a8d69b9db48075e1939e28b1ad70ee23fa3fa8f90149904778bacf", size = 157271, upload-time = "2025-11-25T20:31:47.518Z" },
 ]
 
 [[package]]
@@ -1558,15 +1630,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "0.6.4"
+version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/21/9b198d11732101ee8cdf30af98d0b4f11254c768de15173e57f5260fd14b/langgraph_prebuilt-0.6.4.tar.gz", hash = "sha256:e9e53b906ee5df46541d1dc5303239e815d3ec551e52bb03dd6463acc79ec28f", size = 125695, upload-time = "2025-08-07T18:17:57.333Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/f9/54f8891b32159e4542236817aea2ee83de0de18bce28e9bdba08c7f93001/langgraph_prebuilt-1.0.5.tar.gz", hash = "sha256:85802675ad778cc7240fd02d47db1e0b59c0c86d8369447d77ce47623845db2d", size = 144453, upload-time = "2025-11-20T16:47:39.23Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/7f/973b0d9729d9693d6e5b4bc5f3ae41138d194cb7b16b0ed230020beeb13a/langgraph_prebuilt-0.6.4-py3-none-any.whl", hash = "sha256:819f31d88b84cb2729ff1b79db2d51e9506b8fb7aaacfc0d359d4fe16e717344", size = 28025, upload-time = "2025-08-07T18:17:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5e/aeba4a5b39fe6e874e0dd003a82da71c7153e671312671a8dacc5cb7c1af/langgraph_prebuilt-1.0.5-py3-none-any.whl", hash = "sha256:22369563e1848862ace53fbc11b027c28dd04a9ac39314633bb95f2a7e258496", size = 35072, upload-time = "2025-11-20T16:47:38.187Z" },
 ]
 
 [[package]]
@@ -2005,7 +2077,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.106.1"
+version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2017,9 +2089,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/b6/1aff7d6b8e9f0c3ac26bfbb57b9861a6711d5d60bd7dd5f7eebbf80509b7/openai-1.106.1.tar.gz", hash = "sha256:5f575967e3a05555825c43829cdcd50be6e49ab6a3e5262f0937a3f791f917f1", size = 561095, upload-time = "2025-09-04T18:17:15.303Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/e4/42591e356f1d53c568418dc7e30dcda7be31dd5a4d570bca22acb0525862/openai-2.8.1.tar.gz", hash = "sha256:cb1b79eef6e809f6da326a7ef6038719e35aa944c42d081807bfa1be8060f15f", size = 602490, upload-time = "2025-11-17T22:39:59.549Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/e1/47887212baa7bc0532880d33d5eafbdb46fcc4b53789b903282a74a85b5b/openai-1.106.1-py3-none-any.whl", hash = "sha256:bfdef37c949f80396c59f2c17e0eda35414979bc07ef3379596a93c9ed044f3a", size = 930768, upload-time = "2025-09-04T18:17:13.349Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4f/dbc0c124c40cb390508a82770fb9f6e3ed162560181a85089191a851c59a/openai-2.8.1-py3-none-any.whl", hash = "sha256:c6c3b5a04994734386e8dad3c00a393f56d3b68a27cd2e8acae91a59e4122463", size = 1022688, upload-time = "2025-11-17T22:39:57.675Z" },
 ]
 
 [[package]]
@@ -2066,7 +2138,8 @@ version = "1.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
-    { name = "grpcio" },
+    { name = "grpcio", version = "1.74.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-common" },
     { name = "opentelemetry-proto" },


### PR DESCRIPTION
## Summary

- **Implements executor capability reporting** - Executors can now advertise their DynamicCommandWhitelist configuration to the central API on startup
- **TTL-based storage with heartbeat refresh** - Capabilities expire after 1 hour, executors send heartbeats every 5 minutes to keep them alive
- **Graceful degradation by design** - Missing capabilities don't break functionality; feature is disabled by default and fails silently if API doesn't support it
- **Comprehensive test coverage** - 49 new tests (30 unit + 19 API endpoint tests) with 95.87% module coverage

## New Endpoints

| Endpoint | Auth | Description |
|----------|------|-------------|
| `POST /executor/capabilities` | Executor token | Report capabilities on startup |
| `POST /executor/heartbeat` | Executor token | Refresh TTL to prevent expiration |
| `GET /api/v1/clusters/{id}/capabilities` | API key | Query capabilities for a cluster |
| `GET /debug/clusters/{id}` | API key | Detailed cluster status including capabilities |

## New Module

```
kubently/modules/capability/
├── __init__.py      # Black box interface
└── capability.py    # CapabilityModule + ExecutorCapabilities dataclass
```

## Helm Configuration

```yaml
executor:
  capabilities:
    enabled: false          # Disabled by default
    heartbeatInterval: 300  # 5 minutes
```

## Test plan

- [x] Unit tests for CapabilityModule Redis operations
- [x] Unit tests for ExecutorCapabilities serialization
- [x] API endpoint tests for all 4 new endpoints
- [x] Validation tests for Pydantic models
- [x] Workflow tests (report → heartbeat, expiration → re-report)
- [ ] Manual E2E test with deployed executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)