### PR TITLE
Fix kubently install chat handoff 404 (CLI 2.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] - 2026-07-08
+
+### Fixed
+- **`kubently install` chat handoff 404 (CLI 2.3.2)** — the post-install chat passed the
+  bare API URL to the debug session, but the A2A client expects the full `/a2a/` URL
+  (as `kubently debug` builds); every question failed with "Endpoint not found".
+  Standalone `kubently debug` was unaffected
+
 ## [Unreleased] - 2026-07-06
 
 ### Added

--- a/kubently-cli/nodejs/package.json
+++ b/kubently-cli/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubently/cli",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "mcpName": "io.github.kubently/kubently",
   "description": "Modern Node.js CLI for Kubently - Troubleshooting Kubernetes Agentically",
   "type": "module",

--- a/kubently-cli/nodejs/src/commands/install.ts
+++ b/kubently-cli/nodejs/src/commands/install.ts
@@ -158,9 +158,9 @@ async function runInstall(config: Config, opts: InstallOpts): Promise<void> {
   console.log(chalk.gray('  The API is reachable while a port-forward is running; start one any time with:'));
   console.log(chalk.gray(`  kubectl -n ${namespace} port-forward svc/kubently-api 8080:8080\n`));
 
-  // 6. Straight into the chat
+  // 6. Straight into the chat (runDebugSession expects the full /a2a/ URL, same as debug.ts)
   if (opts.chat) {
-    await runDebugSession(LOCAL_API_URL, apiKey, clusterId);
+    await runDebugSession(`${LOCAL_API_URL}/a2a/`, apiKey, clusterId);
   }
   portForward.kill();
 }


### PR DESCRIPTION
## Summary
- The chat that `kubently install` drops into passed the bare API URL to `runDebugSession`, but the A2A client posts to the URL as-is and expects `/a2a/` to already be appended (as `kubently debug` and interactive mode do). Every in-chat question 404'd with a misleading "check the URL" error. One-line fix + version bump to 2.3.2.

## Verified
- E2E on kind: `kubently install --yes` → in-chat question "are any pods currently unhealthy?" → agent answered "No unhealthy pods."
- 12 jest tests pass, build clean.

## Post-merge
- [ ] `npm publish` 2.3.2 (2.3.1 on npm has the broken handoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)