### PR TITLE
Add MCP server, executor whitelist enforcement, and cloud-auth support

### DIFF
--- a/deployment/helm/kubently/templates/executor-serviceaccount.yaml
+++ b/deployment/helm/kubently/templates/executor-serviceaccount.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubently.fullname" . }}-executor
+  {{- with .Values.executor.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "kubently.labels" . | nindent 4 }}
     app.kubernetes.io/component: executor

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -128,6 +128,15 @@ executor:
   #     apiUrl: "http://kubently-api.central-cluster.svc.cluster.local:8080"
   apiUrl: ""
 
+  # ServiceAccount annotations for the executor pod's cloud identity.
+  # This is how you wire cloud IAM to the executor with NO code changes — kubectl
+  # and cloud SDKs in the executor pick up credentials automatically:
+  #   AWS IRSA:               eks.amazonaws.com/role-arn: arn:aws:iam::<acct>:role/<role>
+  #   GKE Workload Identity:  iam.gke.io/gcp-service-account: <gsa>@<project>.iam.gserviceaccount.com
+  # See docs/CLOUD_AUTH.md.
+  serviceAccount:
+    annotations: {}
+
   # ----------------------------------------------------------------------------
   # Security & Command Whitelist
   # ----------------------------------------------------------------------------

--- a/docs/CLOUD_AUTH.md
+++ b/docs/CLOUD_AUTH.md
@@ -1,0 +1,90 @@
+# Cloud Authentication for Executors
+
+Kubently executors carry **no cloud-provider SDK code**. The executor simply shells out
+to `kubectl`, so cloud credentials are picked up the same way any in-cluster workload gets
+them: from the executor pod's **ServiceAccount**, wired to a cloud IAM identity.
+
+This means you can give an executor scoped cloud access — including reaching cluster API
+servers and assuming roles for richer debugging — **without changing a line of Kubently
+code**. You only set annotations on the executor ServiceAccount.
+
+```yaml
+# values.yaml
+executor:
+  serviceAccount:
+    annotations:
+      # AWS IRSA:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/kubently-executor
+      # GKE Workload Identity (use one or the other, per cloud):
+      iam.gke.io/gcp-service-account: kubently-executor@my-project.iam.gserviceaccount.com
+```
+
+The annotation block is rendered onto `templates/executor-serviceaccount.yaml`; if you set
+no annotations, none are emitted.
+
+---
+
+## AWS — IRSA (IAM Roles for Service Accounts)
+
+1. Create an IAM role with a trust policy for the cluster's OIDC provider, scoped to the
+   executor ServiceAccount (`system:serviceaccount:<namespace>:<release>-kubently-executor`).
+2. Grant that role whatever AWS permissions the executor needs (e.g.
+   `eks:DescribeCluster`, or `sts:AssumeRole` for cross-account debugging — see below).
+3. Map the IAM identity to in-cluster RBAC. On EKS this is an **access entry** (or the legacy
+   `aws-auth` ConfigMap) that maps the role to a Kubernetes group; Kubently's read-only
+   executor RBAC then applies as usual.
+4. Annotate the executor SA:
+
+   ```yaml
+   executor:
+     serviceAccount:
+       annotations:
+         eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/kubently-executor
+   ```
+
+### Cross-account / assume-role debugging
+For executors that must reach resources or clusters in another AWS account, give the
+executor's IRSA role `sts:AssumeRole` on the target account's role, and configure the
+target role's trust policy to allow it. Because `kubectl` and the AWS CLI in the pod read
+the standard credential chain, an `AWS_*`/profile-based assume-role config (or a
+`credential_process`) is honored automatically — no Kubently change required.
+
+> Note: the cloud identity governs **authentication** to the cloud/cluster endpoint.
+> What the executor may *do* in a cluster is still bounded by Kubernetes RBAC on the
+> executor ServiceAccount (read-only by default) plus the command whitelist.
+
+---
+
+## GKE — Workload Identity
+
+1. Create a Google service account (GSA) with the needed roles (e.g.
+   `roles/container.viewer`).
+2. Allow the Kubernetes SA to impersonate the GSA:
+
+   ```bash
+   gcloud iam service-accounts add-iam-policy-binding \
+     kubently-executor@my-project.iam.gserviceaccount.com \
+     --role roles/iam.workloadIdentityUser \
+     --member "serviceAccount:my-project.svc.id.goog[<namespace>/<release>-kubently-executor]"
+   ```
+
+3. Annotate the executor SA:
+
+   ```yaml
+   executor:
+     serviceAccount:
+       annotations:
+         iam.gke.io/gcp-service-account: kubently-executor@my-project.iam.gserviceaccount.com
+   ```
+
+As with AWS, Workload Identity authenticates the executor to GCP/GKE; Kubernetes RBAC and
+the command whitelist still bound what it can run.
+
+---
+
+## Why this design
+
+Keeping cloud auth in deployment config rather than executor code is what makes Kubently
+**vendor-neutral**: the same executor image runs against EKS, GKE, AKS, or vanilla
+Kubernetes, and the only thing that changes per cloud is a ServiceAccount annotation. There
+is no provider SDK to maintain, no per-cloud build, and no credentials baked into the image.

--- a/docs/RESUME_PUNCHLIST.md
+++ b/docs/RESUME_PUNCHLIST.md
@@ -22,7 +22,10 @@ See `.claude/.../memory/kubently-competitive-landscape.md` for the full competit
   relaxed to allow configmaps (secrets still blocked). Made `sseclient` optional / dropped
   dead `httpx` import so the executor is unit-testable. Tests:
   `tests/test_executor_enforcement.py` (2), `tests/test_dynamic_whitelist.py` (+1).
-- ⬜ #2 cloud-auth docs, #4 fan-out, mTLS — not started.
+- ✅ **#2 cloud-auth — DONE.** Added `executor.serviceAccount.annotations` passthrough to the
+  chart (`executor-serviceaccount.yaml` + values.yaml) so IRSA / GKE Workload Identity work
+  with zero code change. Docs: `docs/CLOUD_AUTH.md`. Verified via `helm template`.
+- ⬜ #4 fan-out, mTLS — not started (deferred/optional).
 
 ---
 

--- a/docs/RESUME_PUNCHLIST.md
+++ b/docs/RESUME_PUNCHLIST.md
@@ -25,6 +25,16 @@ See `.claude/.../memory/kubently-competitive-landscape.md` for the full competit
 - ✅ **#2 cloud-auth — DONE.** Added `executor.serviceAccount.annotations` passthrough to the
   chart (`executor-serviceaccount.yaml` + values.yaml) so IRSA / GKE Workload Identity work
   with zero code change. Docs: `docs/CLOUD_AUTH.md`. Verified via `helm template`.
+- ✅ **MCP auth — DONE.** `/mcp` now requires the same `X-API-Key` as A2A, via an explicit
+  ASGI wrapper (`add_api_key_auth` in `mcp/server.py`). Tests: `tests/test_mcp_auth.py` (3).
+  E2E-verified: no-key → 401, valid key → tools work, write verb → blocked.
+- 🔴 **SECURITY (pre-existing, NOT yet fixed): A2A auth bypass.** `/a2a/` `message/stream`
+  invokes the agent with NO api key. Root cause: A2A's auth uses Starlette `add_middleware`
+  on the sub-app before `mount()`, which doesn't run once mounted (lazy middleware stack) —
+  same failure mode found for MCP. Fix: wrap `a2a_app` with an explicit ASGI auth wrapper
+  (mirror `add_api_key_auth`) in `main.py` before `app.mount(mount_path, a2a_app)`, and drop
+  the ineffective `add_middleware` in `modules/a2a/__init__.py`. Verify: `POST /a2a/` without
+  key must 401.
 - ⬜ #4 fan-out, mTLS — not started (deferred/optional).
 
 ---

--- a/docs/RESUME_PUNCHLIST.md
+++ b/docs/RESUME_PUNCHLIST.md
@@ -1,0 +1,117 @@
+# Kubently — Resume Punch List
+
+Written 2026-06-29 after a competitive-landscape review. Strategic frame: Kubently's
+defensible niche is **free, OSS, vendor-neutral, multi-cluster K8s troubleshooting via
+outbound executors** — the one thing kagent (the strongest competitor) deliberately keeps
+out of open-source and paywalls behind Solo Enterprise. Lead with that. Treat A2A as a
+checkbox, not the headline.
+
+See `.claude/.../memory/kubently-competitive-landscape.md` for the full competitive read.
+
+---
+
+## Status (updated 2026-06-29)
+- ✅ **#1 MCP server — DONE.** `kubently/modules/mcp/{tools,server}.py`; mounted at `/mcp`
+  in `main.py` lifespan (conditional on `mcp` SDK). Tools: `list_clusters`,
+  `execute_kubectl`. Tests: `tests/test_mcp_tools.py` (3), `tests/test_mcp_server.py` (1).
+  `mcp>=1.2.0` added to the `a2a` extra. Note: full app-boot verification is blocked locally
+  by a pre-existing `a2a-sdk` version drift (`PushNotificationSender` import in
+  `modules/a2a/__init__.py`); verify the mount end-to-end via `./deploy-test.sh`.
+- ✅ **#3 Whitelist enforcement — DONE.** Wired `validate_command()` into
+  `sse_executor._run_kubectl`; whitelist loaded in `__init__`. Default READ_ONLY config
+  relaxed to allow configmaps (secrets still blocked). Made `sseclient` optional / dropped
+  dead `httpx` import so the executor is unit-testable. Tests:
+  `tests/test_executor_enforcement.py` (2), `tests/test_dynamic_whitelist.py` (+1).
+- ⬜ #2 cloud-auth docs, #4 fan-out, mTLS — not started.
+
+---
+
+## P0 — Sharpen the differentiator
+
+### 1. Expose Kubently as an MCP server
+**Why:** MCP won the agent tool-calling layer (~10k servers, ~97M monthly downloads). Today
+Kubently only speaks A2A. Exposing your *multi-cluster execution* as MCP tools makes the whole
+fleet callable from any MCP client (Claude Desktop, Cursor, other agents) — this amplifies the
+differentiator instead of competing with the ecosystem.
+**Scope (lazy):** thin adapter over the existing central API. The tool implementations already
+exist in `agent.py`; the MCP server just wraps `/debug/clusters` + `/debug/execute`.
+- Tools to expose: `list_clusters()`, `execute_kubectl(cluster_id, command)`, and optionally
+  `get_pod_logs` / `debug_resource` (reuse existing impls).
+- Use the official `mcp` Python SDK (FastMCP), streamable-HTTP transport.
+- Mount at `/mcp/` alongside the A2A mount at `/a2a/` in the FastAPI app, OR run as a sibling
+  process. Prefer mounting — fewer moving parts.
+**Files:** new `kubently/modules/mcp/server.py`; wire into `kubently/main.py`. Reuse tool logic
+from `kubently/modules/a2a/protocol_bindings/a2a_server/agent.py`.
+**Effort:** S–M. Mostly plumbing; no new business logic.
+**ponytail:** do NOT build a custom MCP framework. FastMCP + 3–4 tool wrappers. Done.
+
+### 2. Document the cloud-auth extensibility (IRSA / GKE Workload Identity)
+**Why:** This is a real strength and currently undocumented. The executor has zero cloud SDK
+code — it shells to `kubectl`, so AWS IRSA/assume-role and GKE Workload Identity work purely via
+ServiceAccount annotations on the executor pod. That's the vendor-neutral story done right.
+**Scope:** a docs page + Helm values examples showing the SA annotations for each cloud. No code
+change expected (verify the executor pod template lets you set SA + annotations via Helm).
+**Files:** new `docs/CLOUD_AUTH.md`; check `kubently/modules/executor/k8s-deployment.yaml` /
+Helm executor templates expose `serviceAccount.annotations`.
+**Effort:** S (mostly docs). Add a Helm passthrough for SA annotations if missing.
+
+---
+
+## P0 — Close the real security gap (small change, real payoff)
+
+### 3. Connect the existing whitelist enforcement to the execution path
+**Why:** The enforcement logic already exists and is real — `validate_command()` is fully
+implemented (`dynamic_whitelist.py:442`). It is simply **never called on the execution path**.
+Repo-wide there are ZERO call sites for `validate_command` (only its definition + a README line).
+`_run_kubectl` (`sse_executor.py:246`) runs `subprocess.run(["kubectl"] + args)` raw. The
+whitelist is loaded only in `_get_capabilities_payload()` (`sse_executor.py:297`), which calls
+`get_config_summary()` to *advertise* capabilities to `/executor/capabilities` — not to gate
+execution. So the lock is built but not installed on the door, which is the dangerous kind: it
+reads as protection in a security review.
+**Current real defense without it:** executor-SA RBAC (read-only, no secrets) + agent-side verb
+blocking in `validate_kubectl_command` (`agent.py:57`). Gap it closes: an API-key holder POSTing
+directly to `/debug/execute` bypasses the agent-side check — today only RBAC stops a write verb.
+Wiring the executor check makes it genuine three-layer defense.
+**Scope (small):** load the whitelist once in `SSEExecutor.__init__`, then in `_run_kubectl`:
+```python
+if WHITELIST_AVAILABLE:
+    ok, reason = self._whitelist.validate_command(args)
+    if not ok:
+        return {"success": False, "error": f"Blocked by whitelist: {reason}",
+                "status": "BLOCKED", "return_code": -1}
+```
+**Files:** `kubently/modules/executor/sse_executor.py` (call site + init). Logic already exists in
+`dynamic_whitelist.py` — no new validator needed. Add one unit test that a write verb returns
+`BLOCKED`.
+**Effort:** S. Also fix CLAUDE.md, which currently implies enforcement that doesn't happen.
+
+---
+
+## P2 — Optional, only if the use case is real
+
+### 4. Cross-cluster simultaneous fan-out
+**Why / honest scoping:** Multi-cluster targeting already works (one cluster per
+`execute_kubectl` call; agent issues sequential calls for several). What's missing is a single
+"broadcast to clusters [A,B,C] and aggregate" primitive. Only build this if "show me X across
+ALL clusters at once" is a real user workflow — for interactive debugging, sequential is usually
+fine.
+**Scope if built:** add `execute_kubectl_multi(cluster_ids: list, command)` that publishes to N
+channels concurrently and aggregates results by `command_id`. The Redis-per-cluster routing
+already supports it; it's an aggregation layer, not new transport.
+**Files:** `agent.py` (new tool), `main.py` (batch publish + result correlation).
+**Effort:** M.
+**ponytail:** skip until a user asks. YAGNI.
+
+---
+
+## Explicitly deferred (do NOT do yet)
+- **mTLS / per-executor cert identity.** The zero-trust norm (argocd-agent, OCM) but not worth it
+  for current scale/threat model. Redis bearer tokens are fine for now. Revisit if you target
+  security-sensitive enterprises.
+
+## Positioning / non-code
+- Update README + docs to lead with: *"free, self-hosted, vendor-neutral multi-cluster kubectl
+  troubleshooter that reaches clusters you can't (outbound-dial, no inbound ingress, no shared
+  kubeconfig)."* A2A becomes a feature bullet, not the pitch.
+- Watch kagent issues #417 / #1490 (multi-cluster, both closed not-planned) — if they reopen, the
+  competitive gap is closing.

--- a/docs/RESUME_PUNCHLIST.md
+++ b/docs/RESUME_PUNCHLIST.md
@@ -28,7 +28,7 @@ See `.claude/.../memory/kubently-competitive-landscape.md` for the full competit
 - ✅ **MCP auth — DONE.** `/mcp` now requires the same `X-API-Key` as A2A, via an explicit
   ASGI wrapper (`add_api_key_auth` in `mcp/server.py`). Tests: `tests/test_mcp_auth.py` (3).
   E2E-verified: no-key → 401, valid key → tools work, write verb → blocked.
-- 🔴 **SECURITY (pre-existing, NOT yet fixed): A2A auth bypass.** `/a2a/` `message/stream`
+- ✅ **SECURITY: A2A auth bypass — FIXED.** (was: /a2a/ ran the agent with no key.) `/a2a/` `message/stream`
   invokes the agent with NO api key. Root cause: A2A's auth uses Starlette `add_middleware`
   on the sub-app before `mount()`, which doesn't run once mounted (lazy middleware stack) —
   same failure mode found for MCP. Fix: wrap `a2a_app` with an explicit ASGI auth wrapper

--- a/docs/RESUME_PUNCHLIST.md
+++ b/docs/RESUME_PUNCHLIST.md
@@ -28,13 +28,12 @@ See `.claude/.../memory/kubently-competitive-landscape.md` for the full competit
 - ✅ **MCP auth — DONE.** `/mcp` now requires the same `X-API-Key` as A2A, via an explicit
   ASGI wrapper (`add_api_key_auth` in `mcp/server.py`). Tests: `tests/test_mcp_auth.py` (3).
   E2E-verified: no-key → 401, valid key → tools work, write verb → blocked.
-- ✅ **SECURITY: A2A auth bypass — FIXED.** (was: /a2a/ ran the agent with no key.) `/a2a/` `message/stream`
-  invokes the agent with NO api key. Root cause: A2A's auth uses Starlette `add_middleware`
-  on the sub-app before `mount()`, which doesn't run once mounted (lazy middleware stack) —
-  same failure mode found for MCP. Fix: wrap `a2a_app` with an explicit ASGI auth wrapper
-  (mirror `add_api_key_auth`) in `main.py` before `app.mount(mount_path, a2a_app)`, and drop
-  the ineffective `add_middleware` in `modules/a2a/__init__.py`. Verify: `POST /a2a/` without
-  key must 401.
+- ✅ **SECURITY: A2A auth bypass — FIXED.** Was: `/a2a/` `message/stream` ran the agent with
+  NO api key (root cause: A2A's Starlette `add_middleware` on the sub-app didn't run once
+  mounted — lazy middleware stack, same failure mode as MCP). Fix: wrap `a2a_app` with the
+  shared ASGI auth wrapper (`add_api_key_auth(..., public_well_known=True)`) at the mount in
+  `main.py`; removed the ineffective `add_middleware` in `modules/a2a/__init__.py`. E2E-verified:
+  agent card no-key → 200 (public), `message/stream` no-key/bad-key → 401, valid key → agent runs.
 - ⬜ #4 fan-out, mTLS — not started (deferred/optional).
 
 ---

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -147,8 +147,15 @@ async def lifespan(app: FastAPI):
     if a2a_server:
         # A2A module provides its own mount configuration (black box interface)
         mount_path, a2a_app = a2a_server.get_mount_config()
-        app.mount(mount_path, a2a_app)
-        logger.info(f"A2A server mounted at {mount_path} on main port {config.get('port', 8080)}")
+        # Enforce API-key auth at the mount via an explicit ASGI wrapper. The A2A SDK's
+        # own add_middleware() doesn't run once the app is mounted (lazy middleware stack),
+        # which left /a2a/ open — this wrapper always runs. The agent card stays public.
+        from kubently.modules.auth import AuthModule
+        from kubently.modules.mcp.server import add_api_key_auth
+
+        authed_a2a = add_api_key_auth(a2a_app, AuthModule(redis_client), public_well_known=True)
+        app.mount(mount_path, authed_a2a)
+        logger.info(f"A2A server mounted at {mount_path} (API-key auth enforced at mount)")
     else:
         logger.error("Failed to initialize A2A server - this is a critical failure")
         raise RuntimeError("A2A server initialization failed")

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -157,11 +157,14 @@ async def lifespan(app: FastAPI):
     # Exposes Kubently's multi-cluster troubleshooting as MCP tools for any MCP client.
     mcp_stack = None
     try:
-        from kubently.modules.mcp.server import build_mcp_server
+        from kubently.modules.auth import AuthModule
+        from kubently.modules.mcp.server import add_api_key_auth, build_mcp_server
 
         mcp_server = build_mcp_server()
         mcp_app = mcp_server.streamable_http_app()  # must run before accessing session_manager
-        app.mount("/mcp", mcp_app)
+        # Require the same API-key auth as the A2A endpoint (the CLI's X-API-Key).
+        authed_mcp = add_api_key_auth(mcp_app, AuthModule(redis_client))
+        app.mount("/mcp", authed_mcp)
         # Starlette doesn't run a mounted sub-app's lifespan, so start the MCP session
         # manager ourselves and keep it alive for the process lifetime.
         mcp_stack = AsyncExitStack()

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 import uuid
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import datetime, timezone
 from typing import AsyncGenerator, Optional, Tuple
 
@@ -153,6 +153,25 @@ async def lifespan(app: FastAPI):
         logger.error("Failed to initialize A2A server - this is a critical failure")
         raise RuntimeError("A2A server initialization failed")
 
+    # Mount MCP server (optional - only if the `mcp` SDK is installed).
+    # Exposes Kubently's multi-cluster troubleshooting as MCP tools for any MCP client.
+    mcp_stack = None
+    try:
+        from kubently.modules.mcp.server import build_mcp_server
+
+        mcp_server = build_mcp_server()
+        mcp_app = mcp_server.streamable_http_app()  # must run before accessing session_manager
+        app.mount("/mcp", mcp_app)
+        # Starlette doesn't run a mounted sub-app's lifespan, so start the MCP session
+        # manager ourselves and keep it alive for the process lifetime.
+        mcp_stack = AsyncExitStack()
+        await mcp_stack.enter_async_context(mcp_server.session_manager.run())
+        logger.info("MCP server mounted at /mcp")
+    except ImportError:
+        logger.info("mcp package not installed; MCP server not mounted")
+    except Exception as e:
+        logger.warning(f"Failed to mount MCP server: {e}")
+
     logger.info("Kubently API started successfully")
 
     yield
@@ -160,7 +179,8 @@ async def lifespan(app: FastAPI):
     # Shutdown
     logger.info("Shutting down Kubently API...")
 
-
+    if mcp_stack:
+        await mcp_stack.aclose()
     if redis_client:
         await redis_client.close()
     logger.info("Kubently API shutdown complete")

--- a/kubently/modules/a2a/__init__.py
+++ b/kubently/modules/a2a/__init__.py
@@ -144,31 +144,13 @@ class A2AModule:
 
             # Build and cache the FastAPI app
             self._app = a2a_app.build()
-            
-            # Add authentication middleware using the reusable middleware module
-            if self.redis_client:
-                from kubently.modules.auth import AuthModule
-                from kubently.modules.middleware import create_api_key_middleware
-                
-                # Create auth module and middleware
-                auth_module = AuthModule(self.redis_client)
-                auth_middleware = create_api_key_middleware(
-                    auth_module=auth_module,
-                    skip_paths={"/": ["GET"]},  # Skip auth for agent card endpoint
-                    error_format="jsonrpc"  # Use JSON-RPC error format for A2A
-                )
-                
-                # Register middleware with the app. A2AStarletteApplication.build()
-                # returns a Starlette app, which has no FastAPI-style @app.middleware
-                # decorator — use add_middleware(BaseHTTPMiddleware, dispatch=...),
-                # which works on both Starlette and FastAPI. auth_middleware's
-                # __call__(request, call_next) matches the dispatch signature.
-                from starlette.middleware.base import BaseHTTPMiddleware
-                self._app.add_middleware(BaseHTTPMiddleware, dispatch=auth_middleware)
 
-                logger.info("A2A sub-application created with authentication middleware")
-            else:
-                logger.warning("A2A app created without authentication (no Redis client)")
+            # NOTE: Auth is intentionally NOT added here. add_middleware() on this built
+            # sub-app does not reliably run once it is mounted under the main app (Starlette
+            # builds the middleware stack lazily), which previously left /a2a/ unauthenticated.
+            # API-key auth is enforced at the mount point in kubently/main.py via an explicit
+            # ASGI wrapper (add_api_key_auth). If A2A is ever run standalone via run_server(),
+            # wrap get_app() the same way there.
 
         return self._app
 

--- a/kubently/modules/executor/dynamic_whitelist.py
+++ b/kubently/modules/executor/dynamic_whitelist.py
@@ -115,7 +115,9 @@ class DynamicCommandWhitelist:
                 "events",
                 "version",
             },
-            "restrictedResources": {"secrets", "configmaps"},
+            # configmaps are allowed (RBAC permits them and they're core to troubleshooting);
+            # secrets stay restricted as defense-in-depth alongside RBAC.
+            "restrictedResources": {"secrets"},
             "allowedFlags": {
                 "--namespace",
                 "--all-namespaces",

--- a/kubently/modules/executor/sse_executor.py
+++ b/kubently/modules/executor/sse_executor.py
@@ -11,7 +11,6 @@ DynamicCommandWhitelist configuration to the central API, enabling
 capability-aware agent behavior.
 """
 
-import asyncio
 import json
 import logging
 import os
@@ -20,11 +19,16 @@ import sys
 import time
 from queue import Queue
 from threading import Thread
-from typing import Any, Dict, List, Optional
+from typing import Any
 
-import httpx
 import requests
-import sseclient
+
+# sseclient is only needed at runtime for the SSE stream; make it optional so the
+# command-execution logic stays importable (and unit-testable) without it.
+try:
+    import sseclient
+except ImportError:
+    sseclient = None
 
 # Optional import - DynamicCommandWhitelist may not be available in all deployments
 try:
@@ -71,6 +75,15 @@ class SSEKubentlyExecutor:
 
         # Track last heartbeat time
         self._last_heartbeat = 0
+
+        # Load the command whitelist for enforcement (defense-in-depth on top of RBAC).
+        # Always on when available; falls back to safe READ_ONLY defaults if no config file.
+        self._whitelist = None
+        if WHITELIST_AVAILABLE:
+            try:
+                self._whitelist = DynamicCommandWhitelist(config_path=self.whitelist_config_path)
+            except Exception as e:
+                logger.warning(f"Failed to load command whitelist ({e}); enforcement disabled")
 
         # Security validation: Warn if using HTTP in production
         if self.api_url.startswith("http://") and self.verify_ssl:
@@ -125,6 +138,9 @@ class SSEKubentlyExecutor:
         """
         Connect to SSE endpoint and listen for commands.
         """
+        if sseclient is None:
+            raise RuntimeError("sseclient is required to run the executor; install sseclient-py")
+
         url = f"{self.api_url}/executor/stream"
         logger.info(f"Connecting to SSE endpoint: {url}")
 
@@ -187,7 +203,7 @@ class SSEKubentlyExecutor:
             except Exception as e:
                 logger.error(f"Error processing command: {e}")
 
-    def _execute_command(self, command: Dict) -> None:
+    def _execute_command(self, command: dict) -> None:
         """
         Execute a command and send result back.
 
@@ -211,7 +227,7 @@ class SSEKubentlyExecutor:
         try:
             # Configure TLS verification
             verify_setting = self.ca_cert_path if self.ca_cert_path else self.verify_ssl
-            
+
             response = requests.post(
                 f"{self.api_url}/executor/results",
                 json=result,
@@ -226,7 +242,7 @@ class SSEKubentlyExecutor:
         except Exception as e:
             logger.error(f"Failed to submit result for {command_id}: {e}")
 
-    def _run_kubectl(self, args: List[str]) -> Dict:
+    def _run_kubectl(self, args: list[str]) -> dict:
         """
         Execute kubectl command.
 
@@ -236,6 +252,18 @@ class SSEKubentlyExecutor:
         Returns:
             Result dictionary with output and status
         """
+        # Enforce the whitelist before executing (defense-in-depth; RBAC is the backstop).
+        if self._whitelist is not None:
+            allowed, reason = self._whitelist.validate_command(args)
+            if not allowed:
+                logger.warning(f"Blocked by whitelist: {' '.join(args)} ({reason})")
+                return {
+                    "success": False,
+                    "error": f"Blocked by whitelist: {reason}",
+                    "status": "BLOCKED",
+                    "return_code": -1,
+                }
+
         try:
             # Prepend kubectl to args
             cmd = ["kubectl"] + args
@@ -284,18 +312,17 @@ class SSEKubentlyExecutor:
 
     # Capability Reporting Methods
 
-    def _get_capabilities_payload(self) -> Dict[str, Any]:
+    def _get_capabilities_payload(self) -> dict[str, Any]:
         """
         Gather capabilities from DynamicCommandWhitelist or use defaults.
 
         Returns:
             Dictionary with capability data for the API
         """
-        # Try to use DynamicCommandWhitelist if available
-        if WHITELIST_AVAILABLE:
+        # Reuse the whitelist loaded in __init__ (avoids a second config-watcher thread)
+        if self._whitelist is not None:
             try:
-                whitelist = DynamicCommandWhitelist(config_path=self.whitelist_config_path)
-                summary = whitelist.get_config_summary()
+                summary = self._whitelist.get_config_summary()
                 return {
                     "mode": summary.get("mode", "readOnly"),
                     "allowed_verbs": summary.get("allowed_verbs", []),

--- a/kubently/modules/mcp/__init__.py
+++ b/kubently/modules/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP server module — exposes Kubently's multi-cluster troubleshooting over MCP."""

--- a/kubently/modules/mcp/server.py
+++ b/kubently/modules/mcp/server.py
@@ -1,0 +1,51 @@
+"""
+FastMCP server exposing Kubently's multi-cluster troubleshooting over MCP.
+
+Any MCP client (Claude Desktop, Cursor, other agents) can connect and get tools to
+list clusters and run read-only kubectl against any registered cluster — the same
+fleet the A2A agent reaches. Read-only safety is enforced downstream by the executor
+whitelist + RBAC.
+
+This module imports the `mcp` SDK; callers should import it lazily so the API still
+boots when the SDK isn't installed (see kubently/main.py).
+"""
+
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+from kubently.modules.mcp import tools
+
+
+def _creds() -> tuple[str, str]:
+    """Resolve the internal API URL + key at call time (same pattern as the A2A agent)."""
+    from kubently.modules.auth import AuthModule
+
+    api_url = os.getenv("KUBENTLY_API_URL", "http://localhost:8080")
+    api_key = AuthModule.extract_first_api_key()
+    return api_url, api_key
+
+
+def build_mcp_server() -> FastMCP:
+    """Build the Kubently MCP server with its tools registered."""
+    mcp = FastMCP("kubently")
+
+    @mcp.tool()
+    async def list_clusters() -> list[str]:
+        """List the Kubernetes clusters currently available for troubleshooting."""
+        api_url, api_key = _creds()
+        return await tools.list_clusters(api_url, api_key)
+
+    @mcp.tool()
+    async def execute_kubectl(cluster_id: str, command: str, namespace: str = "default") -> str:
+        """Run a read-only kubectl command against a cluster.
+
+        Args:
+            cluster_id: Target cluster (use list_clusters to discover IDs).
+            command: kubectl command without the leading `kubectl`, e.g. "get pods -o wide".
+            namespace: Namespace to use when the command doesn't specify one.
+        """
+        api_url, api_key = _creds()
+        return await tools.execute_kubectl(api_url, api_key, cluster_id, command, namespace)
+
+    return mcp

--- a/kubently/modules/mcp/server.py
+++ b/kubently/modules/mcp/server.py
@@ -28,7 +28,9 @@ def _creds() -> tuple[str, str]:
 
 def build_mcp_server() -> FastMCP:
     """Build the Kubently MCP server with its tools registered."""
-    mcp = FastMCP("kubently")
+    # streamable_http_path="/" so that mounting the app at "/mcp" in main.py yields a clean
+    # "/mcp" endpoint (FastMCP's default internal path is "/mcp", which would give "/mcp/mcp").
+    mcp = FastMCP("kubently", streamable_http_path="/")
 
     @mcp.tool()
     async def list_clusters() -> list[str]:

--- a/kubently/modules/mcp/server.py
+++ b/kubently/modules/mcp/server.py
@@ -53,17 +53,38 @@ def build_mcp_server() -> FastMCP:
     return mcp
 
 
-def add_api_key_auth(app, auth_module):
+def add_api_key_auth(app, auth_module, public_well_known=False):
     """Wrap an ASGI app so it requires API-key auth — the same X-API-Key the CLI/A2A use.
 
     Returns a new ASGI app to MOUNT in place of `app`. This is a plain ASGI wrapper rather
-    than Starlette `add_middleware`, because middleware added to a sub-app after
-    `streamable_http_app()` doesn't reliably run once the sub-app is mounted (the middleware
-    stack is built lazily). The wrapper is the mounted app, so it always runs.
+    than Starlette `add_middleware`, because middleware added to a sub-app after it is built
+    doesn't reliably run once the sub-app is mounted (the middleware stack is built lazily).
+    The wrapper IS the mounted app, so it always runs — this is also the fix for the A2A
+    mount, which had the same latent bypass.
+
+    public_well_known=True leaves GET requests to a `/.well-known/...` path unauthenticated
+    (the A2A agent card, which must stay publicly discoverable). Mounted sub-apps see the
+    FULL path in scope["path"] with the mount prefix in scope["root_path"], so we compare
+    the path relative to root_path.
+
+    Note: generic ASGI helper that happens to live here; reused by main.py for both /mcp
+    and /a2a. Move to modules/middleware if a third caller appears.
     """
+
+    def _is_public(scope):
+        if not public_well_known or scope.get("method") != "GET":
+            return False
+        path = scope.get("path", "")
+        root = scope.get("root_path", "")
+        rel = path[len(root):] if root and path.startswith(root) else path
+        return rel.startswith("/.well-known/")
 
     async def asgi(scope, receive, send):
         if scope.get("type") != "http":
+            await app(scope, receive, send)
+            return
+
+        if _is_public(scope):
             await app(scope, receive, send)
             return
 

--- a/kubently/modules/mcp/server.py
+++ b/kubently/modules/mcp/server.py
@@ -51,3 +51,36 @@ def build_mcp_server() -> FastMCP:
         return await tools.execute_kubectl(api_url, api_key, cluster_id, command, namespace)
 
     return mcp
+
+
+def add_api_key_auth(app, auth_module):
+    """Wrap an ASGI app so it requires API-key auth — the same X-API-Key the CLI/A2A use.
+
+    Returns a new ASGI app to MOUNT in place of `app`. This is a plain ASGI wrapper rather
+    than Starlette `add_middleware`, because middleware added to a sub-app after
+    `streamable_http_app()` doesn't reliably run once the sub-app is mounted (the middleware
+    stack is built lazily). The wrapper is the mounted app, so it always runs.
+    """
+
+    async def asgi(scope, receive, send):
+        if scope.get("type") != "http":
+            await app(scope, receive, send)
+            return
+
+        headers = {k.decode("latin-1").lower(): v.decode("latin-1") for k, v in scope.get("headers", [])}
+        api_key = headers.get("x-api-key")
+        valid = False
+        if api_key:
+            valid, _ = await auth_module.verify_api_key(api_key)
+
+        if not valid:
+            from starlette.responses import JSONResponse
+
+            await JSONResponse({"error": "Unauthorized: valid X-API-Key required"}, status_code=401)(
+                scope, receive, send
+            )
+            return
+
+        await app(scope, receive, send)
+
+    return asgi

--- a/kubently/modules/mcp/tools.py
+++ b/kubently/modules/mcp/tools.py
@@ -1,0 +1,61 @@
+"""
+MCP tool adapters for Kubently.
+
+Thin async wrappers over the central API (the same endpoints the A2A agent uses).
+Keeping these free of the `mcp` SDK import makes them unit-testable and lets the
+API boot even when the SDK isn't installed.
+
+Read-only safety is enforced downstream by the executor whitelist + RBAC, so these
+adapters stay deliberately thin.
+"""
+
+
+import httpx
+
+_TIMEOUT = 30.0
+
+
+async def list_clusters(api_url: str, api_key: str) -> list[str]:
+    """Return the IDs of clusters currently available for troubleshooting."""
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        response = await client.get(
+            f"{api_url}/debug/clusters",
+            headers={"X-Api-Key": api_key},
+        )
+        if response.status_code != 200:
+            return []
+        return response.json().get("clusters", [])
+
+
+async def execute_kubectl(
+    api_url: str,
+    api_key: str,
+    cluster_id: str,
+    command: str,
+    namespace: str = "default",
+) -> str:
+    """Run a kubectl command against a cluster and return its output.
+
+    `command` is the kubectl command without the leading `kubectl` (e.g. "get pods").
+    """
+    parts = command.split()
+    if not parts:
+        return "Error: empty command"
+    verb, args = parts[0], parts[1:]
+
+    payload = {
+        "cluster_id": cluster_id,
+        "command_type": verb,
+        "args": args,
+        "namespace": namespace,
+        "timeout_seconds": 30,
+    }
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        response = await client.post(
+            f"{api_url}/debug/execute",
+            headers={"X-Api-Key": api_key},
+            json=payload,
+        )
+        if response.status_code != 200:
+            return f"Error: HTTP {response.status_code}: {response.text}"
+        return response.json().get("output", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ a2a = [
     
     # Optional MCP support
     "langchain-mcp-adapters>=0.1.0",
+    "mcp>=1.2.0",  # serve Kubently as an MCP server (FastMCP + streamable-http)
     
     # Async support
     "aiohttp>=3.9.0",

--- a/tests/test_dynamic_whitelist.py
+++ b/tests/test_dynamic_whitelist.py
@@ -151,6 +151,22 @@ class TestDynamicCommandWhitelist:
         assert is_valid is False
         assert "restricted" in reason
 
+    def test_default_readonly_allows_configmaps_blocks_secrets(self):
+        """Default READ_ONLY config should permit configmap reads but still block secrets.
+
+        Configmaps are bread-and-butter for troubleshooting and are allowed by the
+        executor's RBAC, so the whitelist default must not regress them when enforcement
+        is turned on. Secrets stay restricted.
+        """
+        whitelist = DynamicCommandWhitelist(config_path="/nonexistent/path")
+
+        ok_cm, _ = whitelist.validate_command(["get", "configmaps"])
+        ok_secret, reason = whitelist.validate_command(["get", "secrets"])
+
+        assert ok_cm is True
+        assert ok_secret is False
+        assert "restricted" in reason
+
     def test_security_modes(self):
         """Test different security modes have correct defaults."""
         # Test READ_ONLY mode

--- a/tests/test_executor_enforcement.py
+++ b/tests/test_executor_enforcement.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Tests for executor-side command whitelist enforcement.
+
+These verify that SSEKubentlyExecutor._run_kubectl actually gates commands
+through the DynamicCommandWhitelist before shelling out to kubectl — closing
+the bypass where a direct POST to /debug/execute would otherwise run a write
+verb (RBAC remains the ultimate backstop; this is defense-in-depth).
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.executor.sse_executor import SSEKubentlyExecutor
+
+
+@pytest.fixture
+def executor(monkeypatch):
+    """A real executor instance with required env vars set."""
+    monkeypatch.setenv("KUBENTLY_API_URL", "http://localhost:8080")
+    monkeypatch.setenv("CLUSTER_ID", "test-cluster")
+    monkeypatch.setenv("KUBENTLY_TOKEN", "test-token")
+    # Force default whitelist (file absent -> safe READ_ONLY defaults)
+    monkeypatch.setenv("KUBENTLY_WHITELIST_CONFIG", "/nonexistent/whitelist.yaml")
+    return SSEKubentlyExecutor()
+
+
+def test_run_kubectl_blocks_write_verb(executor, monkeypatch):
+    """A write verb must be blocked before kubectl is ever invoked."""
+    ran = {"called": False}
+
+    def fake_run(*args, **kwargs):
+        ran["called"] = True
+        raise AssertionError("subprocess.run should not be called for a blocked command")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = executor._run_kubectl(["delete", "pod", "foo"])
+
+    assert result["status"] == "BLOCKED"
+    assert result["success"] is False
+    assert ran["called"] is False
+
+
+def test_run_kubectl_allows_read_verb(executor, monkeypatch):
+    """A normal read command still runs kubectl."""
+
+    class FakeProc:
+        stdout = "pod/foo"
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: FakeProc())
+
+    result = executor._run_kubectl(["get", "pods"])
+
+    assert result["status"] == "SUCCESS"
+    assert result["success"] is True

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -49,3 +49,28 @@ def test_mcp_accepts_valid_api_key():
     r = _wrapped_client().post("/", headers={"X-API-Key": "good-key"}, json={})
     assert r.status_code == 200
     assert r.text == "REACHED"
+
+
+def _mounted_card_client():
+    """Mount the wrapper UNDER a prefix (like /a2a) so the test exercises the real
+    root_path behavior — mounted sub-apps see the full path, not the stripped one."""
+    from fastapi import FastAPI
+
+    async def downstream(scope, receive, send):
+        await PlainTextResponse("REACHED")(scope, receive, send)
+
+    parent = FastAPI()
+    parent.mount("/a2a", add_api_key_auth(downstream, FakeAuthModule(), public_well_known=True))
+    return TestClient(parent)
+
+
+def test_well_known_card_is_public_even_when_mounted_under_prefix():
+    r = _mounted_card_client().get("/a2a/.well-known/agent.json")
+    assert r.status_code == 200
+    assert r.text == "REACHED"
+
+
+def test_protected_path_still_requires_key_when_well_known_public():
+    # a POST to the RPC root is not public even with public_well_known enabled
+    r = _mounted_card_client().post("/a2a/", json={})
+    assert r.status_code == 401

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+The MCP endpoint must require the same API-key auth as the A2A endpoint the CLI uses.
+Tests the ASGI auth wrapper directly: no key -> 401 (downstream never reached);
+valid key -> downstream reached. Skipped when the `mcp` SDK isn't installed.
+"""
+
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("mcp")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+from kubently.modules.mcp.server import add_api_key_auth
+
+
+class FakeAuthModule:
+    async def verify_api_key(self, api_key):
+        if api_key == "good-key":
+            return True, "tester"
+        return False, None
+
+
+def _wrapped_client():
+    async def downstream(scope, receive, send):
+        await PlainTextResponse("REACHED")(scope, receive, send)
+
+    return TestClient(add_api_key_auth(downstream, FakeAuthModule()))
+
+
+def test_mcp_rejects_missing_api_key():
+    r = _wrapped_client().post("/", json={"jsonrpc": "2.0", "method": "ping", "id": 1})
+    assert r.status_code == 401
+    assert "REACHED" not in r.text
+
+
+def test_mcp_rejects_invalid_api_key():
+    r = _wrapped_client().post("/", headers={"X-API-Key": "wrong"}, json={})
+    assert r.status_code == 401
+
+
+def test_mcp_accepts_valid_api_key():
+    r = _wrapped_client().post("/", headers={"X-API-Key": "good-key"}, json={})
+    assert r.status_code == 200
+    assert r.text == "REACHED"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+Light wiring test for the FastMCP server. Skipped when the `mcp` SDK isn't installed
+(it lives in the optional `a2a` extra), so the core unit suite stays green everywhere.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("mcp")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_build_mcp_server_registers_expected_tools(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "test:abc123")
+    from kubently.modules.mcp.server import build_mcp_server
+
+    server = build_mcp_server()
+    server.streamable_http_app()  # session manager / tool manager initialized here
+
+    names = sorted(tool.name for tool in asyncio.run(server.list_tools()))
+    assert names == ["execute_kubectl", "list_clusters"]

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Tests for the MCP server tool adapters (kubently.modules.mcp.tools).
+
+These adapters expose Kubently's multi-cluster troubleshooting over MCP by calling
+the same central API endpoints the A2A agent uses (/debug/clusters, /debug/execute).
+The logic under test is the request shape and response parsing; HTTP is faked.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.mcp import tools
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+class FakeAsyncClient:
+    """Minimal async-context httpx.AsyncClient stand-in that records calls."""
+
+    def __init__(self, get_response=None, post_response=None, recorder=None):
+        self._get_response = get_response
+        self._post_response = post_response
+        self._rec = recorder if recorder is not None else {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, headers=None):
+        self._rec["get_url"] = url
+        self._rec["get_headers"] = headers
+        return self._get_response
+
+    async def post(self, url, headers=None, json=None):
+        self._rec["post_url"] = url
+        self._rec["post_headers"] = headers
+        self._rec["post_json"] = json
+        return self._post_response
+
+
+@pytest.mark.asyncio
+async def test_list_clusters_returns_ids(monkeypatch):
+    rec = {}
+    monkeypatch.setattr(
+        tools.httpx,
+        "AsyncClient",
+        lambda *a, **k: FakeAsyncClient(
+            get_response=FakeResponse(200, {"clusters": ["prod", "staging"]}), recorder=rec
+        ),
+    )
+
+    result = await tools.list_clusters("http://api:8080", "key123")
+
+    assert result == ["prod", "staging"]
+    assert rec["get_url"] == "http://api:8080/debug/clusters"
+    assert rec["get_headers"]["X-Api-Key"] == "key123"
+
+
+@pytest.mark.asyncio
+async def test_execute_kubectl_posts_verb_and_args(monkeypatch):
+    rec = {}
+    monkeypatch.setattr(
+        tools.httpx,
+        "AsyncClient",
+        lambda *a, **k: FakeAsyncClient(
+            post_response=FakeResponse(200, {"output": "pod/foo Running"}), recorder=rec
+        ),
+    )
+
+    result = await tools.execute_kubectl(
+        "http://api:8080", "key123", "prod", "get pods", namespace="kube-system"
+    )
+
+    assert result == "pod/foo Running"
+    assert rec["post_url"] == "http://api:8080/debug/execute"
+    body = rec["post_json"]
+    assert body["cluster_id"] == "prod"
+    assert body["command_type"] == "get"
+    assert body["args"] == ["pods"]
+    assert body["namespace"] == "kube-system"
+
+
+@pytest.mark.asyncio
+async def test_execute_kubectl_surfaces_http_error(monkeypatch):
+    monkeypatch.setattr(
+        tools.httpx,
+        "AsyncClient",
+        lambda *a, **k: FakeAsyncClient(post_response=FakeResponse(404, {"detail": "no cluster"})),
+    )
+
+    result = await tools.execute_kubectl("http://api:8080", "key123", "ghost", "get pods")
+
+    assert "404" in result

--- a/uv.lock
+++ b/uv.lock
@@ -1105,6 +1105,7 @@ a2a = [
     { name = "langgraph" },
     { name = "langgraph-checkpoint-redis" },
     { name = "langsmith" },
+    { name = "mcp" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -1163,6 +1164,7 @@ requires-dist = [
     { name = "langgraph", marker = "extra == 'a2a'", specifier = ">=1.0,<2" },
     { name = "langgraph-checkpoint-redis", marker = "extra == 'a2a'", specifier = ">=0.5.0" },
     { name = "langsmith", marker = "extra == 'a2a'", specifier = ">=0.1.0" },
+    { name = "mcp", marker = "extra == 'a2a'", specifier = ">=1.2.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27.0" },
@@ -2047,7 +2049,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Adds an MCP server interface, wires executor-side command whitelist enforcement, and adds cloud IAM support for executors. Also makes API-key auth consistently enforced across the mounted A2A and MCP sub-apps.

## Changes

### MCP server (`/mcp`)
- Exposes Kubently's multi-cluster troubleshooting over the MCP streamable-HTTP transport, so any MCP client (Claude Desktop, Cursor, other agents) can list clusters and run read-only `kubectl` against any registered cluster.
- Tools: `list_clusters`, `execute_kubectl` — thin adapters over the existing central API (`/debug/clusters`, `/debug/execute`), the same path the A2A agent uses.
- Mounted at a clean `/mcp` path; conditional on the `mcp` SDK so the API still boots without it.
- `mcp>=1.2.0` added to the `a2a` extra.

### Executor command whitelist enforcement
- `validate_command()` is now actually called on the execution path in `sse_executor._run_kubectl` (previously the whitelist was only used to *advertise* capabilities, never to gate execution). Write verbs are rejected at the executor edge as defense-in-depth on top of RBAC.
- Default READ_ONLY config relaxed to allow `configmaps` (still blocks `secrets`), matching what executor RBAC permits — no troubleshooting regression.
- Made `sseclient` optional and dropped a dead `httpx` import so the executor's command logic is unit-testable.

### Cloud authentication for executors
- Added `executor.serviceAccount.annotations` passthrough to the Helm chart so AWS IRSA and GKE Workload Identity work with zero code changes (the executor shells to `kubectl` and inherits pod credentials).
- New docs: `docs/CLOUD_AUTH.md`.

### Auth on mounted sub-apps
- API-key auth (`X-API-Key`, same as the CLI) is enforced on both the `/mcp` and `/a2a` mounts via an explicit ASGI wrapper. The A2A agent card stays publicly discoverable.

## Testing
- 151 unit tests pass (new: MCP tools/server/auth, executor enforcement, whitelist default).
- Full kind e2e: healthz, executor registration, agent LLM round-trip through the executor.
- MCP e2e over the real protocol: no-key rejected, valid key lists clusters + runs read commands, write verbs blocked.
- A2A verified: agent card public, `message/stream` requires a valid `X-API-Key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)