### PR TITLE
CLI 2.3.1: mcpName for MCP registry validation

### DIFF
--- a/kubently-cli/nodejs/package.json
+++ b/kubently-cli/nodejs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kubently/cli",
-  "version": "2.3.0",
+  "version": "2.3.1",
+  "mcpName": "io.github.kubently/kubently",
   "description": "Modern Node.js CLI for Kubently - Troubleshooting Kubernetes Agentically",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -1,30 +1,22 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.kubently/kubently",
-  "description": "Troubleshoot Kubernetes clusters agentically — natural-language cluster diagnosis via the ask_kubently tool",
+  "description": "Troubleshoot Kubernetes agentically: natural-language cluster diagnosis via ask_kubently",
   "repository": {
     "url": "https://github.com/kubently/kubently",
     "source": "github"
   },
-  "version_detail": {
-    "version": "2.3.0"
-  },
+  "version": "2.3.1",
   "packages": [
     {
-      "registry_name": "npm",
-      "name": "@kubently/cli",
-      "version": "2.3.0",
-      "runtime_hint": "npx",
-      "package_arguments": [
+      "registryType": "npm",
+      "identifier": "@kubently/cli",
+      "version": "2.3.1",
+      "runtimeHint": "npx",
+      "packageArguments": [
         { "type": "positional", "value": "mcp" }
       ],
-      "environment_variables": []
-    }
-  ],
-  "remotes": [
-    {
-      "transport_type": "streamable-http",
-      "url": "https://<your-kubently-host>/mcp/"
+      "transport": { "type": "stdio" }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Bump CLI to 2.3.1 with `"mcpName": "io.github.kubently/kubently"` in package.json — required by the official MCP registry's anti-squatting check (the npm package must declare the registry name it belongs to).
- Fix `server.json` to the current registry schema (camelCase fields, top-level `version`, ≤100-char description, placeholder remote dropped).

## Test Plan
- [x] Registry publish validated everything up to the npm-package check (auth, namespace, schema all pass)
- [ ] After merge + `npm publish` of 2.3.1: `mcp-publisher publish` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)