### PR TITLE
Fix fresh-install executor registration race (CLI 2.3.3, chart 1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased] - 2026-07-08
 
 ### Fixed
+- **Fresh-install executor race (CLI 2.3.3, chart 1.0.1)** — `kubently install`
+  restarted the executor on every run; on first installs the rolling update briefly
+  ran old+new executor pods with the same cluster identity and the old pod's SSE
+  disconnect could clobber the new pod's registration, timing out the "waiting for
+  executor" step. The restart now only happens on reruns (stale-token recovery), and
+  the executor Deployment uses `strategy: Recreate`
+
+### Fixed
 - **`kubently install` chat handoff 404 (CLI 2.3.2)** — the post-install chat passed the
   bare API URL to the debug session, but the A2A client expects the full `/a2a/` URL
   (as `kubently debug` builds); every question failed with "Endpoint not found".

--- a/deployment/helm/kubently/Chart.yaml
+++ b/deployment/helm/kubently/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubently
 description: Kubently - Troubleshooting Kubernetes Agentically
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.0.0"
 home: https://github.com/kubently/kubently
 maintainers:

--- a/deployment/helm/kubently/templates/executor-deployment.yaml
+++ b/deployment/helm/kubently/templates/executor-deployment.yaml
@@ -10,6 +10,10 @@ spec:
   # Always 1 replica - each executor represents a unique cluster identity
   # Multiple replicas would create duplicate agents for the same cluster
   replicas: 1
+  # Recreate: a rolling update briefly runs old+new pods with the same cluster
+  # identity; the old pod's SSE disconnect can clobber the new pod's registration
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "kubently.selectorLabels" . | nindent 6 }}

--- a/kubently-cli/nodejs/package.json
+++ b/kubently-cli/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubently/cli",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "mcpName": "io.github.kubently/kubently",
   "description": "Modern Node.js CLI for Kubently - Troubleshooting Kubernetes Agentically",
   "type": "module",

--- a/kubently-cli/nodejs/src/commands/install.ts
+++ b/kubently-cli/nodejs/src/commands/install.ts
@@ -113,8 +113,8 @@ async function runInstall(config: Config, opts: InstallOpts): Promise<void> {
 
   // 2. Helm install (waits for deployments). Reuse the existing executor token on
   // rerun — rotating it strands the running executor pod on the old value (401 loop).
-  const executorToken =
-    getSecretValue(namespace, 'kubently-executor-token', 'token') ?? genToken(32);
+  const existingToken = getSecretValue(namespace, 'kubently-executor-token', 'token');
+  const executorToken = existingToken ?? genToken(32);
   spinner = ora('Installing Kubently via Helm (this can take a few minutes)').start();
   run(
     'helm',
@@ -139,10 +139,14 @@ async function runInstall(config: Config, opts: InstallOpts): Promise<void> {
 
   // 4. Wait for the executor to register (the chart's sync-executor-tokens init
   // container seeds executor:token:{clusterId} into Redis from the Helm secret).
-  // Restart the executor first: pods don't roll on secret change, so a rerun or
-  // recovery install would otherwise leave it authenticating with a stale token.
+  // On RERUNS only, restart the executor first: pods don't roll on secret change,
+  // so a recovery install could leave it authenticating with a stale token. On a
+  // fresh install the executor booted with the right token — restarting it just
+  // races its own registration.
   spinner = ora('Waiting for the executor to connect').start();
-  restartExecutor(namespace);
+  if (existingToken !== null) {
+    restartExecutor(namespace);
+  }
   const admin = new KubentlyAdminClient(LOCAL_API_URL, apiKey);
   await waitFor(async () => {
     const { clusters } = await admin.listClusters();


### PR DESCRIPTION
## Summary
- Test battery on a fresh cluster caught `kubently install` timing out at "waiting for executor to connect": the unconditional executor restart made the rolling update briefly run two pods with the same cluster identity, and the old pod's SSE disconnect could clobber the new pod's registration.
- Fix: restart only on reruns (when a token secret pre-existed — the stale-token recovery case); executor Deployment now uses `strategy: Recreate` so any restart is clean. Chart 1.0.1.

## Verified
- Fresh kind cluster + local chart: install → connected without restart → in-chat question answered ("8" pods in kube-system).
- 12 jest tests; `helm template` renders `strategy: Recreate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)