### PR TITLE
Fix npm OIDC publish: remove registry-url placeholder token

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
+          # no registry-url: it writes an .npmrc authToken entry (placeholder when the
+          # secret is absent) that preempts OIDC trusted publishing
 
       # Trusted publishing (OIDC) needs npm >= 11.5; runners ship older
       - name: Update npm


### PR DESCRIPTION
setup-node's registry-url writes an .npmrc authToken entry, filled with a literal placeholder when NPM_TOKEN is absent — npm authenticated with garbage instead of falling through to OIDC trusted publishing. Removing registry-url lets trusted publishing engage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)