### PR TITLE
MCP distribution + proactive diagnosis + release fixes (roadmap phases 2-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased] - 2026-07-06
 
 ### Added
+- **`kubently mcp`: stdio MCP bridge (CLI 2.3.0)** — `claude mcp add kubently -- kubently mcp`
+  proxies stdio to the deployed `/mcp/` endpoint via mcp-remote, reading URL/key from CLI
+  config. Plus `server.json` manifest for the official MCP registry and README/MCP.md
+  connect guides
 - **`kubently install`: one-command onboarding (CLI 2.2.0)**
   - Installs Kubently via Helm into the current kubectl context: creates the
     namespace and all three secrets (API keys, Redis password, LLM key),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased] - 2026-07-06
 
 ### Added
+- **Proactive diagnosis: Alertmanager → Slack** — new `POST /webhooks/alertmanager`
+  endpoint (X-API-Key or Bearer auth) accepts the standard Alertmanager webhook
+  payload, diagnoses each firing alert with the Kubently agent in the background
+  (fan-out capped at 3 per payload), and posts the result to `SLACK_WEBHOOK_URL`
+  (Slack incoming webhook). Configure via `api.env.SLACK_WEBHOOK_URL`
 - **`kubently mcp`: stdio MCP bridge (CLI 2.3.0)** — `claude mcp add kubently -- kubently mcp`
   proxies stdio to the deployed `/mcp/` endpoint via mcp-remote, reading URL/key from CLI
   config. Plus `server.json` manifest for the official MCP registry and README/MCP.md

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ prompts for it, or reads `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` /
 `--chart ./deployment/helm/kubently` to install from a local checkout, and
 `kubently install --help` for everything else.
 
+### Use from Claude Code / Cursor (MCP)
+
+Already ran `kubently install`? Add Kubently to Claude Code:
+
+```bash
+claude mcp add kubently -- kubently mcp
+```
+
+Or connect directly over HTTP (no bridge process):
+
+```bash
+claude mcp add --transport http kubently http://localhost:8080/mcp/ \
+  --header "X-API-Key: <your-api-key>"
+```
+
+Then ask Claude things like *"use kubently to figure out why payments pods are
+crashlooping"*. Any MCP client works — see [docs/MCP.md](docs/MCP.md) for
+Cursor and generic configuration.
+
 **📖 See [QUICK_START.md](docs/QUICK_START.md) for full quick-start guide**
 
 **📚 See [GETTING_STARTED.md](docs/GETTING_STARTED.md) for production deployment**

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ Then ask Claude things like *"use kubently to figure out why payments pods are
 crashlooping"*. Any MCP client works — see [docs/MCP.md](docs/MCP.md) for
 Cursor and generic configuration.
 
+### Proactive diagnosis (Alertmanager → Slack)
+
+Set `api.env.SLACK_WEBHOOK_URL` to a Slack incoming-webhook URL and point
+Alertmanager at Kubently:
+
+```yaml
+receivers:
+  - name: kubently
+    webhook_configs:
+      - url: https://<your-kubently-host>/webhooks/alertmanager
+        http_config:
+          http_headers:            # Alertmanager >= 0.28
+            X-API-Key:
+              secrets: ["<your-api-key>"]
+```
+
+Each firing alert is diagnosed by the agent and the result is posted to Slack —
+the bot often explains the root cause before you've opened your laptop.
+
 **📖 See [QUICK_START.md](docs/QUICK_START.md) for full quick-start guide**
 
 **📚 See [GETTING_STARTED.md](docs/GETTING_STARTED.md) for production deployment**

--- a/deployment/helm/kubently/Chart.lock
+++ b/deployment/helm/kubently/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 21.2.14
-digest: sha256:ecda45d6d39c4d5a15845571b6a672866c0e10d7ac4e7384ccbf802ac90a22d9
-generated: "2025-09-05T22:31:56.198736-05:00"

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -46,6 +46,7 @@ api:
   
   env:
     LOG_LEVEL: "INFO"
+    # SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/..."  # enables /webhooks/alertmanager -> Slack diagnosis
     MAX_COMMANDS_PER_FETCH: "10"
     COMMAND_TIMEOUT: "30"
     SESSION_TTL: "300"

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -104,6 +104,23 @@ The agent only ever runs read-only kubectl.
 
 ## Connecting a Client
 
+### Kubently CLI bridge (easiest, stdio clients)
+
+If you've run `kubently install` (or `kubently init`), the CLI already knows your
+API URL and key. `kubently mcp` runs a local stdio↔HTTP bridge (via
+[`mcp-remote`](https://www.npmjs.com/package/mcp-remote)), so any stdio-only MCP
+client can connect without knowing the endpoint:
+
+```bash
+# Claude Code
+claude mcp add kubently -- kubently mcp
+
+# Any stdio MCP client config
+{ "command": "kubently", "args": ["mcp"] }
+```
+
+Point it at a different deployment with `kubently mcp --api-url <url> --api-key <key>`.
+
 > **Caveat**: MCP remote-HTTP client config formats vary between clients and
 > change over time. The examples below use the common `mcpServers` streamable-HTTP
 > shape, but you should check your client's current documentation for the exact

--- a/docs/superpowers/plans/2026-07-06-mcp-distribution.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-distribution.md
@@ -1,0 +1,294 @@
+# MCP Distribution (Roadmap Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Engineers already using Claude Code / Cursor get Kubently as a tool in two lines — via native HTTP transport or a `kubently mcp` stdio bridge — plus registry manifests so it's discoverable.
+
+**Architecture:** The server side already exists (`ask_kubently` tool at `/mcp/`, streamable HTTP, `X-API-Key` auth — see docs/MCP.md). This phase is packaging: (1) a `kubently mcp` CLI subcommand that bridges stdio↔HTTP by delegating to the community-standard `mcp-remote` proxy via `npx` (no new bundled dependency, no hand-rolled protocol code), reading URL/key from the existing `~/.kubently/config.json`; (2) docs showing both connect paths; (3) a `server.json` manifest for the official MCP registry with submission instructions.
+
+**Tech Stack:** TypeScript ESM CLI (commander), `npx -y mcp-remote` at runtime, jest (configured in Phase 1).
+
+**Key repo facts** (verified 2026-07-06):
+- MCP endpoint: `/mcp/` — trailing slash REQUIRED (bare `/mcp` 307-redirects and some clients drop the method); `X-API-Key` header auth (docs/MCP.md).
+- `Config` (kubently-cli/nodejs/src/lib/config.ts) has `getApiUrl()` / `getApiKey()`, both `string | undefined`.
+- CLI is at 2.2.0 after Phase 1; commands live in `src/commands/`, registered in `src/index.ts`; pure helpers pattern + tests established in `src/lib/installer.ts` / `.test.ts`.
+
+---
+
+### Task 1: `kubently mcp` stdio bridge (TDD on the pure part)
+
+**Files:**
+- Create: `kubently-cli/nodejs/src/commands/mcp.ts`
+- Modify: `kubently-cli/nodejs/src/lib/installer.test.ts` → no; test goes in a new `kubently-cli/nodejs/src/commands/mcp.test.ts`
+- Modify: `kubently-cli/nodejs/src/index.ts` (register)
+- Modify: `kubently-cli/nodejs/package.json` (version 2.2.0 → 2.3.0)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `kubently-cli/nodejs/src/commands/mcp.test.ts`:
+
+```ts
+import { describe, it, expect } from '@jest/globals';
+import { buildMcpRemoteArgs, mcpUrl } from './mcp.js';
+
+describe('mcpUrl', () => {
+  it('appends /mcp/ with exactly one slash (trailing slash required by server)', () => {
+    expect(mcpUrl('http://localhost:8080')).toBe('http://localhost:8080/mcp/');
+    expect(mcpUrl('http://localhost:8080/')).toBe('http://localhost:8080/mcp/');
+    expect(mcpUrl('https://kubently.example.com')).toBe('https://kubently.example.com/mcp/');
+  });
+});
+
+describe('buildMcpRemoteArgs', () => {
+  it('builds the npx mcp-remote invocation with auth header and http-only transport', () => {
+    expect(buildMcpRemoteArgs('http://localhost:8080', 'k3y')).toEqual([
+      '-y',
+      'mcp-remote',
+      'http://localhost:8080/mcp/',
+      '--header',
+      'X-API-Key:k3y',
+      '--transport',
+      'http-only',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd kubently-cli/nodejs && npx jest src/commands/mcp.test.ts`
+Expected: FAIL — cannot resolve `./mcp.js`.
+
+- [ ] **Step 3: Implement the command**
+
+Create `kubently-cli/nodejs/src/commands/mcp.ts`:
+
+```ts
+import { spawn } from 'node:child_process';
+import { Command } from 'commander';
+import { Config } from '../lib/config.js';
+
+/** /mcp/ with the trailing slash — bare /mcp 307-redirects and some clients drop the method. */
+export function mcpUrl(apiUrl: string): string {
+  return `${apiUrl.replace(/\/+$/, '')}/mcp/`;
+}
+
+export function buildMcpRemoteArgs(apiUrl: string, apiKey: string): string[] {
+  // ponytail: delegate stdio<->streamable-HTTP proxying to the community-standard
+  // mcp-remote instead of hand-rolling protocol code; npx caches it after first run
+  return [
+    '-y',
+    'mcp-remote',
+    mcpUrl(apiUrl),
+    '--header',
+    `X-API-Key:${apiKey}`,
+    '--transport',
+    'http-only',
+  ];
+}
+
+export function mcpCommand(config: Config): Command {
+  const cmd = new Command('mcp');
+
+  cmd
+    .description('🔌 Run a local stdio MCP bridge to the Kubently API (for MCP clients)')
+    .option('--api-url <url>', 'Kubently API URL (default: from ~/.kubently/config.json)')
+    .option('--api-key <key>', 'API key (default: from ~/.kubently/config.json)')
+    .action((opts) => {
+      const apiUrl = opts.apiUrl ?? config.getApiUrl();
+      const apiKey = opts.apiKey ?? config.getApiKey();
+      if (!apiUrl || !apiKey) {
+        // stderr only — stdout belongs to the MCP protocol
+        console.error(
+          'kubently mcp: missing API URL or key. Run "kubently install" or "kubently init" first, or pass --api-url/--api-key.'
+        );
+        process.exit(1);
+      }
+      const child = spawn('npx', buildMcpRemoteArgs(apiUrl, apiKey), { stdio: 'inherit' });
+      child.on('exit', (code) => process.exit(code ?? 1));
+    });
+
+  return cmd;
+}
+```
+
+**Why stderr matters:** an MCP client owns the stdio channel; any stray stdout line corrupts the JSON-RPC stream. No banner, no chalk, nothing on stdout from this command.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/commands/mcp.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Register + version bump + full verify**
+
+In `src/index.ts` add `import { mcpCommand } from './commands/mcp.js';` next to the other command imports, and `program.addCommand(mcpCommand(config));` after the install command registration.
+
+**Banner guard:** `src/index.ts` prints a figlet banner in a `preAction` hook for main commands. Verify the hook only fires for `thisCommand.name() === 'kubently'`… it does, but the top-level `showBanner()` on bare invocation isn't hit for subcommands. Confirm by running `node dist/index.js mcp --api-url http://x --api-key y` and checking NOTHING prints to stdout before mcp-remote output (banner would corrupt the protocol). If the banner appears, gate it: skip when `process.argv[2] === 'mcp'`.
+
+In `package.json`: `"version": "2.2.0"` → `"version": "2.3.0"`.
+
+Run: `npm run build && npx jest && node dist/index.js mcp --help`
+Expected: build clean, all tests pass, help shows `--api-url`/`--api-key`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add kubently-cli/nodejs/src/commands/mcp.ts kubently-cli/nodejs/src/commands/mcp.test.ts kubently-cli/nodejs/src/index.ts kubently-cli/nodejs/package.json
+git commit -m "feat(cli): kubently mcp — stdio bridge to /mcp/ via mcp-remote"
+```
+
+---
+
+### Task 2: Registry manifest (official MCP registry)
+
+**Files:**
+- Create: `server.json` (repo root — where the registry publisher expects it)
+
+- [ ] **Step 1: Write the manifest**
+
+Create `server.json`:
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.kubently/kubently",
+  "description": "Troubleshoot Kubernetes clusters agentically — natural-language cluster diagnosis via the ask_kubently tool",
+  "repository": {
+    "url": "https://github.com/kubently/kubently",
+    "source": "github"
+  },
+  "version_detail": {
+    "version": "2.3.0"
+  },
+  "packages": [
+    {
+      "registry_name": "npm",
+      "name": "@kubently/cli",
+      "version": "2.3.0",
+      "runtime_hint": "npx",
+      "package_arguments": [
+        { "type": "positional", "value": "mcp" }
+      ],
+      "environment_variables": []
+    }
+  ],
+  "remotes": [
+    {
+      "transport_type": "streamable-http",
+      "url": "https://<your-kubently-host>/mcp/"
+    }
+  ]
+}
+```
+
+Note: if the schema URL 404s or the current registry schema differs (it has churned), fetch the current schema from https://github.com/modelcontextprotocol/registry and adjust field names — keep the same content. Validation happens at `mcp-publisher publish` time anyway.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server.json
+git commit -m "feat: MCP registry manifest (server.json)"
+```
+
+Actual submission (`mcp-publisher login github && mcp-publisher publish`) requires the user's GitHub auth interactively — listed as a follow-up for the user, not automated here. Same for Smithery (needs an account on smithery.ai; it can import from the official registry).
+
+---
+
+### Task 3: Docs — two-line connect for Claude Code / Cursor
+
+**Files:**
+- Modify: `README.md` (new "Use from Claude Code / Cursor (MCP)" section after the quickstart)
+- Modify: `docs/MCP.md` (add the `kubently mcp` bridge + `claude mcp add` examples)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: README section**
+
+Insert after the quickstart section:
+
+```markdown
+### Use from Claude Code / Cursor (MCP)
+
+Already ran `kubently install`? Add Kubently to Claude Code:
+
+​```bash
+claude mcp add kubently -- kubently mcp
+​```
+
+Or connect directly over HTTP (no bridge process):
+
+​```bash
+claude mcp add --transport http kubently http://localhost:8080/mcp/ \
+  --header "X-API-Key: <your-api-key>"
+​```
+
+Then ask Claude things like *"use kubently to figure out why payments pods are
+crashlooping"*. Any MCP client works — see [docs/MCP.md](docs/MCP.md) for
+Cursor and generic configuration.
+```
+
+(Strip the `​` zero-width fence escapes.)
+
+- [ ] **Step 2: docs/MCP.md — add bridge section**
+
+Read docs/MCP.md and add a "Connecting with the Kubently CLI bridge" section alongside the existing client examples, showing `kubently mcp` (uses saved config), `--api-url`/`--api-key` overrides, and the `claude mcp add kubently -- kubently mcp` one-liner. Keep the existing HTTP examples — the bridge is for stdio-only clients.
+
+- [ ] **Step 3: CHANGELOG entry** (top of file, under a `## [Unreleased] - <today>` heading if today's section exists, else create it)
+
+```markdown
+- **`kubently mcp`: stdio MCP bridge (CLI 2.3.0)** — `claude mcp add kubently -- kubently mcp`
+  proxies stdio to the deployed `/mcp/` endpoint via mcp-remote, reading URL/key from CLI
+  config. Plus `server.json` manifest for the official MCP registry and README/MCP.md
+  connect guides.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/MCP.md CHANGELOG.md
+git commit -m "docs: two-line MCP connect for Claude Code/Cursor; changelog"
+```
+
+---
+
+### Task 4: E2E verification against the kind cluster
+
+No files. Uses the existing `kubently` kind cluster (context `kind-kubently`, namespace `kubently`).
+
+- [ ] **Step 1: Port-forward and configure**
+
+```bash
+kubectl --context kind-kubently -n kubently port-forward svc/kubently-api 8080:8080 &
+```
+
+Get an API key for that cluster (from the `kubently-api-keys` secret: `kubectl --context kind-kubently -n kubently get secret kubently-api-keys -o jsonpath='{.data.keys}' | base64 -d | head -1`).
+
+- [ ] **Step 2: Drive the bridge over stdio**
+
+MCP stdio is newline-delimited JSON-RPC. Send an initialize + tools/list through the bridge:
+
+```bash
+cd kubently-cli/nodejs
+printf '%s\n%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | timeout 60 node dist/index.js mcp --api-url http://localhost:8080 --api-key "<key>" 2>/dev/null
+```
+
+Expected: two JSON-RPC results on stdout — an `initialize` result (serverInfo) and a `tools/list` result containing `"ask_kubently"`. If mcp-remote exits before responding, drop `--transport http-only` and retry (transport flag names have churned across mcp-remote versions; adjust `buildMcpRemoteArgs` + test to whatever works).
+
+- [ ] **Step 3: Kill the port-forward, record results**
+
+```bash
+pkill -f "port-forward.*kubently-api 8080"
+```
+
+Record the tools/list output in the PR description.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** stdio bridge (Task 1), registry listing (Task 2 — manifest committed, submission is a user follow-up since it needs interactive GitHub auth), two-line docs (Task 3), verified against a real deployment (Task 4).
+- **Known risk:** `mcp-remote` CLI flags (`--transport http-only`, `--header`) have churned across versions; Task 4 Step 2 includes the fallback procedure. The header uses `X-API-Key:value` (no space) because some mcp-remote versions split on the first colon only.
+- **Deliberately skipped:** bundling mcp-remote as a dependency (npx is cached after first run; a lockstep dep adds maintenance for no UX gain), Smithery automation (account-gated).

--- a/docs/superpowers/plans/2026-07-07-proactive-diagnosis.md
+++ b/docs/superpowers/plans/2026-07-07-proactive-diagnosis.md
@@ -1,0 +1,387 @@
+# Proactive Diagnosis (Roadmap Phase 3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Alertmanager fires a webhook at Kubently; Kubently diagnoses the alert with its own agent and posts the result to a Slack incoming webhook — "the bot diagnosed the alert before I opened my laptop."
+
+**Architecture:** New black-box module `kubently/modules/webhook/` with an APIRouter. `POST /webhooks/alertmanager` (X-API-Key auth via existing `verify_api_key`) returns 202 immediately and diagnoses in a background task, reusing the exact agent entry point the MCP module uses (`kubently.modules.mcp.tools.ask_kubently` with a lazily-built `KubentlyAgent`). The answer is POSTed to `SLACK_WEBHOOK_URL` with httpx (already a direct dependency). Pure functions (alert parsing, query building, Slack formatting) are unit-tested; the endpoint is tested with a mocked agent; live E2E uses a mock Slack pod on the kind cluster.
+
+**Tech Stack:** FastAPI APIRouter, httpx, pytest (existing tests/ layout), Helm `api.env` passthrough for `SLACK_WEBHOOK_URL`.
+
+**Key repo facts** (verified 2026-07-07):
+- `kubently/main.py` has `verify_api_key` dependency (line ~214) used by debug endpoints; lazy-import pattern for agent-dependent features (MCP mounts only when the SDK imports).
+- `kubently/modules/mcp/tools.py: ask_kubently(agent, query, cluster_id, conversation_id)` → `{"answer": md, "thread_id": id}`.
+- `KubentlyAgent(redis_client=...)` built lazily in `kubently/modules/mcp/server.py`.
+- Alertmanager webhook payload: `{"status": "firing"|"resolved", "alerts": [{"status", "labels": {alertname, namespace, pod, cluster?...}, "annotations": {summary?, description?}, ...}], ...}`.
+
+---
+
+### Task 1: Webhook module (TDD)
+
+**Files:**
+- Create: `kubently/modules/webhook/__init__.py`
+- Create: `kubently/modules/webhook/alertmanager.py`
+- Test: `tests/test_webhook.py`
+
+- [ ] **Step 1: Failing tests for the pure functions**
+
+`tests/test_webhook.py`:
+
+```python
+from kubently.modules.webhook.alertmanager import (
+    build_query,
+    firing_alerts,
+    format_slack_message,
+)
+
+PAYLOAD = {
+    "status": "firing",
+    "alerts": [
+        {
+            "status": "firing",
+            "labels": {
+                "alertname": "KubePodCrashLooping",
+                "namespace": "payments",
+                "pod": "api-5c9",
+                "cluster": "prod-east",
+            },
+            "annotations": {"summary": "Pod payments/api-5c9 is crash looping"},
+        },
+        {"status": "resolved", "labels": {"alertname": "Done"}, "annotations": {}},
+    ],
+}
+
+
+def test_firing_alerts_filters_resolved():
+    alerts = firing_alerts(PAYLOAD)
+    assert len(alerts) == 1
+    assert alerts[0]["labels"]["alertname"] == "KubePodCrashLooping"
+
+
+def test_firing_alerts_tolerates_garbage():
+    assert firing_alerts({}) == []
+    assert firing_alerts({"alerts": "nope"}) == []
+
+
+def test_build_query_includes_key_facts():
+    q = build_query(PAYLOAD["alerts"][0])
+    assert "KubePodCrashLooping" in q
+    assert "payments" in q
+    assert "prod-east" in q
+    assert "crash looping" in q
+
+
+def test_build_query_minimal_alert():
+    q = build_query({"labels": {"alertname": "X"}, "annotations": {}})
+    assert "X" in q
+
+
+def test_format_slack_message():
+    msg = format_slack_message(PAYLOAD["alerts"][0], "root cause: bad image")
+    assert "KubePodCrashLooping" in msg["text"]
+    assert "root cause: bad image" in msg["text"]
+```
+
+Run: `python3 -m pytest tests/test_webhook.py -q` → expect import error (module missing).
+
+- [ ] **Step 2: Implement pure functions + router**
+
+`kubently/modules/webhook/__init__.py`:
+
+```python
+from .alertmanager import create_router  # noqa: F401
+```
+
+`kubently/modules/webhook/alertmanager.py`:
+
+```python
+"""Alertmanager webhook -> Kubently diagnosis -> Slack incoming webhook.
+
+Proactive mode: Alertmanager POSTs its standard webhook payload here; each firing
+alert is diagnosed by the same agent that serves A2A/MCP, and the answer is posted
+to SLACK_WEBHOOK_URL. The endpoint ACKs 202 immediately; diagnosis runs in the
+background (it can take minutes).
+"""
+
+import asyncio
+import logging
+import os
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+MAX_ALERTS_PER_PAYLOAD = 3  # ponytail: cap fan-out per webhook; raise if users batch more
+
+
+def firing_alerts(payload: dict) -> list[dict]:
+    alerts = payload.get("alerts") if isinstance(payload, dict) else None
+    if not isinstance(alerts, list):
+        return []
+    return [a for a in alerts if isinstance(a, dict) and a.get("status") == "firing"]
+
+
+def build_query(alert: dict) -> str:
+    labels = alert.get("labels", {})
+    ann = alert.get("annotations", {})
+    parts = [f"Alert '{labels.get('alertname', 'unknown')}' is firing"]
+    if labels.get("cluster"):
+        parts.append(f"in cluster {labels['cluster']}")
+    if labels.get("namespace"):
+        parts.append(f"in namespace {labels['namespace']}")
+    if labels.get("pod"):
+        parts.append(f"on pod {labels['pod']}")
+    summary = ann.get("summary") or ann.get("description") or ""
+    lead = " ".join(parts) + (f": {summary}" if summary else "")
+    return (
+        f"{lead}. Diagnose the root cause and suggest a fix. "
+        "Be concise; this will be posted to Slack."
+    )
+
+
+def format_slack_message(alert: dict, answer: str) -> dict:
+    name = alert.get("labels", {}).get("alertname", "alert")
+    return {"text": f":rotating_light: *Kubently diagnosis for `{name}`*\n\n{answer}"}
+
+
+async def _diagnose_and_post(agent, alert: dict, slack_url: str) -> None:
+    from kubently.modules.mcp import tools
+
+    try:
+        result = await tools.ask_kubently(agent, build_query(alert), None, None)
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(slack_url, json=format_slack_message(alert, result["answer"]))
+            resp.raise_for_status()
+        logger.info("Posted diagnosis for %s to Slack", alert.get("labels", {}).get("alertname"))
+    except Exception:
+        logger.exception("Proactive diagnosis failed for alert %s", alert.get("labels", {}))
+
+
+def create_router(verify_api_key, redis_client=None) -> APIRouter:
+    """Router factory; agent built lazily on first alert (langchain import is heavy)."""
+    router = APIRouter()
+    state: dict = {"agent": None}
+
+    def _agent():
+        if state["agent"] is None:
+            from kubently.modules.a2a.protocol_bindings.a2a_server.agent import KubentlyAgent
+
+            state["agent"] = KubentlyAgent(redis_client=redis_client)
+        return state["agent"]
+
+    @router.post("/webhooks/alertmanager", status_code=202)
+    async def alertmanager_webhook(request: Request, auth=Depends(verify_api_key)):
+        slack_url = os.environ.get("SLACK_WEBHOOK_URL")
+        if not slack_url:
+            raise HTTPException(503, "SLACK_WEBHOOK_URL is not configured")
+        payload = await request.json()
+        alerts = firing_alerts(payload)
+        for alert in alerts[:MAX_ALERTS_PER_PAYLOAD]:
+            asyncio.create_task(_diagnose_and_post(_agent(), alert, slack_url))
+        if len(alerts) > MAX_ALERTS_PER_PAYLOAD:
+            logger.warning(
+                "Alertmanager payload had %d firing alerts; diagnosing first %d",
+                len(alerts),
+                MAX_ALERTS_PER_PAYLOAD,
+            )
+        return {"accepted": min(len(alerts), MAX_ALERTS_PER_PAYLOAD)}
+
+    return router
+```
+
+Run: `python3 -m pytest tests/test_webhook.py -q` → all pass.
+
+- [ ] **Step 3: Endpoint test with mocked agent + Slack**
+
+Append to `tests/test_webhook.py` (follow the style of tests/test_mcp_server.py for app/dependency fakes):
+
+```python
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from kubently.modules.webhook.alertmanager import create_router
+
+
+def make_app(monkeypatch, slack_url="http://slack.test/hook"):
+    if slack_url:
+        monkeypatch.setenv("SLACK_WEBHOOK_URL", slack_url)
+    else:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    app = FastAPI()
+    app.include_router(create_router(verify_api_key=lambda: ("ok", None)))
+    return app
+
+
+def test_webhook_503_when_slack_not_configured(monkeypatch):
+    client = TestClient(make_app(monkeypatch, slack_url=None))
+    assert client.post("/webhooks/alertmanager", json=PAYLOAD).status_code == 503
+
+
+def test_webhook_accepts_firing_alerts(monkeypatch):
+    # Stub the diagnosis coroutine so no agent/langchain import happens
+    import kubently.modules.webhook.alertmanager as am
+
+    calls = []
+
+    async def fake_diag(agent, alert, url):
+        calls.append(alert)
+
+    monkeypatch.setattr(am, "_diagnose_and_post", fake_diag)
+    monkeypatch.setattr(am, "KubentlyAgent", object, raising=False)
+    client = TestClient(make_app(monkeypatch))
+    # also stub the lazy agent builder path by pre-seeding state via a no-op:
+    resp = client.post("/webhooks/alertmanager", json=PAYLOAD)
+    assert resp.status_code == 202
+    assert resp.json() == {"accepted": 1}
+```
+
+Note: the lazy `_agent()` still imports KubentlyAgent in the accept test — if that import
+is heavy/unavailable in the unit-test env, refactor so `_agent()` is only called inside
+`_diagnose_and_post` (pass a callable), keeping the endpoint import-free. Adjust to
+whatever the existing test env supports; tests/test_mcp_server.py shows what's importable.
+
+Run: `python3 -m pytest tests/test_webhook.py -q` → all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubently/modules/webhook tests/test_webhook.py
+git commit -m "feat: alertmanager webhook -> agent diagnosis -> slack (proactive mode)"
+```
+
+---
+
+### Task 2: Wire into main.py + Helm/docs
+
+**Files:**
+- Modify: `kubently/main.py` (include router in lifespan/startup near the MCP mount, same lazy pattern)
+- Modify: `deployment/helm/kubently/values.yaml` (comment documenting `api.env.SLACK_WEBHOOK_URL`)
+- Modify: `README.md` (short "Proactive diagnosis" section), `CHANGELOG.md`
+
+- [ ] **Step 1: main.py wiring** — after the MCP mount block, add:
+
+```python
+    # Proactive mode: Alertmanager webhook -> diagnosis -> Slack (needs the agent stack).
+    try:
+        from kubently.modules.webhook import create_router
+
+        app.include_router(create_router(verify_api_key, redis_client=redis_client))
+        logger.info("Alertmanager webhook mounted at /webhooks/alertmanager")
+    except ImportError as e:
+        logger.info(f"Webhook module not mounted: {e}")
+```
+
+Place inside the same startup path where `verify_api_key` and `redis_client` are in scope; match the MCP block's error-handling style. Verify with `python3 -c "import kubently.main"` if that's how other changes are smoke-checked (or run the existing unit suite).
+
+- [ ] **Step 2: values.yaml + docs**
+
+In the `api.env` block of values.yaml add a comment:
+
+```yaml
+    # SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/..."  # enables /webhooks/alertmanager -> Slack diagnosis
+```
+
+README section (after the MCP section):
+
+```markdown
+### Proactive diagnosis (Alertmanager → Slack)
+
+Set `api.env.SLACK_WEBHOOK_URL` to a Slack incoming-webhook URL and point
+Alertmanager at Kubently:
+
+​```yaml
+receivers:
+  - name: kubently
+    webhook_configs:
+      - url: https://<your-kubently-host>/webhooks/alertmanager
+        http_config:
+          authorization:
+            type: X-API-Key   # sent as the X-API-Key header
+            credentials: <your-api-key>
+​```
+
+Each firing alert gets diagnosed by the agent and the result lands in Slack.
+```
+
+**Verify the Alertmanager auth shape**: Alertmanager's `http_config.authorization` sets an `Authorization: <type> <credentials>` header, NOT arbitrary headers. If `verify_api_key` only reads `X-API-Key`, either (a) note in docs that Alertmanager ≥0.25 supports `webhook_configs.http_config.headers` custom headers if available, or (b) extend `verify_api_key` usage in the router to also accept `Authorization: Bearer <key>`. Check `verify_api_key`'s implementation in main.py and pick the smallest correct option; update the README snippet to match reality.
+
+CHANGELOG: add an entry under today's Unreleased section.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubently/main.py deployment/helm/kubently/values.yaml README.md CHANGELOG.md
+git commit -m "feat: mount alertmanager webhook; helm/docs for proactive mode"
+```
+
+---
+
+### Task 3: Live E2E on kind with a mock Slack
+
+No files (scratch pod on the existing `kind-kubently` cluster).
+
+- [ ] **Step 1: Mock Slack sink**
+
+```bash
+kubectl --context kind-kubently -n kubently run mock-slack --image=python:3.12-alpine --restart=Never -- \
+  python3 -c "
+from http.server import BaseHTTPRequestHandler, HTTPServer
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get('Content-Length', 0)))
+        print('SLACK-POST:', body.decode()[:2000], flush=True)
+        self.send_response(200); self.end_headers(); self.wfile.write(b'ok')
+HTTPServer(('', 8080), H).serve_forever()
+"
+kubectl --context kind-kubently -n kubently expose pod mock-slack --port 8080
+```
+
+- [ ] **Step 2: Rebuild API image with the webhook, set env, roll**
+
+Rebuild/load the API image the way `deployment/scripts/kind-e2e.sh` does (BUILD=true path), then:
+
+```bash
+kubectl --context kind-kubently -n kubently set env deploy/kubently-api SLACK_WEBHOOK_URL=http://mock-slack:8080
+kubectl --context kind-kubently -n kubently rollout status deploy/kubently-api --timeout=150s
+```
+
+(Or run the full `ANTHROPIC_API_KEY=... ./deployment/scripts/kind-e2e.sh` then `set env` — whichever is less fiddly.)
+
+- [ ] **Step 3: Fire a fake alert and watch the sink**
+
+```bash
+kubectl --context kind-kubently -n kubently port-forward svc/kubently-api 8080:8080 &
+KEY=$(kubectl --context kind-kubently -n kubently get secret kubently-api-keys -o jsonpath='{.data.keys}' | base64 -d | head -1)
+curl -s -X POST http://localhost:8080/webhooks/alertmanager \
+  -H "X-API-Key: $KEY" -H "Content-Type: application/json" \
+  -d '{"status":"firing","alerts":[{"status":"firing","labels":{"alertname":"TestAlwaysFiring","cluster":"kind","namespace":"kube-system"},"annotations":{"summary":"synthetic test alert for e2e"}}]}'
+# expect {"accepted":1}; then within ~1-2 min:
+kubectl --context kind-kubently -n kubently logs pod/mock-slack | grep -c "SLACK-POST"
+```
+
+Expected: `{"accepted": 1}` immediately; mock-slack log shows one SLACK-POST containing "Kubently diagnosis" and real diagnostic content.
+
+- [ ] **Step 4: Cleanup**
+
+```bash
+kubectl --context kind-kubently -n kubently delete pod/mock-slack svc/mock-slack
+pkill -f "port-forward.*kubently-api 8080"
+```
+
+---
+
+### Task 4: Ship everything (single PR #37)
+
+- [ ] Push branch; confirm PR #37 includes phase-2 + fixes + phase-3.
+- [ ] Merge PR #37 (user-authorized: "fix everything in 37 and keep going").
+- [ ] Confirm `release-chart.yml` run on main succeeds; `curl https://kubently.github.io/kubently/index.yaml` lists kubently 1.0.0.
+- [ ] Tag `cli-v2.3.0` on the merge commit and push the tag → `publish-npm.yml` publishes; confirm `npm view @kubently/cli version` → 2.3.0.
+- [ ] Final public-path check: fresh kind cluster, `npx -y @kubently/cli@2.3.0 install --yes --no-chat` with NO `--chart` (published chart + published images + published CLI).
+- [ ] Cleanup, report.
+
+## Self-Review Notes
+- Alertmanager auth header shape flagged as a verification step (Task 2 Step 2) rather than assumed.
+- Agent import kept lazy everywhere so the API still boots without the `a2a` extra.
+- Deliberately skipped: dedup/rate-limiting of repeat alerts (`ponytail:` cap comment marks the ceiling — add Redis-keyed dedup when someone's Slack gets noisy), resolved-alert notifications, Slack blocks formatting.

--- a/kubently-cli/nodejs/package.json
+++ b/kubently-cli/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubently/cli",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Modern Node.js CLI for Kubently - Troubleshooting Kubernetes Agentically",
   "type": "module",
   "main": "dist/index.js",

--- a/kubently-cli/nodejs/src/commands/install.ts
+++ b/kubently-cli/nodejs/src/commands/install.ts
@@ -155,8 +155,7 @@ async function runInstall(config: Config, opts: InstallOpts): Promise<void> {
   config.setApiKey(apiKey);
   config.save();
   console.log(chalk.green('\n✓ Kubently installed. CLI config saved to ~/.kubently/config.json'));
-  console.log(chalk.gray(`  Port-forward is running in the background (pid ${portForward.pid}).`));
-  console.log(chalk.gray('  Re-create it later with:'));
+  console.log(chalk.gray('  The API is reachable while a port-forward is running; start one any time with:'));
   console.log(chalk.gray(`  kubectl -n ${namespace} port-forward svc/kubently-api 8080:8080\n`));
 
   // 6. Straight into the chat

--- a/kubently-cli/nodejs/src/commands/mcp.test.ts
+++ b/kubently-cli/nodejs/src/commands/mcp.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildMcpRemoteArgs, mcpUrl } from './mcp.js';
+
+describe('mcpUrl', () => {
+  it('appends /mcp/ with exactly one slash (trailing slash required by server)', () => {
+    expect(mcpUrl('http://localhost:8080')).toBe('http://localhost:8080/mcp/');
+    expect(mcpUrl('http://localhost:8080/')).toBe('http://localhost:8080/mcp/');
+    expect(mcpUrl('https://kubently.example.com')).toBe('https://kubently.example.com/mcp/');
+  });
+});
+
+describe('buildMcpRemoteArgs', () => {
+  it('builds the npx mcp-remote invocation with auth header and http-only transport', () => {
+    expect(buildMcpRemoteArgs('http://localhost:8080', 'k3y')).toEqual([
+      '-y',
+      'mcp-remote',
+      'http://localhost:8080/mcp/',
+      '--header',
+      'X-API-Key:k3y',
+      '--transport',
+      'http-only',
+    ]);
+  });
+});

--- a/kubently-cli/nodejs/src/commands/mcp.ts
+++ b/kubently-cli/nodejs/src/commands/mcp.ts
@@ -1,0 +1,46 @@
+import { spawn } from 'node:child_process';
+import { Command } from 'commander';
+import { Config } from '../lib/config.js';
+
+/** /mcp/ with the trailing slash — bare /mcp 307-redirects and some clients drop the method. */
+export function mcpUrl(apiUrl: string): string {
+  return `${apiUrl.replace(/\/+$/, '')}/mcp/`;
+}
+
+export function buildMcpRemoteArgs(apiUrl: string, apiKey: string): string[] {
+  // ponytail: delegate stdio<->streamable-HTTP proxying to the community-standard
+  // mcp-remote instead of hand-rolling protocol code; npx caches it after first run
+  return [
+    '-y',
+    'mcp-remote',
+    mcpUrl(apiUrl),
+    '--header',
+    `X-API-Key:${apiKey}`,
+    '--transport',
+    'http-only',
+  ];
+}
+
+export function mcpCommand(config: Config): Command {
+  const cmd = new Command('mcp');
+
+  cmd
+    .description('🔌 Run a local stdio MCP bridge to the Kubently API (for MCP clients)')
+    .option('--api-url <url>', 'Kubently API URL (default: from ~/.kubently/config.json)')
+    .option('--api-key <key>', 'API key (default: from ~/.kubently/config.json)')
+    .action((opts) => {
+      const apiUrl = opts.apiUrl ?? config.getApiUrl();
+      const apiKey = opts.apiKey ?? config.getApiKey();
+      if (!apiUrl || !apiKey) {
+        // stderr only — stdout belongs to the MCP protocol
+        console.error(
+          'kubently mcp: missing API URL or key. Run "kubently install" or "kubently init" first, or pass --api-url/--api-key.'
+        );
+        process.exit(1);
+      }
+      const child = spawn('npx', buildMcpRemoteArgs(apiUrl, apiKey), { stdio: 'inherit' });
+      child.on('exit', (code) => process.exit(code ?? 1));
+    });
+
+  return cmd;
+}

--- a/kubently-cli/nodejs/src/index.ts
+++ b/kubently-cli/nodejs/src/index.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import figlet from 'figlet';
 import { initCommand } from './commands/init.js';
 import { installCommand } from './commands/install.js';
+import { mcpCommand } from './commands/mcp.js';
 import { clusterCommands } from './commands/cluster.js';
 import { debugCommand } from './commands/debug.js';
 import { createLoginCommand } from './commands/login.js';
@@ -46,8 +47,9 @@ program
   .option('--a2a-path <path>', 'Custom A2A endpoint path (default: /a2a)')
   .option('--debug', 'Enable debug output', false)
   .hook('preAction', (thisCommand) => {
-    // Show banner for main commands (not subcommands)
-    if (thisCommand.name() === 'kubently' && process.argv.length > 2) {
+    // Show banner for main commands (not subcommands).
+    // Never for `mcp`: an MCP client owns stdout — any stray output corrupts the JSON-RPC stream.
+    if (thisCommand.name() === 'kubently' && process.argv.length > 2 && process.argv[2] !== 'mcp') {
       showBanner();
     }
     
@@ -73,6 +75,7 @@ program
 
 // Add commands
 program.addCommand(installCommand(config));
+program.addCommand(mcpCommand(config));
 program.addCommand(initCommand(config));
 program.addCommand(createLoginCommand());
 program.addCommand(clusterCommands(config));

--- a/kubently-cli/nodejs/src/lib/installer.test.ts
+++ b/kubently-cli/nodejs/src/lib/installer.test.ts
@@ -77,13 +77,6 @@ describe('buildHelmArgs', () => {
     expect(args).toContain('executor.token=tok');
     expect(args).toContain('--wait');
   });
-
-  it('pins a current Anthropic model (published image default is retired)', () => {
-    expect(buildHelmArgs(base)).toContain('api.env.ANTHROPIC_MODEL_NAME=claude-sonnet-4-6');
-    expect(buildHelmArgs({ ...base, provider: 'openai' }).join(' ')).not.toContain(
-      'ANTHROPIC_MODEL_NAME'
-    );
-  });
 });
 
 describe('secretManifest', () => {

--- a/kubently-cli/nodejs/src/lib/installer.ts
+++ b/kubently-cli/nodejs/src/lib/installer.ts
@@ -44,12 +44,6 @@ export interface HelmOpts {
 
 export function buildHelmArgs(o: HelmOpts): string[] {
   const chart = o.chartPath ? [o.chartPath] : ['kubently', '--repo', HELM_REPO_URL];
-  // ponytail: pin the Anthropic model — the published :latest API image still defaults
-  // to a retired model id; drop this once the image is republished from current main
-  const modelPin =
-    o.provider === 'anthropic-claude'
-      ? ['--set', 'api.env.ANTHROPIC_MODEL_NAME=claude-sonnet-4-6']
-      : [];
   return [
     'upgrade',
     '--install',
@@ -63,7 +57,6 @@ export function buildHelmArgs(o: HelmOpts): string[] {
     'api.existingSecret=kubently-api-keys',
     '--set',
     `api.env.LLM_PROVIDER=${o.provider}`,
-    ...modelPin,
     '--set',
     'executor.enabled=true',
     '--set',

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -182,6 +182,17 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Failed to mount MCP server: {e}")
 
+    # Proactive mode: Alertmanager webhook -> agent diagnosis -> Slack incoming webhook.
+    # Auth accepts X-API-Key or Authorization Bearer (verify_dual_auth); the agent stack
+    # is imported lazily inside the background task, so mounting is cheap.
+    try:
+        from kubently.modules.webhook import create_router as create_webhook_router
+
+        app.include_router(create_webhook_router(verify_dual_auth, redis_client=redis_client))
+        logger.info("Alertmanager webhook mounted at /webhooks/alertmanager")
+    except Exception as e:
+        logger.warning(f"Failed to mount alertmanager webhook: {e}")
+
     logger.info("Kubently API started successfully")
 
     yield

--- a/kubently/modules/webhook/__init__.py
+++ b/kubently/modules/webhook/__init__.py
@@ -1,0 +1,1 @@
+from .alertmanager import create_router  # noqa: F401

--- a/kubently/modules/webhook/alertmanager.py
+++ b/kubently/modules/webhook/alertmanager.py
@@ -1,0 +1,94 @@
+"""Alertmanager webhook -> Kubently diagnosis -> Slack incoming webhook.
+
+Proactive mode: Alertmanager POSTs its standard webhook payload here; each firing
+alert is diagnosed by the same agent that serves A2A/MCP, and the answer is posted
+to SLACK_WEBHOOK_URL. The endpoint ACKs 202 immediately; diagnosis runs in the
+background (it can take minutes).
+"""
+
+import asyncio
+import logging
+import os
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+MAX_ALERTS_PER_PAYLOAD = 3  # ponytail: cap fan-out per webhook; add Redis-keyed dedup if Slack gets noisy
+
+
+def firing_alerts(payload) -> list[dict]:
+    alerts = payload.get("alerts") if isinstance(payload, dict) else None
+    if not isinstance(alerts, list):
+        return []
+    return [a for a in alerts if isinstance(a, dict) and a.get("status") == "firing"]
+
+
+def build_query(alert: dict) -> str:
+    labels = alert.get("labels", {})
+    ann = alert.get("annotations", {})
+    parts = [f"Alert '{labels.get('alertname', 'unknown')}' is firing"]
+    if labels.get("cluster"):
+        parts.append(f"in cluster {labels['cluster']}")
+    if labels.get("namespace"):
+        parts.append(f"in namespace {labels['namespace']}")
+    if labels.get("pod"):
+        parts.append(f"on pod {labels['pod']}")
+    summary = ann.get("summary") or ann.get("description") or ""
+    lead = " ".join(parts) + (f": {summary}" if summary else "")
+    return (
+        f"{lead}. Diagnose the root cause and suggest a fix. "
+        "Be concise; this will be posted to Slack."
+    )
+
+
+def format_slack_message(alert: dict, answer: str) -> dict:
+    name = alert.get("labels", {}).get("alertname", "alert")
+    return {"text": f":rotating_light: *Kubently diagnosis for `{name}`*\n\n{answer}"}
+
+
+async def _diagnose_and_post(agent_factory, alert: dict, slack_url: str) -> None:
+    from kubently.modules.mcp import tools
+
+    try:
+        result = await tools.ask_kubently(agent_factory(), build_query(alert), None, None)
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(slack_url, json=format_slack_message(alert, result["answer"]))
+            resp.raise_for_status()
+        logger.info("Posted diagnosis for %s to Slack", alert.get("labels", {}).get("alertname"))
+    except Exception:
+        logger.exception("Proactive diagnosis failed for alert %s", alert.get("labels", {}))
+
+
+def create_router(verify_api_key, redis_client=None) -> APIRouter:
+    """Router factory. The agent (and its heavy langchain import) is only touched
+    inside the background task, so the API boots and ACKs without the a2a stack."""
+    router = APIRouter()
+    state: dict = {"agent": None}
+
+    def _agent():
+        if state["agent"] is None:
+            from kubently.modules.a2a.protocol_bindings.a2a_server.agent import KubentlyAgent
+
+            state["agent"] = KubentlyAgent(redis_client=redis_client)
+        return state["agent"]
+
+    @router.post("/webhooks/alertmanager", status_code=202)
+    async def alertmanager_webhook(request: Request, auth=Depends(verify_api_key)):
+        slack_url = os.environ.get("SLACK_WEBHOOK_URL")
+        if not slack_url:
+            raise HTTPException(503, "SLACK_WEBHOOK_URL is not configured")
+        payload = await request.json()
+        alerts = firing_alerts(payload)
+        for alert in alerts[:MAX_ALERTS_PER_PAYLOAD]:
+            asyncio.create_task(_diagnose_and_post(_agent, alert, slack_url))
+        if len(alerts) > MAX_ALERTS_PER_PAYLOAD:
+            logger.warning(
+                "Alertmanager payload had %d firing alerts; diagnosing first %d",
+                len(alerts),
+                MAX_ALERTS_PER_PAYLOAD,
+            )
+        return {"accepted": min(len(alerts), MAX_ALERTS_PER_PAYLOAD)}
+
+    return router

--- a/server.json
+++ b/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.kubently/kubently",
+  "description": "Troubleshoot Kubernetes clusters agentically — natural-language cluster diagnosis via the ask_kubently tool",
+  "repository": {
+    "url": "https://github.com/kubently/kubently",
+    "source": "github"
+  },
+  "version_detail": {
+    "version": "2.3.0"
+  },
+  "packages": [
+    {
+      "registry_name": "npm",
+      "name": "@kubently/cli",
+      "version": "2.3.0",
+      "runtime_hint": "npx",
+      "package_arguments": [
+        { "type": "positional", "value": "mcp" }
+      ],
+      "environment_variables": []
+    }
+  ],
+  "remotes": [
+    {
+      "transport_type": "streamable-http",
+      "url": "https://<your-kubently-host>/mcp/"
+    }
+  ]
+}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Unit tests for the Alertmanager webhook module (proactive diagnosis)."""
+
+import os
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.webhook.alertmanager import (  # noqa: E402
+    build_query,
+    create_router,
+    firing_alerts,
+    format_slack_message,
+)
+
+PAYLOAD = {
+    "status": "firing",
+    "alerts": [
+        {
+            "status": "firing",
+            "labels": {
+                "alertname": "KubePodCrashLooping",
+                "namespace": "payments",
+                "pod": "api-5c9",
+                "cluster": "prod-east",
+            },
+            "annotations": {"summary": "Pod payments/api-5c9 is crash looping"},
+        },
+        {"status": "resolved", "labels": {"alertname": "Done"}, "annotations": {}},
+    ],
+}
+
+
+def test_firing_alerts_filters_resolved():
+    alerts = firing_alerts(PAYLOAD)
+    assert len(alerts) == 1
+    assert alerts[0]["labels"]["alertname"] == "KubePodCrashLooping"
+
+
+def test_firing_alerts_tolerates_garbage():
+    assert firing_alerts({}) == []
+    assert firing_alerts({"alerts": "nope"}) == []
+    assert firing_alerts(None) == []
+
+
+def test_build_query_includes_key_facts():
+    q = build_query(PAYLOAD["alerts"][0])
+    assert "KubePodCrashLooping" in q
+    assert "payments" in q
+    assert "prod-east" in q
+    assert "crash looping" in q
+
+
+def test_build_query_minimal_alert():
+    q = build_query({"labels": {"alertname": "X"}, "annotations": {}})
+    assert "X" in q
+
+
+def test_format_slack_message():
+    msg = format_slack_message(PAYLOAD["alerts"][0], "root cause: bad image")
+    assert "KubePodCrashLooping" in msg["text"]
+    assert "root cause: bad image" in msg["text"]
+
+
+def make_app(monkeypatch, slack_url="http://slack.test/hook"):
+    if slack_url:
+        monkeypatch.setenv("SLACK_WEBHOOK_URL", slack_url)
+    else:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    app = FastAPI()
+    app.include_router(create_router(verify_api_key=lambda: ("ok", None)))
+    return app
+
+
+def test_webhook_503_when_slack_not_configured(monkeypatch):
+    client = TestClient(make_app(monkeypatch, slack_url=None))
+    assert client.post("/webhooks/alertmanager", json=PAYLOAD).status_code == 503
+
+
+def test_webhook_accepts_firing_alerts(monkeypatch):
+    import kubently.modules.webhook.alertmanager as am
+
+    diagnosed = []
+
+    async def fake_diag(agent_factory, alert, url):
+        diagnosed.append(alert)
+
+    monkeypatch.setattr(am, "_diagnose_and_post", fake_diag)
+    client = TestClient(make_app(monkeypatch))
+    resp = client.post("/webhooks/alertmanager", json=PAYLOAD)
+    assert resp.status_code == 202
+    assert resp.json() == {"accepted": 1}
+
+
+def test_webhook_caps_alert_fanout(monkeypatch):
+    import kubently.modules.webhook.alertmanager as am
+
+    async def fake_diag(agent_factory, alert, url):
+        pass
+
+    monkeypatch.setattr(am, "_diagnose_and_post", fake_diag)
+    many = {"alerts": [PAYLOAD["alerts"][0]] * 10}
+    client = TestClient(make_app(monkeypatch))
+    resp = client.post("/webhooks/alertmanager", json=many)
+    assert resp.json() == {"accepted": am.MAX_ALERTS_PER_PAYLOAD}


### PR DESCRIPTION
## Summary
- **`kubently mcp`** (CLI 2.3.0): stdio↔HTTP MCP bridge via `mcp-remote`; `claude mcp add kubently -- kubently mcp`. Banner suppressed on stdout for protocol cleanliness. Plus `server.json` manifest for the official MCP registry and README/MCP.md connect guides.
- **Proactive diagnosis (phase 3)**: `POST /webhooks/alertmanager` (X-API-Key or Bearer) diagnoses each firing alert with the agent in the background (fan-out capped at 3) and posts the result to `SLACK_WEBHOOK_URL`. New black-box module `kubently/modules/webhook/`.
- **Release fixes**: stale `Chart.lock` removed (was failing `release-chart.yml`); the now-unneeded `ANTHROPIC_MODEL_NAME` CLI pin dropped (fresh images published); misleading port-forward message tidied.

## Verified
- Python suite: 159 passed (8 new webhook tests). CLI: 12 jest tests, build clean.
- MCP bridge live E2E: `initialize` + `tools/list` → `["ask_kubently"]` over stdio against the kind cluster.
- Proactive E2E on kind: synthetic Alertmanager payload → 202 → agent diagnosis posted to a mock Slack sink (correctly identified the canary alert).

## Post-merge release steps
- [ ] `release-chart.yml` green; https://kubently.github.io/kubently/index.yaml live
- [ ] tag `cli-v2.3.0` → npm publishes 2.3.0
- [ ] public-path E2E: `npx @kubently/cli install` with no `--chart`
- [ ] `mcp-publisher publish` (interactive; user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)