### PR TITLE
docs: document MCP server support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [Unreleased] - 2026-06-30
+
+### Added
+- **MCP Server Documentation**
+  - New `docs/MCP.md` connect guide covering the MCP (Model Context Protocol) server:
+    streamable-HTTP endpoint at `/mcp`, `X-API-Key` authentication, auto-enablement
+    via the `a2a` extra, the two exposed tools (`list_clusters`, `execute_kubectl`),
+    and client configuration examples (generic streamable-HTTP, Claude Desktop/Cursor)
+  - Surfaced MCP as a supported connection method in `README.md` (alongside A2A) and
+    added it to the `docs/INDEX.md` documentation index
+  - Expanded the MCP mention in `docs/AGENTGATEWAY_SETUP.md` into a short section
+    linking to `docs/MCP.md`
+
+### Fixed
+- **Stale MCP Tool References**
+  - Corrected outdated MCP tool names in `docs/SYSTEM_DESIGN.md` and
+    `docs/ARCHITECTURE.md` (removed `create_debug_session`, `get_command_result`,
+    `close_session`, and the old `execute_kubectl` signature) to reflect the real
+    tools: `list_clusters()` and `execute_kubectl(cluster_id, command, namespace)`,
+    plus the correct `/mcp` streamable-HTTP + `X-API-Key` facts and a link to `MCP.md`
+
 ## [Unreleased] - 2025-12-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Kubently (*Kubernetes + Agentically*) enables AI agents to troubleshoot Kubernet
 
 - **Multi-LLM Support**: Compatible with Google Gemini, OpenAI, Anthropic, and other providers
 - **A2A Protocol**: Industry-standard agent-to-agent communication for complex workflows
+- **MCP Server**: Optional [Model Context Protocol](docs/MCP.md) endpoint so MCP clients (Claude Desktop, Cursor, custom agents) get direct tool access
 - **Natural Language Interface**: Conversational Kubernetes troubleshooting and debugging
 - **Comprehensive Analysis**: Automated issue detection, root cause analysis, and solution recommendations
 - **Security-First**: API key authentication, OAuth/OIDC support, and TLS with cert-manager
@@ -122,6 +123,7 @@ helm install kubently deployment/helm -f deployment/helm/test-values.yaml
 ### Usage & Operations
 - **[CLI Admin Guide](docs/GETTING_STARTED.md#step-5-register-and-deploy-executors)** - Managing clusters and executors
 - **[Test Queries](docs/TEST_QUERIES.md)** - Example API requests and A2A protocol usage
+- **[MCP Connect Guide](docs/MCP.md)** - Connect MCP clients (Claude Desktop, Cursor, custom agents)
 - **[Environment Variables](docs/ENVIRONMENT_VARIABLES.md)** - Configuration reference
 
 ### Architecture & Development

--- a/docs/AGENTGATEWAY_SETUP.md
+++ b/docs/AGENTGATEWAY_SETUP.md
@@ -11,6 +11,12 @@ This guide covers deploying [kgateway/agentgateway](https://kgateway.dev/docs/ag
 - **Traffic Management**: Load balancing, retries, timeouts for agent traffic
 - **Security**: Centralized authentication, TLS termination, CORS handling
 
+Kubently also exposes an optional **MCP (Model Context Protocol) server** over
+streamable HTTP at `/mcp`, alongside the A2A endpoint at `/a2a/`. Agentgateway can
+route MCP traffic to this endpoint just as it does A2A traffic — the same
+`X-API-Key` authentication applies. For the tools exposed, client configuration,
+and authentication details, see the [MCP Connect Guide](MCP.md).
+
 ### Architecture
 
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -279,28 +279,31 @@ Executor: 100MB-256MB RAM, 0.1 CPU
 
 ### Multi-Agent System (MAS) Integration
 
-Kubently exposes MCP-compatible tools for agent-to-agent communication:
+Kubently exposes an MCP (Model Context Protocol) server over streamable HTTP at
+`/mcp`, authenticated with the `X-API-Key` header. It exposes the following tools
+for agent-to-agent communication:
 
 ```python
-# MCP Tool Registration
+# MCP Tools (streamable HTTP at /mcp, X-API-Key auth)
 tools = [
     {
-        "name": "create_debug_session",
-        "parameters": {
-            "cluster_id": "string",
-            "correlation_id": "string"
-        }
+        "name": "list_clusters",
+        "parameters": {},
+        "returns": "list[str]"  # available cluster IDs
     },
     {
         "name": "execute_kubectl",
         "parameters": {
-            "session_id": "string",
-            "command": "string",
-            "timeout": "integer"
-        }
+            "cluster_id": "string",
+            "command": "string",     # kubectl command without leading 'kubectl'
+            "namespace": "string"    # default: "default"
+        },
+        "returns": "string"
     }
 ]
 ```
+
+See [MCP.md](MCP.md) for the full connect guide.
 
 ### A2A Communication Pattern
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@
 #### Operational Guides
 - **[DEPLOYMENT.md](DEPLOYMENT.md)** - Production deployment, configuration, and operations
 - **[API.md](API.md)** - Complete API reference with endpoints and examples
+- **[MCP.md](MCP.md)** - MCP (Model Context Protocol) server connect guide
 - **[DEVELOPMENT.md](DEVELOPMENT.md)** - Developer guide, testing, and contribution guidelines
 
 ### Module Specifications

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,166 @@
+# MCP (Model Context Protocol) Connect Guide
+
+## Overview
+
+Kubently runs an optional **MCP (Model Context Protocol) server** so that any MCP
+client — Claude Desktop, Cursor, or your own custom agents — gets the same
+read-only, multi-cluster Kubernetes troubleshooting that the A2A agent has.
+
+Where the [A2A interface](A2A_CONFIGURATION.md) is a full conversational agent you
+talk to in natural language, the MCP server exposes a small set of **tools** that
+an MCP client drives directly. Both interfaces share the same authentication,
+session, and queue infrastructure, so connecting over MCP gives your client
+direct access to Kubently's cluster tooling without a separate deployment.
+
+## Endpoint & Transport
+
+| Property | Value |
+|----------|-------|
+| Endpoint | `https://<your-kubently-host>/mcp` |
+| Transport | Streamable HTTP (FastMCP) |
+
+The MCP server is served over **streamable HTTP** and is mounted at `/mcp` on the
+main Kubently API port (the same port that serves the REST API and `/a2a/`).
+
+For local development, this is typically `http://localhost:8080/mcp` after a
+port-forward:
+
+```bash
+kubectl port-forward -n kubently svc/kubently-api 8080:8080
+```
+
+## Authentication
+
+All MCP requests **must** include the `X-API-Key` header:
+
+```
+X-API-Key: <your-api-key>
+```
+
+- The key is the **same API key** used by the Kubently CLI and the A2A protocol —
+  i.e. a key from the `API_KEYS` environment variable.
+- Requests without a valid key receive an HTTP `401` response:
+
+  ```json
+  {"error": "Unauthorized: valid X-API-Key required"}
+  ```
+
+See the [Secret Management](../CLAUDE.md#secret-management-best-practices) section
+for how API keys are provisioned (`API_KEYS` / the `kubently-api-keys` secret).
+
+## Enabling It
+
+There is **no separate enable flag or environment variable** for the MCP server.
+It is auto-mounted at API startup whenever the `mcp` Python SDK is installed,
+which ships as part of the `a2a` extra.
+
+On a successful mount, the API logs:
+
+```
+MCP server mounted at /mcp
+```
+
+If the SDK is not installed, the API logs the following and continues without the
+MCP endpoint:
+
+```
+mcp package not installed; MCP server not mounted
+```
+
+> **Internal wiring**: the MCP tools call the Kubently API internally using the
+> URL in `KUBENTLY_API_URL` (default `http://localhost:8080`). You normally do not
+> need to set this.
+
+## Tools
+
+The MCP server exposes exactly two tools:
+
+| Tool | Signature | Description |
+|------|-----------|-------------|
+| `list_clusters` | `list_clusters() -> list[str]` | Returns the IDs of the clusters currently available for troubleshooting. Adapter over `GET /debug/clusters`. |
+| `execute_kubectl` | `execute_kubectl(cluster_id: str, command: str, namespace: str = "default") -> str` | Runs a read-only kubectl command against the given cluster and returns its output. Adapter over `POST /debug/execute`. |
+
+### `command` format
+
+For `execute_kubectl`, the `command` argument is the kubectl command **without** the
+leading `kubectl`. The first word is the verb/command type and the rest are
+arguments. For example:
+
+```
+get pods -o wide
+```
+
+### Read-only safety
+
+Read-only safety is **not** enforced in the MCP layer. The MCP tools do not
+validate or filter commands. Read-only behavior is enforced **downstream** by the
+executor command whitelist and Kubernetes RBAC on the target cluster. Treat the
+MCP layer as a transport/adapter, not a policy boundary.
+
+## Connecting a Client
+
+> **Caveat**: MCP remote-HTTP client config formats vary between clients and
+> change over time. The examples below use the common `mcpServers` streamable-HTTP
+> shape, but you should check your client's current documentation for the exact
+> remote-server config syntax it expects.
+
+### Generic streamable-HTTP MCP client
+
+A typical streamable-HTTP MCP client configuration looks like this:
+
+```json
+{
+  "mcpServers": {
+    "kubently": {
+      "type": "streamable-http",
+      "url": "https://<your-kubently-host>/mcp",
+      "headers": {
+        "X-API-Key": "<your-api-key>"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop / Cursor
+
+Claude Desktop and Cursor read an `mcpServers` block (in their respective settings
+/ `mcp.json` files). The same shape applies:
+
+```json
+{
+  "mcpServers": {
+    "kubently": {
+      "type": "streamable-http",
+      "url": "https://kubently.your-domain.com/mcp",
+      "headers": {
+        "X-API-Key": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+After saving the config, restart the client and confirm that the `list_clusters`
+and `execute_kubectl` tools appear in its tool list.
+
+## Relationship to A2A
+
+Kubently offers two ways for AI clients to connect, both backed by the same
+auth/session/queue infrastructure:
+
+| Interface | Endpoint | What it is |
+|-----------|----------|------------|
+| **A2A** | `/a2a/` | A full agent you talk to in natural language; it plans and runs the kubectl tooling itself and streams responses over SSE. |
+| **MCP** | `/mcp` | A set of tools (`list_clusters`, `execute_kubectl`) that any MCP client drives directly — the calling client does the reasoning. |
+
+Use A2A when you want Kubently to do the reasoning and troubleshooting
+conversationally. Use MCP when you have your own agent or client that wants direct
+tool access to clusters.
+
+## References
+
+- [A2A Configuration Guide](A2A_CONFIGURATION.md) - The conversational agent interface
+- [Agentgateway Setup](AGENTGATEWAY_SETUP.md) - Running a gateway in front of Kubently
+- [Model Context Protocol](https://modelcontextprotocol.io/) - Official MCP specification
+- [Kubently Documentation](../README.md)

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -385,11 +385,13 @@ Each module must adhere to these interface principles:
 ## A2A Integration Patterns
 
 ### MCP Tool Exposure
-When integrated via MCP (Model Context Protocol), Kubently exposes the following tools:
-- `create_debug_session(cluster_id, correlation_id)`
-- `execute_kubectl(session_id, command, timeout)`
-- `get_command_result(result_id)`
-- `close_session(session_id)`
+When integrated via MCP (Model Context Protocol), Kubently exposes its MCP server
+over streamable HTTP at `/mcp` (authenticated with the `X-API-Key` header). It
+exposes the following tools:
+- `list_clusters() -> list[str]`
+- `execute_kubectl(cluster_id, command, namespace="default") -> str`
+
+See [MCP.md](MCP.md) for the full connect guide.
 
 ### Request/Response Headers
 For A2A communication, include:

--- a/docs/superpowers/plans/2026-06-30-mcp-docs-and-site-redesign.md
+++ b/docs/superpowers/plans/2026-06-30-mcp-docs-and-site-redesign.md
@@ -1,0 +1,183 @@
+# MCP Docs + kubently.io Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document Kubently's MCP server as a first-class connection method, and redesign kubently.io into a committed "Terminal Noir" dark theme.
+
+**Architecture:** Two independent streams. Stream 1 edits markdown docs in the `kubently` repo. Stream 2 rebuilds the Jekyll theme in the `kubently-site` repo (minima removed, custom dark CSS/layouts). No application code changes.
+
+**Tech Stack:** Markdown; Jekyll 4 + GitHub Pages, SCSS, vanilla JS (typewriter), Rouge (dark syntax theme), Ruby 3.3.0.
+
+**Verified facts (do not re-derive):**
+- MCP endpoint: `/mcp`, **streamable HTTP** transport (FastMCP, `streamable_http_path="/"`).
+- Auth: `X-API-Key` header (same key as CLI/A2A). 401 without a valid key.
+- Enablement: auto-mounted at startup **when the `mcp` SDK is installed** (the `a2a` extra). No env flag. Logs `MCP server mounted at /mcp`.
+- Tools: `list_clusters() -> list[str]`; `execute_kubectl(cluster_id, command, namespace="default") -> str` (command = kubectl without the leading `kubectl`, e.g. `get pods -o wide`).
+- Internal wiring: adapters call `/debug/clusters` and `/debug/execute`; `KUBENTLY_API_URL` sets the internal API URL.
+
+**Repo paths:**
+- Stream 1: `/Users/adickinson/repos/kubently/.claude/worktrees/sleepy-ishizaka-d20640`
+- Stream 2: `/Users/adickinson/repos/kubently-site`
+
+---
+
+## File Structure
+
+**Stream 1 (docs, `kubently`):**
+- Create: `docs/MCP.md` — the MCP connect guide (single source of truth for MCP usage).
+- Modify: `docs/SYSTEM_DESIGN.md`, `docs/ARCHITECTURE.md`, `docs/AGENTGATEWAY_SETUP.md`, `docs/INDEX.md`, `README.md`, `CHANGELOG.md`.
+
+**Stream 2 (site, `kubently-site`):**
+- `assets/css/style.scss` — full custom dark stylesheet (no minima).
+- `assets/css/syntax-dark.scss` *(new)* — dark Rouge highlight theme.
+- `_layouts/default.html`, `_layouts/home.html`, `_layouts/page.html`.
+- `_includes/head.html`, `header.html`, `footer.html`, `navigation.html`.
+- `index.md` — rebuilt hero + sections incl. A2A/MCP connect block.
+- `assets/js/main.js` — typewriter content + reveal + flow animation toggles.
+- `_config.yml` — drop `theme: minima`.
+
+---
+
+# STREAM 1 — MCP DOCUMENTATION
+
+### Task 1: Verify MCP facts against source
+
+**Files:** Read-only — `kubently/modules/mcp/server.py`, `kubently/modules/mcp/tools.py`, `kubently/main.py` (mount region ~L150-195), `pyproject.toml`/`requirements*` (confirm the `a2a` extra pulls `mcp`).
+
+- [ ] **Step 1:** Confirm tool names/signatures, the `/mcp` mount, `X-API-Key` enforcement, and the "SDK installed → mounted" behavior still match the Verified facts above. If anything differs, correct the facts block and any dependent task before writing prose.
+
+### Task 2: Write `docs/MCP.md`
+
+**Files:** Create `docs/MCP.md`.
+
+- [ ] **Step 1:** Write the guide with these sections:
+  - **Overview** — Kubently runs an optional MCP server so any MCP client (Claude Desktop, Cursor, custom agents) gets the same read-only multi-cluster troubleshooting the A2A agent has.
+  - **Endpoint & transport** — streamable HTTP at `https://<your-kubently-host>/mcp`.
+  - **Authentication** — `X-API-Key: <key>` header; 401 otherwise; same keys as `API_KEYS` / the CLI.
+  - **Enabling it** — present whenever the `mcp` SDK is installed (the `a2a` extra); startup log line `MCP server mounted at /mcp`; no separate flag.
+  - **Tools** — table: `list_clusters()` → cluster IDs; `execute_kubectl(cluster_id, command, namespace="default")` → command output; note read-only enforcement (executor whitelist + RBAC) and the `command` format.
+  - **Connect a client** — a generic streamable-HTTP MCP client config (URL + `X-API-Key` header) and a Claude Desktop / Cursor example. *(Verify the exact client config shape before finalizing; if a remote-HTTP header config isn't supported by a given client, say so and show the supported path.)*
+  - **Relationship to A2A** — both share auth/session/queue; A2A = full agent over `/a2a/`, MCP = tools for any MCP client over `/mcp`.
+- [ ] **Step 2 (verify):** `grep -n "create_debug_session\|get_command_result\|close_session" docs/MCP.md` → expect **no matches** (no stale tool names). Confirm `list_clusters` and `execute_kubectl` both appear.
+
+### Task 3: Fix stale MCP tool names in design docs
+
+**Files:** Modify `docs/SYSTEM_DESIGN.md` ("MCP Tool Exposure"), `docs/ARCHITECTURE.md` ("Multi-Agent System (MAS) Integration").
+
+- [ ] **Step 1:** Replace stale tool names (`create_debug_session`, `execute_kubectl`(old sig), `get_command_result`, `close_session`) with the real `list_clusters` / `execute_kubectl(cluster_id, command, namespace)` and the `/mcp` streamable-HTTP + `X-API-Key` facts. Link to `MCP.md` for detail.
+- [ ] **Step 2 (verify):** `grep -rn "create_debug_session\|get_command_result\|close_session" docs/` → expect **no matches**.
+
+### Task 4: Surface MCP in entry-point docs
+
+**Files:** Modify `docs/AGENTGATEWAY_SETUP.md`, `docs/INDEX.md`, `README.md`.
+
+- [ ] **Step 1:** `AGENTGATEWAY_SETUP.md` — expand the one-line MCP mention into a short paragraph linking to `MCP.md`.
+- [ ] **Step 2:** `INDEX.md` — add `MCP.md` to the documentation index.
+- [ ] **Step 3:** `README.md` — in the connect/usage area, add MCP next to A2A as a supported way to connect, linking to `docs/MCP.md`.
+- [ ] **Step 4 (verify):** `grep -rln "MCP.md" docs/INDEX.md README.md docs/AGENTGATEWAY_SETUP.md` → all three present.
+
+### Task 5: Changelog + commit (Stream 1)
+
+**Files:** Modify `CHANGELOG.md`.
+
+- [ ] **Step 1:** Add an entry: MCP server documented (`docs/MCP.md`); stale MCP tool names corrected; MCP surfaced in README/INDEX.
+- [ ] **Step 2 (commit — only when the user approves committing):**
+  ```bash
+  cd /Users/adickinson/repos/kubently/.claude/worktrees/sleepy-ishizaka-d20640
+  gcmwm "docs: document MCP server and fix stale MCP tool references"
+  ```
+
+---
+
+# STREAM 2 — kubently.io REDESIGN (Terminal Noir)
+
+> Build order: foundation (tokens + shell) → homepage sections → inner-page theme → verify.
+> Verification is **build + visual**, not unit tests: run `bundle exec jekyll serve` and
+> screenshot. Commit after each task group.
+
+**Design tokens (use as SCSS/CSS variables):** bg `#0a0c10`, bg-deep `#070a0e`, surface `#0d1117`, surface-2 `#15191f`, border `#1b222b`, border-2 `#2c333d`, text `#e6edf3`, text-muted `#8b97a5`, accent `#2dd4bf`, accent-2 `#22d3ee`, ok `#56d364`, warn `#e3b341`. Fonts: Inter (UI), JetBrains Mono (mono).
+
+### Task 6: Branch + strip minima foundation
+
+**Files:** `_config.yml`, `assets/css/style.scss`, `_layouts/default.html`, `_includes/head.html`.
+
+- [ ] **Step 1:** From `~/repos/kubently-site`, create a branch: `git checkout -b redesign-terminal-noir`.
+- [ ] **Step 2:** `style.scss` — remove `@import "minima";`. Add `:root` design tokens above + a base reset, `body` (dark bg, Inter, `color-scheme: dark`), link/selection styles, and a `prefers-reduced-motion` block that disables animations.
+- [ ] **Step 3:** `_config.yml` — remove/neutralize `theme: minima` (keep plugins, nav, seo). 
+- [ ] **Step 4:** `_layouts/default.html` — own the full HTML shell: `<!DOCTYPE html>`, `{% include head.html %}`, `{% include header.html %}`, `<main>{{ content }}</main>`, `{% include footer.html %}`, scripts. (Previously inherited from minima.)
+- [ ] **Step 5:** `_includes/head.html` — meta, SEO tag, fonts preconnect + Inter/JetBrains Mono, `style.scss` link, favicon/logo, theme-color `#0a0c10`.
+- [ ] **Step 6 (verify):** `cd ~/repos/kubently-site && bundle exec jekyll build 2>&1 | tail -5` → builds with **no minima errors**. `grep -rn "minima" _config.yml assets/css/style.scss` → no active import.
+- [ ] **Step 7 (commit):** `git add -A && git commit -m "redesign: strip minima, add dark foundation + custom shell"`
+
+### Task 7: Header, footer, nav (dark)
+
+**Files:** `_includes/header.html`, `footer.html`, `navigation.html`, `style.scss`.
+
+- [ ] **Step 1:** `header.html` — sticky dark header: logo (existing `kubently.svg`/cropped logo), nav links from `_config.yml` `navigation`, a GitHub button. Mobile hamburger (CSS/JS toggle).
+- [ ] **Step 2:** `navigation.html` — render `site.navigation` incl. the Guides children as a dropdown.
+- [ ] **Step 3:** `footer.html` — dark footer: tagline, GitHub/docs links, license note.
+- [ ] **Step 4:** `style.scss` — component styles for header (blur, border-bottom, sticky), nav hover/active, dropdown, footer, mobile menu.
+- [ ] **Step 5 (verify):** serve locally; header sticky + nav dropdown + mobile menu work; footer dark. Screenshot.
+- [ ] **Step 6 (commit):** `git commit -am "redesign: dark header, nav, footer"`
+
+### Task 8: Homepage hero (live terminal)
+
+**Files:** `index.md`, `style.scss`, `assets/js/main.js`.
+
+- [ ] **Step 1:** `index.md` hero block — two columns: left = mono kicker (`// Kubernetes, agentically`), headline "Debug clusters by **talking to them**", subtitle (mentions A2A **and** MCP), CTAs (Get started / GitHub), shield badges; right = terminal window (chrome dots + title + `#typewriter` body).
+- [ ] **Step 2:** `style.scss` — hero layout/grid, one soft radial accent glow behind hero (replaces the 3 aurora orbs), terminal window styling, blinking cursor, responsive single-column < 640px.
+- [ ] **Step 3:** `main.js` — set the typewriter script lines to a realistic Kubently troubleshooting session (the prod-EU CrashLoopBackOff → missing secret root-cause flow from the mockup); keep existing reveal-on-scroll.
+- [ ] **Step 4 (verify):** serve; typewriter animates; reduced-motion shows static final text; mobile collapses cleanly. Screenshot hero.
+- [ ] **Step 5 (commit):** `git commit -am "redesign: terminal-noir hero with live debug terminal"`
+
+### Task 9: Connect section (A2A + MCP) — the MCP story
+
+**Files:** `index.md`, `style.scss`.
+
+- [ ] **Step 1:** `index.md` — "Speaks your agent's language" section, two cards:
+  - **A2A** — full agent over `/a2a/`; tiny `curl` snippet (message/stream) + `X-API-Key`.
+  - **MCP** — tools for any MCP client over `/mcp` (streamable HTTP, `X-API-Key`); tiny client-config snippet; "New" tag; link to docs `MCP.md`.
+- [ ] **Step 2:** `style.scss` — two-card grid, code-snippet styling (mono, surface bg, accent prompt), card hover, "New" badge.
+- [ ] **Step 3 (verify):** serve; both cards render with readable snippets; mobile stacks. Screenshot.
+- [ ] **Step 4 (commit):** `git commit -am "redesign: A2A + MCP connect section"`
+
+### Task 10: "How it works" animated flow + features + use cases
+
+**Files:** `index.md`, `style.scss`.
+
+- [ ] **Step 1:** `index.md` — "How it works": `Agent → Kubently API → Executor → Cluster` flow with animated packets and captions (SSE / read-only / multi-cluster). Reuse the mockup's flow markup.
+- [ ] **Step 2:** `index.md` — Features grid (real-time SSE, read-only/RBAC, multi-LLM, simple deploy, autoscale, flexible integration) and Use cases (intelligent troubleshooting / multi-agent / enterprise) — replace emoji with inline-SVG line icons in accent color.
+- [ ] **Step 3:** `style.scss` — flow nodes/arrows + packet keyframes (reduced-motion safe), feature/use-case card grid, icon sizing.
+- [ ] **Step 4 (verify):** serve; flow animates; cards align on desktop + mobile. Screenshot full homepage.
+- [ ] **Step 5 (commit):** `git commit -am "redesign: how-it-works flow, features, use cases"`
+
+### Task 11: Inner-page (docs) theme + dark syntax highlighting
+
+**Files:** `_layouts/page.html`, `assets/css/syntax-dark.scss` (new), `style.scss`, `_includes/head.html`.
+
+- [ ] **Step 1:** Generate/author a dark Rouge theme into `assets/css/syntax-dark.scss` (e.g. `bundle exec rougify style monokai.sublime > assets/css/syntax-dark.css` then adapt, or hand-write tokens to match palette). Link it from `head.html`.
+- [ ] **Step 2:** `_layouts/page.html` — long-form dark layout: constrained measure (~72ch), page title header, optional in-page TOC, `.page-content` prose.
+- [ ] **Step 3:** `style.scss` — `.page-content` typography for dark: headings, paragraphs, lists, links, blockquotes, **tables**, inline code, fenced code blocks (surface bg + border), images. Ensure WCAG-AA contrast.
+- [ ] **Step 4 (verify):** serve and open **each** inner page — `/installation/`, `/guides/`, `/api/`, `/architecture/`, `/contributing/` — confirm readable dark long-form and **styled** code blocks (no unstyled white blocks). Screenshot `/api/` (code-heavy) and `/architecture/`.
+- [ ] **Step 5 (commit):** `git commit -am "redesign: dark docs/page theme + syntax highlighting"`
+
+### Task 12: Cross-cutting polish + full verification
+
+**Files:** `style.scss`, any page as needed.
+
+- [ ] **Step 1:** Focus-visible states on all interactive elements; scrollbar styling; 404 page if present; check `og:image`/SEO still set.
+- [ ] **Step 2 (verify — build):** `bundle exec jekyll build 2>&1 | tail -5` → clean build, no warnings about missing minima includes/classes. `grep -rn "minima" _layouts _includes assets _config.yml` → no active references.
+- [ ] **Step 3 (verify — visual):** Playwright/screenshot pass over homepage + all 5 inner pages at desktop (1280) and mobile (390) widths; confirm no layout breaks, no unstyled regions, contrast OK.
+- [ ] **Step 4 (commit):** `git commit -am "redesign: polish, a11y, final verification"`
+
+### Task 13: Hand off site for review
+
+- [ ] **Step 1:** Summarize screenshots + the branch; do **not** push or open a PR until the user asks. Confirm whether the typewriter/flow copy and the MCP snippet are accurate before any deploy to `kubently.io`.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Stream 1 tasks 2-5 cover every doc in the spec table (`MCP.md`, SYSTEM_DESIGN, ARCHITECTURE, AGENTGATEWAY_SETUP, README, INDEX, CHANGELOG; CLAUDE.md note is optional/low-priority and intentionally dropped to stay lazy). Stream 2 tasks 6-12 cover all spec files (style.scss, syntax theme, all layouts/includes, index.md, main.js, _config.yml) and both risks (minima base reset → Task 6/11; Rouge CSS → Task 11). Dark-only (no light toggle) honored.
+- **Verification fit:** A redesign has no meaningful unit tests; gates are `jekyll build` + per-page screenshots, which is the correct check for this work.
+- **Commits:** gated on user approval per the user's "commit only when asked" rule.

--- a/docs/superpowers/specs/2026-06-30-mcp-docs-and-site-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-30-mcp-docs-and-site-redesign-design.md
@@ -1,0 +1,138 @@
+# MCP Docs Update + kubently.io Site Redesign — Design
+
+**Date:** 2026-06-30
+**Status:** Awaiting review
+
+## Overview
+
+Two related deliverables:
+
+1. **Docs (this repo, `kubently/`)** — update documentation to reflect the now-shipped
+   **MCP server** so MCP is a documented, first-class way to connect to Kubently
+   (alongside the A2A protocol).
+2. **Site redesign (`~/repos/kubently-site/`)** — redesign kubently.io from a templated
+   docs-site look into a committed **"Terminal Noir"** dark aesthetic that signals a serious
+   project, and surface MCP in the connect story.
+
+These are independent and can ship separately.
+
+---
+
+## Stream 1 — MCP Documentation (repo: `kubently`)
+
+### What MCP actually is (verified facts to document)
+
+- Implemented at `kubently/modules/mcp/server.py` + `kubently/modules/mcp/tools.py`,
+  mounted in `kubently/main.py` at `/mcp`.
+- Built on **FastMCP** (official Python MCP SDK). Conditionally mounted only when the MCP
+  SDK is installed (via the `a2a` extra).
+- **Auth:** same `X-API-Key` header as the CLI / A2A, enforced by the shared
+  `add_api_key_auth()` ASGI wrapper. 401 without a valid key.
+- **Tools exposed:** `list_clusters()` and
+  `execute_kubectl(cluster_id, command, namespace="default")` — thin adapters over the
+  existing `/debug/clusters` and `/debug/execute` endpoints. Read-only enforced downstream
+  by executor whitelist + Kubernetes RBAC.
+
+> Implementation details above are from exploration and **will be re-verified against the
+> source before any doc text is written** (exact tool names, signatures, enable flag).
+
+### Changes
+
+| File | Change |
+|------|--------|
+| `docs/MCP.md` *(new)* | Dedicated MCP guide: what it is, `/mcp` endpoint, X-API-Key auth, the two tools, and copy-paste connect configs for Claude Desktop / Cursor / generic MCP clients. |
+| `docs/SYSTEM_DESIGN.md` | Fix the "MCP Tool Exposure" section — replace stale tool names (`create_debug_session`, `get_command_result`, `close_session`) with the real `list_clusters` / `execute_kubectl`. |
+| `docs/ARCHITECTURE.md` | Refresh "Multi-Agent System (MAS) Integration" MCP signatures to match. |
+| `docs/AGENTGATEWAY_SETUP.md` | Expand the one-line MCP mention into a real reference (link to `MCP.md`). |
+| `README.md` | Add MCP alongside A2A as a connection method; link to `docs/MCP.md`. |
+| `docs/INDEX.md` | Add `MCP.md` to the index. |
+| `CHANGELOG.md` | Record the MCP server + docs (project rule: maintain changelog). |
+| `CLAUDE.md` | Short note on how to run/test the MCP server (optional, low priority). |
+
+### Out of scope (Stream 1)
+
+- No changes to MCP implementation code — docs only.
+
+---
+
+## Stream 2 — Site Redesign (repo: `kubently-site`)
+
+### Decisions locked
+
+- **Direction:** Terminal Noir — dark, monospace-accented; the live debug session is the hero.
+- **Scope:** Full theme — homepage **and** all inner pages (installation, guides, api,
+  architecture, contributing) restyled to match.
+- **Toolchain:** Keep **Jekyll + GitHub Pages** (deploy via `.github/workflows/jekyll.yml`
+  already works; content stays in markdown). **Drop `@import "minima"`** and own the
+  layouts + CSS fully — minima is the root cause of the current "templated" feel.
+
+### Art direction
+
+- **Palette (dark-first):** page `#0a0c10` / deepest `#070a0e`; surfaces `#0d1117`,
+  `#15191f`; borders `#1b222b`, `#2c333d`; text `#e6edf3`, muted `#8b97a5`; primary accent
+  **teal/mint `#2dd4bf`**, secondary cyan `#22d3ee`. Teal matches the existing logo, so
+  branding stays coherent. Status colors for terminal: green `#56d364`, amber `#e3b341`.
+- **Type:** Inter (UI) + JetBrains Mono (terminal, code, kicker labels) — both already loaded.
+- **Motion (subtle, all respect `prefers-reduced-motion`):** typewriter terminal (reuse
+  existing `main.js`), blinking cursor, animated packets along the architecture flow,
+  reveal-on-scroll (already present), one soft radial glow behind the hero (replaces the
+  three floating aurora orbs, which read as generic).
+- **Icons:** replace emoji feature icons with a consistent inline-SVG line-icon set in the
+  accent color.
+
+### Homepage structure
+
+1. Sticky dark header — logo, nav, GitHub button.
+2. **Hero** — left: kicker + headline ("Debug clusters by talking to them") + subtitle +
+   CTAs + badges; right: live typewriter **terminal** running a real troubleshooting session.
+3. **Connect section ("Speaks your agent's language")** — two cards, **A2A** and **MCP**,
+   each with a tiny code snippet (A2A: curl to `/a2a/`; MCP: client config JSON for `/mcp`).
+   This is where MCP gets first-class billing on the site.
+4. **How it works** — the animated `Agent → Kubently API → Executor → Cluster` flow with
+   SSE / read-only / multi-cluster captions (the element borrowed from direction C).
+5. **Features** grid — line icons: real-time SSE, read-only/RBAC, multi-LLM, simple deploy,
+   autoscale, flexible integration.
+6. **Use cases** — intelligent troubleshooting / multi-agent systems / enterprise-ready.
+7. **Quick start** — short terminal code block (install + first run).
+8. CTA band + footer.
+
+### Files to own (replacing minima)
+
+| File | Change |
+|------|--------|
+| `assets/css/style.scss` | Remove `@import "minima"`; write the full dark stylesheet (base reset, typography, layout, components, long-form `.page-content` prose, responsive, reduced-motion). The big one. |
+| `_layouts/default.html` | Full HTML shell — no longer inherits minima's default. |
+| `_includes/head.html`, `header.html`, `footer.html`, `navigation.html` | Rewrite for the dark theme + nav from `_config.yml`. |
+| `_layouts/home.html`, `_layouts/page.html` | Restyle; `page` gets readable dark long-form layout for the markdown docs. |
+| `index.md` | Rebuild hero + sections per structure above; add the Connect (A2A + MCP) section. |
+| `assets/css/` syntax theme | Add a **dark Rouge** highlight theme (minima previously supplied highlight CSS; dropping it means code blocks lose styling otherwise). |
+| `_config.yml` | Minor: ensure `theme:` no longer points at minima if that breaks the build; keep nav. |
+
+### Edge cases / risks
+
+- Dropping minima removes its base CSS reset and the classes markdown pages rely on →
+  the new stylesheet must provide a complete typographic base for `.page-content`.
+- Rouge syntax-highlight CSS must be replaced or code blocks render unstyled.
+- Inner doc pages are long-form; dark long-form needs deliberate contrast + line-length
+  limits to stay readable.
+
+### Out of scope (Stream 2)
+
+- **Light-mode toggle** — ship dark-only. *(ponytail: skipped; add a toggle later if asked.)*
+- No content rewrites of the doc pages themselves beyond what the MCP story needs.
+- No toolchain migration (staying on Jekyll).
+
+---
+
+## Verification
+
+- **Docs:** re-read MCP source before writing; confirm tool names/signatures/auth/enable
+  flag match the prose.
+- **Site:** build locally with `bundle exec jekyll serve` (Ruby 3.3.0 per `.tool-versions`);
+  confirm homepage + each inner page render with no minima references and no unstyled code
+  blocks; screenshot key pages (Playwright) to confirm the look.
+
+## Commit / delivery
+
+- Each repo committed separately. The site repo follows the user's normal git flow; nothing
+  is committed or pushed until the user asks.


### PR DESCRIPTION
## What

Documents Kubently's MCP (Model Context Protocol) server as a first-class way to connect — alongside the A2A protocol — and corrects stale MCP references in the design docs.

## Changes

- **New `docs/MCP.md`** — connect guide: `/mcp` streamable-HTTP endpoint, `X-API-Key` auth, auto-enablement (when the `mcp` SDK from the `a2a` extra is installed), the two tools (`list_clusters`, `execute_kubectl`), client config examples (with a caveat that remote-HTTP MCP config varies by client), and an A2A-vs-MCP comparison.
- **`SYSTEM_DESIGN.md` / `ARCHITECTURE.md`** — replaced stale tool names (`create_debug_session`, `get_command_result`, `close_session`, old `execute_kubectl` signature) with the real `list_clusters` / `execute_kubectl(cluster_id, command, namespace)` + `/mcp` + `X-API-Key` facts.
- **`README.md` / `INDEX.md` / `AGENTGATEWAY_SETUP.md`** — surface MCP next to A2A and link to `docs/MCP.md`.
- **`CHANGELOG.md`** — entry recording the above.
- Plus the design spec + implementation plan under `docs/superpowers/`.

## Verification

Every MCP fact was checked against the source (`kubently/modules/mcp/server.py`, `tools.py`, and the `/mcp` mount in `kubently/main.py`): endpoint, transport, auth, enablement, tool signatures, and the "read-only enforced downstream (not in the MCP layer)" note. No application code changed — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)