### PR TITLE
MCP: expose single ask_kubently NL tool instead of raw kubectl; drop flaky gcc build step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased] - 2026-06-30
 
+### Changed
+- **MCP Server: single natural-language tool instead of raw kubectl**
+  - Replaced the two granular MCP tools (`list_clusters`, `execute_kubectl`) with a
+    single `ask_kubently(query, cluster_id?, conversation_id?)` tool that routes the
+    question through Kubently's own `KubentlyAgent` and returns
+    `{"answer": <markdown>, "thread_id": <id>}`. MCP now mirrors the A2A surface over
+    MCP transport — Kubently does the reasoning — rather than letting the caller's LLM
+    drive kubectl directly (which bypassed Kubently's troubleshooting loop)
+  - `build_mcp_server(redis_client)` now constructs and reuses one agent instance,
+    sharing the same Redis-backed conversation memory as A2A; `conversation_id` maps to
+    the agent's `thread_id`. The MCP tool stream is drained to the final answer
+  - Removed the HTTP adapter layer in `kubently/modules/mcp/tools.py` (the agent talks
+    to the queue/session modules directly); updated `docs/MCP.md` and tests accordingly
+
+### Fixed
+- **API Docker build: removed flaky apt/gcc step**
+  - Deleted the `apt-get update && apt-get install gcc` layer from
+    `deployment/docker/api/Dockerfile`. All dependencies (including the `a2a` extra)
+    install from prebuilt wheels on linux/amd64 and linux/arm64, so no build toolchain
+    is needed. This removes a network round-trip to the Debian mirrors that was
+    intermittently failing the build with `apt-get` exit code 100, and speeds the build
+    up. (Executor image is unchanged — it's Alpine/musl, where compilation is still needed.)
+- **MCP endpoint trailing slash documented**
+  - `docs/MCP.md` now specifies the endpoint as `/mcp/` (with trailing slash, same as
+    `/a2a/`); a bare `/mcp` returns a `307` redirect that some HTTP clients mishandle.
+
 ### Added
 - **MCP Server Documentation**
   - New `docs/MCP.md` connect guide covering the MCP (Model Context Protocol) server:

--- a/deployment/docker/api/Dockerfile
+++ b/deployment/docker/api/Dockerfile
@@ -6,10 +6,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 ENV UV_SYSTEM_PYTHON=1
 ENV UV_COMPILE_BYTECODE=1
 
-# Install build dependencies for compiled packages
-RUN apt-get update && apt-get install -y \
-    gcc \
-    && rm -rf /var/lib/apt/lists/*
+# No build toolchain needed: all deps (incl. the a2a extra) install from prebuilt
+# wheels on linux/amd64 and linux/arm64. If a future dep needs compilation, add back:
+#   RUN apt-get update && apt-get install -y gcc && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /app

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -3,26 +3,33 @@
 ## Overview
 
 Kubently runs an optional **MCP (Model Context Protocol) server** so that any MCP
-client — Claude Desktop, Cursor, or your own custom agents — gets the same
-read-only, multi-cluster Kubernetes troubleshooting that the A2A agent has.
+client — Claude Desktop, Cursor, or your own custom agents — can delegate
+Kubernetes troubleshooting to Kubently's agent.
 
-Where the [A2A interface](A2A_CONFIGURATION.md) is a full conversational agent you
-talk to in natural language, the MCP server exposes a small set of **tools** that
-an MCP client drives directly. Both interfaces share the same authentication,
-session, and queue infrastructure, so connecting over MCP gives your client
-direct access to Kubently's cluster tooling without a separate deployment.
+The MCP server exposes a **single natural-language tool**, `ask_kubently`. The
+calling agent passes a question (e.g. "why are pods crashlooping in payments?") and
+Kubently's own troubleshooting agent investigates across the registered clusters —
+running read-only kubectl as needed — and returns a synthesized answer. This mirrors
+the [A2A interface](A2A_CONFIGURATION.md) over MCP transport: in both, **Kubently does
+the reasoning**. The MCP server does *not* expose raw kubectl for the caller's LLM to
+drive — that would bypass Kubently's troubleshooting loop, which is the whole value.
+Both interfaces share the same authentication, session, and queue infrastructure.
 
 ## Endpoint & Transport
 
 | Property | Value |
 |----------|-------|
-| Endpoint | `https://<your-kubently-host>/mcp` |
+| Endpoint | `https://<your-kubently-host>/mcp/` |
 | Transport | Streamable HTTP (FastMCP) |
 
-The MCP server is served over **streamable HTTP** and is mounted at `/mcp` on the
+The MCP server is served over **streamable HTTP** and is mounted at `/mcp/` on the
 main Kubently API port (the same port that serves the REST API and `/a2a/`).
 
-For local development, this is typically `http://localhost:8080/mcp` after a
+> **Trailing slash required.** Use `/mcp/`, not `/mcp` — same as `/a2a/`. A request to
+> the bare `/mcp` returns an HTTP `307` redirect to `/mcp/`; most MCP clients follow it,
+> but some HTTP clients drop the body/method on redirect, so always point at `/mcp/`.
+
+For local development, this is typically `http://localhost:8080/mcp/` after a
 port-forward:
 
 ```bash
@@ -67,35 +74,33 @@ MCP endpoint:
 mcp package not installed; MCP server not mounted
 ```
 
-> **Internal wiring**: the MCP tools call the Kubently API internally using the
-> URL in `KUBENTLY_API_URL` (default `http://localhost:8080`). You normally do not
-> need to set this.
+> **Internal wiring**: the MCP server runs the same `KubentlyAgent` the A2A interface
+> uses, in-process, sharing the same Redis-backed memory and queue. There is no extra
+> configuration to wire up.
 
 ## Tools
 
-The MCP server exposes exactly two tools:
+The MCP server exposes exactly one tool:
 
 | Tool | Signature | Description |
 |------|-----------|-------------|
-| `list_clusters` | `list_clusters() -> list[str]` | Returns the IDs of the clusters currently available for troubleshooting. Adapter over `GET /debug/clusters`. |
-| `execute_kubectl` | `execute_kubectl(cluster_id: str, command: str, namespace: str = "default") -> str` | Runs a read-only kubectl command against the given cluster and returns its output. Adapter over `POST /debug/execute`. |
+| `ask_kubently` | `ask_kubently(query: str, cluster_id: str = None, conversation_id: str = None) -> dict` | Routes a natural-language question through Kubently's troubleshooting agent and returns `{"answer": <markdown>, "thread_id": <id>}`. |
 
-### `command` format
+### Parameters
 
-For `execute_kubectl`, the `command` argument is the kubectl command **without** the
-leading `kubectl`. The first word is the verb/command type and the rest are
-arguments. For example:
-
-```
-get pods -o wide
-```
+- **`query`** (required): the question or problem in plain language, e.g.
+  `"why are pods crashlooping in the payments namespace on prod?"`.
+- **`cluster_id`** (optional): target cluster id. Omit to let Kubently choose or ask;
+  if you don't know the id, just name the cluster in `query`.
+- **`conversation_id`** (optional): pass the `thread_id` from a previous response to
+  continue the same troubleshooting thread (memory is preserved). Omit to start fresh —
+  a new `thread_id` is generated and returned.
 
 ### Read-only safety
 
-Read-only safety is **not** enforced in the MCP layer. The MCP tools do not
-validate or filter commands. Read-only behavior is enforced **downstream** by the
-executor command whitelist and Kubernetes RBAC on the target cluster. Treat the
-MCP layer as a transport/adapter, not a policy boundary.
+Read-only safety is enforced **downstream** by the executor command whitelist and
+Kubernetes RBAC on the target cluster — the same enforcement the A2A agent relies on.
+The agent only ever runs read-only kubectl.
 
 ## Connecting a Client
 
@@ -113,7 +118,7 @@ A typical streamable-HTTP MCP client configuration looks like this:
   "mcpServers": {
     "kubently": {
       "type": "streamable-http",
-      "url": "https://<your-kubently-host>/mcp",
+      "url": "https://<your-kubently-host>/mcp/",
       "headers": {
         "X-API-Key": "<your-api-key>"
       }
@@ -132,7 +137,7 @@ Claude Desktop and Cursor read an `mcpServers` block (in their respective settin
   "mcpServers": {
     "kubently": {
       "type": "streamable-http",
-      "url": "https://kubently.your-domain.com/mcp",
+      "url": "https://kubently.your-domain.com/mcp/",
       "headers": {
         "X-API-Key": "your-api-key"
       }
@@ -141,22 +146,21 @@ Claude Desktop and Cursor read an `mcpServers` block (in their respective settin
 }
 ```
 
-After saving the config, restart the client and confirm that the `list_clusters`
-and `execute_kubectl` tools appear in its tool list.
+After saving the config, restart the client and confirm that the `ask_kubently`
+tool appears in its tool list.
 
 ## Relationship to A2A
 
-Kubently offers two ways for AI clients to connect, both backed by the same
-auth/session/queue infrastructure:
+Kubently offers two ways for AI clients to connect, both backed by the same agent and
+the same auth/session/queue infrastructure — **Kubently does the reasoning in both**:
 
 | Interface | Endpoint | What it is |
 |-----------|----------|------------|
-| **A2A** | `/a2a/` | A full agent you talk to in natural language; it plans and runs the kubectl tooling itself and streams responses over SSE. |
-| **MCP** | `/mcp` | A set of tools (`list_clusters`, `execute_kubectl`) that any MCP client drives directly — the calling client does the reasoning. |
+| **A2A** | `/a2a/` | The agent over Google's A2A protocol; streams responses over SSE. Use when the client speaks A2A. |
+| **MCP** | `/mcp` | The same agent behind a single `ask_kubently` tool; request/response. Use when the client speaks MCP. |
 
-Use A2A when you want Kubently to do the reasoning and troubleshooting
-conversationally. Use MCP when you have your own agent or client that wants direct
-tool access to clusters.
+Pick whichever protocol your client already speaks. Neither exposes raw kubectl to the
+caller — for direct cluster primitives, use the REST API (`/debug/execute`) instead.
 
 ## References
 

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -161,13 +161,13 @@ async def lifespan(app: FastAPI):
         raise RuntimeError("A2A server initialization failed")
 
     # Mount MCP server (optional - only if the `mcp` SDK is installed).
-    # Exposes Kubently's multi-cluster troubleshooting as MCP tools for any MCP client.
+    # Exposes Kubently's troubleshooting agent as a single natural-language MCP tool.
     mcp_stack = None
     try:
         from kubently.modules.auth import AuthModule
         from kubently.modules.mcp.server import add_api_key_auth, build_mcp_server
 
-        mcp_server = build_mcp_server()
+        mcp_server = build_mcp_server(redis_client=redis_client)
         mcp_app = mcp_server.streamable_http_app()  # must run before accessing session_manager
         # Require the same API-key auth as the A2A endpoint (the CLI's X-API-Key).
         authed_mcp = add_api_key_auth(mcp_app, AuthModule(redis_client))

--- a/kubently/modules/mcp/server.py
+++ b/kubently/modules/mcp/server.py
@@ -1,54 +1,62 @@
 """
-FastMCP server exposing Kubently's multi-cluster troubleshooting over MCP.
+FastMCP server exposing Kubently's troubleshooting agent over MCP.
 
-Any MCP client (Claude Desktop, Cursor, other agents) can connect and get tools to
-list clusters and run read-only kubectl against any registered cluster — the same
-fleet the A2A agent reaches. Read-only safety is enforced downstream by the executor
-whitelist + RBAC.
+Any MCP client (Claude Desktop, Cursor, other agents) connects and gets ONE
+natural-language tool: ask Kubently a question and its troubleshooting agent answers,
+investigating across the registered fleet on the caller's behalf. This mirrors the A2A
+surface over MCP transport rather than exposing raw kubectl, so Kubently's reasoning loop
+stays in the loop instead of the caller's LLM driving kubectl directly. Read-only safety
+is enforced downstream by the executor whitelist + RBAC.
 
 This module imports the `mcp` SDK; callers should import it lazily so the API still
 boots when the SDK isn't installed (see kubently/main.py).
 """
-
-import os
 
 from mcp.server.fastmcp import FastMCP
 
 from kubently.modules.mcp import tools
 
 
-def _creds() -> tuple[str, str]:
-    """Resolve the internal API URL + key at call time (same pattern as the A2A agent)."""
-    from kubently.modules.auth import AuthModule
+def build_mcp_server(redis_client=None) -> FastMCP:
+    """Build the Kubently MCP server with its single ask tool registered.
 
-    api_url = os.getenv("KUBENTLY_API_URL", "http://localhost:8080")
-    api_key = AuthModule.extract_first_api_key()
-    return api_url, api_key
+    `redis_client` is passed to the agent for conversation memory (same wiring as A2A).
+    One agent instance is reused across calls; `KubentlyAgent.run()` initializes lazily.
+    """
+    # Lazy import: the agent pulls in langchain/langgraph, which the API boots without
+    # when the optional `a2a` extra isn't installed.
+    from kubently.modules.a2a.protocol_bindings.a2a_server.agent import KubentlyAgent
 
+    agent = KubentlyAgent(redis_client=redis_client)
 
-def build_mcp_server() -> FastMCP:
-    """Build the Kubently MCP server with its tools registered."""
     # streamable_http_path="/" so that mounting the app at "/mcp" in main.py yields a clean
     # "/mcp" endpoint (FastMCP's default internal path is "/mcp", which would give "/mcp/mcp").
     mcp = FastMCP("kubently", streamable_http_path="/")
 
     @mcp.tool()
-    async def list_clusters() -> list[str]:
-        """List the Kubernetes clusters currently available for troubleshooting."""
-        api_url, api_key = _creds()
-        return await tools.list_clusters(api_url, api_key)
+    async def ask_kubently(
+        query: str,
+        cluster_id: str | None = None,
+        conversation_id: str | None = None,
+    ) -> dict:
+        """Ask Kubently to troubleshoot a Kubernetes problem, in natural language.
 
-    @mcp.tool()
-    async def execute_kubectl(cluster_id: str, command: str, namespace: str = "default") -> str:
-        """Run a read-only kubectl command against a cluster.
+        Kubently's agent investigates across the available clusters (running read-only
+        kubectl as needed) and returns a synthesized answer — you do NOT issue kubectl
+        yourself; describe the problem and let Kubently diagnose it.
 
         Args:
-            cluster_id: Target cluster (use list_clusters to discover IDs).
-            command: kubectl command without the leading `kubectl`, e.g. "get pods -o wide".
-            namespace: Namespace to use when the command doesn't specify one.
+            query: The question or problem in plain language, e.g.
+                   "why are pods crashlooping in the payments namespace on prod?".
+            cluster_id: Optional target cluster id. Omit to let Kubently choose or ask;
+                        if you don't know the id, just name the cluster in `query`.
+            conversation_id: Optional id to continue a prior troubleshooting thread —
+                             reuse the `thread_id` from a previous response. Omit to start fresh.
+
+        Returns:
+            {"answer": <markdown>, "thread_id": <id to continue the conversation>}
         """
-        api_url, api_key = _creds()
-        return await tools.execute_kubectl(api_url, api_key, cluster_id, command, namespace)
+        return await tools.ask_kubently(agent, query, cluster_id, conversation_id)
 
     return mcp
 

--- a/kubently/modules/mcp/tools.py
+++ b/kubently/modules/mcp/tools.py
@@ -1,61 +1,38 @@
 """
-MCP tool adapters for Kubently.
+MCP tool logic for Kubently.
 
-Thin async wrappers over the central API (the same endpoints the A2A agent uses).
-Keeping these free of the `mcp` SDK import makes them unit-testable and lets the
-API boot even when the SDK isn't installed.
+The MCP surface is a single natural-language tool: the caller delegates a question and
+Kubently's own troubleshooting agent answers — the same agent reached over A2A. This
+mirrors A2A rather than exposing raw kubectl, so Kubently's reasoning loop stays in the
+loop instead of being bypassed by the caller's LLM driving kubectl directly.
 
-Read-only safety is enforced downstream by the executor whitelist + RBAC, so these
-adapters stay deliberately thin.
+Kept free of the `mcp` SDK import so it stays unit-testable and the API boots even when
+the SDK isn't installed.
 """
 
-
-import httpx
-
-_TIMEOUT = 30.0
+import uuid
 
 
-async def list_clusters(api_url: str, api_key: str) -> list[str]:
-    """Return the IDs of clusters currently available for troubleshooting."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        response = await client.get(
-            f"{api_url}/debug/clusters",
-            headers={"X-Api-Key": api_key},
-        )
-        if response.status_code != 200:
-            return []
-        return response.json().get("clusters", [])
+async def ask_kubently(
+    agent,
+    query: str,
+    cluster_id: str | None = None,
+    conversation_id: str | None = None,
+) -> dict:
+    """Route a natural-language question through the Kubently agent and return its answer.
 
+    `conversation_id` doubles as the agent's memory thread_id; omit it to start a fresh
+    thread (a new id is generated and returned so the caller can continue the conversation).
 
-async def execute_kubectl(
-    api_url: str,
-    api_key: str,
-    cluster_id: str,
-    command: str,
-    namespace: str = "default",
-) -> str:
-    """Run a kubectl command against a cluster and return its output.
-
-    `command` is the kubectl command without the leading `kubectl` (e.g. "get pods").
+    MCP tool calls are request/response, so the agent's stream is drained to its final
+    message. `agent` is a `KubentlyAgent` (injected by the server so this stays SDK-free).
     """
-    parts = command.split()
-    if not parts:
-        return "Error: empty command"
-    verb, args = parts[0], parts[1:]
+    thread_id = conversation_id or str(uuid.uuid4())
+    messages = [{"role": "user", "content": query}]
 
-    payload = {
-        "cluster_id": cluster_id,
-        "command_type": verb,
-        "args": args,
-        "namespace": namespace,
-        "timeout_seconds": 30,
-    }
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        response = await client.post(
-            f"{api_url}/debug/execute",
-            headers={"X-Api-Key": api_key},
-            json=payload,
-        )
-        if response.status_code != 200:
-            return f"Error: HTTP {response.status_code}: {response.text}"
-        return response.json().get("output", "")
+    answer = ""
+    async for event in agent.run(messages, thread_id=thread_id, cluster_id=cluster_id):
+        if event.get("type") in ("message", "error"):
+            answer = event.get("content", answer)
+
+    return {"answer": answer, "thread_id": thread_id}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11,6 +11,9 @@ import sys
 import pytest
 
 pytest.importorskip("mcp")
+# build_mcp_server now constructs Kubently's troubleshooting agent, which lives in the
+# same optional `a2a` extra as the mcp SDK; skip when that stack isn't installed.
+pytest.importorskip("langgraph.checkpoint.redis")
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -23,4 +26,4 @@ def test_build_mcp_server_registers_expected_tools(monkeypatch):
     server.streamable_http_app()  # session manager / tool manager initialized here
 
     names = sorted(tool.name for tool in asyncio.run(server.list_tools()))
-    assert names == ["execute_kubectl", "list_clusters"]
+    assert names == ["ask_kubently"]

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Tests for the MCP server tool adapters (kubently.modules.mcp.tools).
+Tests for the MCP ask tool logic (kubently.modules.mcp.tools.ask_kubently).
 
-These adapters expose Kubently's multi-cluster troubleshooting over MCP by calling
-the same central API endpoints the A2A agent uses (/debug/clusters, /debug/execute).
-The logic under test is the request shape and response parsing; HTTP is faked.
+The tool routes a natural-language query through the Kubently agent and drains its
+stream to the final answer. The agent is faked; the logic under test is the drain
+(last message wins, errors surface) and the conversation_id -> thread_id mapping.
 """
 
 import os
@@ -17,92 +17,55 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from kubently.modules.mcp import tools
 
 
-class FakeResponse:
-    def __init__(self, status_code, payload):
-        self.status_code = status_code
-        self._payload = payload
-        self.text = str(payload)
+class FakeAgent:
+    """Records run() args and yields a scripted sequence of agent events."""
 
-    def json(self):
-        return self._payload
+    def __init__(self, events):
+        self._events = events
+        self.calls = []
 
-
-class FakeAsyncClient:
-    """Minimal async-context httpx.AsyncClient stand-in that records calls."""
-
-    def __init__(self, get_response=None, post_response=None, recorder=None):
-        self._get_response = get_response
-        self._post_response = post_response
-        self._rec = recorder if recorder is not None else {}
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *exc):
-        return False
-
-    async def get(self, url, headers=None):
-        self._rec["get_url"] = url
-        self._rec["get_headers"] = headers
-        return self._get_response
-
-    async def post(self, url, headers=None, json=None):
-        self._rec["post_url"] = url
-        self._rec["post_headers"] = headers
-        self._rec["post_json"] = json
-        return self._post_response
+    async def run(self, messages, thread_id=None, cluster_id=None):
+        self.calls.append(
+            {"messages": messages, "thread_id": thread_id, "cluster_id": cluster_id}
+        )
+        for event in self._events:
+            yield event
 
 
 @pytest.mark.asyncio
-async def test_list_clusters_returns_ids(monkeypatch):
-    rec = {}
-    monkeypatch.setattr(
-        tools.httpx,
-        "AsyncClient",
-        lambda *a, **k: FakeAsyncClient(
-            get_response=FakeResponse(200, {"clusters": ["prod", "staging"]}), recorder=rec
-        ),
+async def test_ask_drains_to_final_message_and_reuses_conversation_id():
+    agent = FakeAgent(
+        [
+            {"type": "message", "content": "investigating...", "metadata": {}},
+            {"type": "message", "content": "final answer", "metadata": {}},
+        ]
     )
 
-    result = await tools.list_clusters("http://api:8080", "key123")
+    result = await tools.ask_kubently(
+        agent, "why crashlooping?", cluster_id="prod", conversation_id="conv-1"
+    )
 
-    assert result == ["prod", "staging"]
-    assert rec["get_url"] == "http://api:8080/debug/clusters"
-    assert rec["get_headers"]["X-Api-Key"] == "key123"
+    assert result == {"answer": "final answer", "thread_id": "conv-1"}
+    # conversation_id is passed through as the agent's memory thread_id, with cluster context.
+    assert agent.calls[0]["thread_id"] == "conv-1"
+    assert agent.calls[0]["cluster_id"] == "prod"
 
 
 @pytest.mark.asyncio
-async def test_execute_kubectl_posts_verb_and_args(monkeypatch):
-    rec = {}
-    monkeypatch.setattr(
-        tools.httpx,
-        "AsyncClient",
-        lambda *a, **k: FakeAsyncClient(
-            post_response=FakeResponse(200, {"output": "pod/foo Running"}), recorder=rec
-        ),
-    )
+async def test_ask_generates_thread_id_when_omitted():
+    agent = FakeAgent([{"type": "message", "content": "ok", "metadata": {}}])
 
-    result = await tools.execute_kubectl(
-        "http://api:8080", "key123", "prod", "get pods", namespace="kube-system"
-    )
+    result = await tools.ask_kubently(agent, "list clusters")
 
-    assert result == "pod/foo Running"
-    assert rec["post_url"] == "http://api:8080/debug/execute"
-    body = rec["post_json"]
-    assert body["cluster_id"] == "prod"
-    assert body["command_type"] == "get"
-    assert body["args"] == ["pods"]
-    assert body["namespace"] == "kube-system"
+    assert result["answer"] == "ok"
+    assert result["thread_id"]  # generated, non-empty, and handed back to the caller
+    assert agent.calls[0]["thread_id"] == result["thread_id"]
 
 
 @pytest.mark.asyncio
-async def test_execute_kubectl_surfaces_http_error(monkeypatch):
-    monkeypatch.setattr(
-        tools.httpx,
-        "AsyncClient",
-        lambda *a, **k: FakeAsyncClient(post_response=FakeResponse(404, {"detail": "no cluster"})),
-    )
+async def test_ask_surfaces_error_event():
+    agent = FakeAgent([{"type": "error", "content": "boom", "metadata": {}}])
 
-    result = await tools.execute_kubectl("http://api:8080", "key123", "ghost", "get pods")
+    result = await tools.ask_kubently(agent, "break", conversation_id="c")
 
-    assert "404" in result
+    assert result == {"answer": "boom", "thread_id": "c"}


### PR DESCRIPTION
## Description

Reworks the MCP server surface so it mirrors A2A instead of exposing raw kubectl.

Previously the MCP server exposed two granular tools — `list_clusters()` and `execute_kubectl(cluster_id, command, namespace)`. That let a calling agent's LLM drive kubectl directly, **bypassing Kubently's own troubleshooting agent** (the prompt + reasoning loop that is the product's actual value). The MCP server was reduced to a kubectl proxy.

This PR replaces those two tools with a **single natural-language tool**, `ask_kubently(query, cluster_id?, conversation_id?)`, that routes the question through the same `KubentlyAgent` the A2A interface uses and returns `{"answer": <markdown>, "thread_id": <id>}`. The calling agent delegates a question; Kubently does the reasoning — A2A semantics over MCP transport.

This is an established pattern: the official MCP project ([discussion #330](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/330)) blesses exposing an agent as a tool as long as it declares an output shape, and frameworks like `mcp-agent`, Microsoft Agent Framework (`.AsAIFunction()`), and the OpenAI Agents SDK (`agent.as_tool()`) all ship it.

### Key implementation notes for reviewers
- `build_mcp_server(redis_client)` now constructs and reuses one `KubentlyAgent` (same wiring as the A2A executor), sharing the same Redis-backed conversation memory.
- MCP is request/response, so the agent's stream is drained to its final message.
- `conversation_id` maps directly to the agent's LangGraph `thread_id` — no separate mapping table (Redis owns memory TTL). Omit it to start fresh; a new id is generated and returned so the caller can continue.
- The HTTP adapter layer in `kubently/modules/mcp/tools.py` is gone — the agent talks to the queue/session modules directly.

### Also in this PR
- **Build fix:** removed the `apt-get update && apt-get install gcc` layer from the API Dockerfile. It was intermittently failing the build with `apt-get` exit 100, and it turns out no dependency needs a compiler — all 69 packages (incl. the `a2a` extra) install from prebuilt wheels on amd64/arm64. Executor image is unchanged (Alpine/musl, where compilation is still needed).
- **Docs:** `docs/MCP.md` rewritten for the single-tool surface, and endpoint references corrected to the trailing-slash `/mcp/` (a bare `/mcp` 307-redirects, same as `/a2a/`).

Fixes # (no tracked issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue) — Dockerfile build
- [x] Documentation update
- [x] Code refactoring

> Note: this **changes the MCP tool contract** (the two old tools are removed). Existing MCP clients wired to `list_clusters`/`execute_kubectl` must switch to `ask_kubently`. The REST API (`/debug/execute`, `/debug/clusters`) is unchanged for anyone needing raw primitives.

## How Has This Been Tested?

- [x] Unit tests pass locally with my changes
- [x] Tested in local Kubernetes cluster (Kind/Minikube)
- [x] Manual testing (describe scenarios)

**Unit:** `tests/test_mcp_tools.py` rewritten to test the drain logic against a fake agent (last-message-wins, error surfacing, `conversation_id`→`thread_id`, generated-id-returned). `tests/test_mcp_server.py` asserts the single `ask_kubently` tool. `8 passed, 1 skipped` (the wiring test skips when the `a2a` extra isn't installed).

**Live smoke test** against the kind `kubently` cluster (built an overlay image, rolled the API, drove the real `/mcp/` endpoint over the streamable-HTTP MCP handshake):
- `tools/list` → `['ask_kubently']` (old two tools gone); schema = `query, cluster_id, conversation_id`.
- `ask_kubently` ran real read-only kubectl against the cluster and returned a synthesized answer + `thread_id`.
- **Multi-turn memory verified:** a follow-up call reusing the returned `conversation_id` correctly resolved "how many pods did you *just check* in *that* namespace?" → "8 pods total" (same `thread_id`), which is only answerable if memory threaded through Redis.

**Build:** verified the full API Dockerfile builds on `linux/amd64` (CI push target) and native `arm64` without the gcc step — all 69 packages from wheels.

**Test Configuration**:
- Kubernetes Version: kind (local)
- Python Version: 3.13

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md with my changes

## Additional Notes:

The live smoke test deployed an overlay image (`FROM kubently-api:latest` + `COPY kubently/`) to dodge the broken apt layer while validating runtime behavior; the apt layer is removed for real in this PR, so the normal `docker build` path is now the verified one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
