### PR TITLE
Ctrl+C exit fix + graceful install reruns (CLI 2.3.4, chart 1.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased] - 2026-07-08
 
+### Fixed (2026-07-09)
+- **Ctrl+C now exits the debug chat immediately (CLI 2.3.4)** — three layered causes:
+  ora's spinner breaks readline keypress flow while animating (even with
+  discardStdin false), so Ctrl+C was swallowed mid-operation; replaced with a
+  static status line. SIGINT now hard-exits instead of leaving in-flight
+  requests holding a half-dead process that replays buffered keystrokes
+- **`kubently install` reruns recover from the Recreate upgrade conflict** —
+  upgrading a live executor Deployment to `strategy: Recreate` (chart 1.0.2)
+  hits "rollingUpdate: Forbidden" (helm three-way merge can't drop the
+  live-defaulted field); the installer now recreates the deployment and
+  retries once
+
 ### Fixed
 - **Fresh-install executor race (CLI 2.3.3, chart 1.0.1)** — `kubently install`
   restarted the executor on every run; on first installs the rolling update briefly

--- a/deployment/helm/kubently/Chart.yaml
+++ b/deployment/helm/kubently/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubently
 description: Kubently - Troubleshooting Kubernetes Agentically
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.0.0"
 home: https://github.com/kubently/kubently
 maintainers:

--- a/deployment/helm/kubently/templates/executor-deployment.yaml
+++ b/deployment/helm/kubently/templates/executor-deployment.yaml
@@ -11,9 +11,12 @@ spec:
   # Multiple replicas would create duplicate agents for the same cluster
   replicas: 1
   # Recreate: a rolling update briefly runs old+new pods with the same cluster
-  # identity; the old pod's SSE disconnect can clobber the new pod's registration
+  # identity; the old pod's SSE disconnect can clobber the new pod's registration.
+  # rollingUpdate must be explicitly nulled or upgrades from a live RollingUpdate
+  # deployment fail ("rollingUpdate: Forbidden" during helm's three-way merge).
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       {{- include "kubently.selectorLabels" . | nindent 6 }}

--- a/kubently-cli/nodejs/package.json
+++ b/kubently-cli/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubently/cli",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "mcpName": "io.github.kubently/kubently",
   "description": "Modern Node.js CLI for Kubently - Troubleshooting Kubernetes Agentically",
   "type": "module",

--- a/kubently-cli/nodejs/src/commands/debug.ts
+++ b/kubently-cli/nodejs/src/commands/debug.ts
@@ -1,7 +1,6 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import * as readline from 'readline';
-import ora from 'ora';
 import { Config } from '../lib/config.js';
 import { KubentlyA2ASession } from '../lib/a2aClient.js';
 
@@ -119,7 +118,14 @@ export async function runDebugSession(
       
       // Process in next tick to let event handler complete
       setImmediate(async () => {
-        const spinner = ora('Waiting for Kubently agent...').start();
+        // Static status line, deliberately NOT an ora spinner: ora (even with
+        // discardStdin: false) breaks readline's keypress flow while animating,
+        // swallowing Ctrl+C exactly when users want to bail out of a slow call.
+        console.log(chalk.gray('⏳ Waiting for Kubently agent... (Ctrl+C to quit)'));
+        const spinner = {
+          succeed: (t: string) => console.log(chalk.green(`✔ ${t}`)),
+          fail: (t: string) => console.log(chalk.red(`✖ ${t}`)),
+        };
 
         try {
           const result = await session.sendMessage(command);
@@ -151,10 +157,24 @@ export async function runDebugSession(
       });
     });
 
-    rl.on('SIGINT', () => {
+    // Hard exit on Ctrl+C: rl.close() alone leaves in-flight agent requests
+    // (SSE/axios sockets) holding the event loop — the process lingers with the
+    // terminal half-released, replaying buffered keystrokes into a dead prompt.
+    const exitNow = () => {
       console.log(chalk.yellow('\n\n👋 Goodbye!'));
       rl.close();
-    });
+      process.exit(0);
+    };
+    rl.on('SIGINT', exitNow);
+    // Catch the signal path too (e.g. forwarded by spinner/stdin handlers)
+    process.once('SIGINT', exitNow);
+    // In raw mode Ctrl+C arrives as a data byte (ETX); readline only surfaces it
+    // while idle at the prompt. Catch it at the stream level so Ctrl+C also works
+    // mid-operation (spinner running, agent request in flight).
+    const etxListener = (chunk: Buffer | string) => {
+      if (chunk.includes('\x03')) exitNow();
+    };
+    process.stdin.on('data', etxListener);
 
     rl.on('close', () => {
       isClosing = true;

--- a/kubently-cli/nodejs/src/commands/install.ts
+++ b/kubently-cli/nodejs/src/commands/install.ts
@@ -116,16 +116,31 @@ async function runInstall(config: Config, opts: InstallOpts): Promise<void> {
   const existingToken = getSecretValue(namespace, 'kubently-executor-token', 'token');
   const executorToken = existingToken ?? genToken(32);
   spinner = ora('Installing Kubently via Helm (this can take a few minutes)').start();
-  run(
-    'helm',
-    buildHelmArgs({
-      namespace,
-      clusterId,
-      executorToken,
-      provider: opts.provider,
-      chartPath: opts.chart,
-    })
-  );
+  const helmArgs = buildHelmArgs({
+    namespace,
+    clusterId,
+    executorToken,
+    provider: opts.provider,
+    chartPath: opts.chart,
+  });
+  try {
+    run('helm', helmArgs);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    // Upgrading a live Deployment to strategy Recreate can hit "rollingUpdate:
+    // Forbidden": helm's three-way merge can't drop the live-defaulted
+    // rollingUpdate field (it was never in the old manifest). Recreate the
+    // executor deployment and retry once.
+    if (msg.includes('Forbidden') && msg.includes('strategy')) {
+      spinner.text = 'Upgrade conflict — recreating executor deployment and retrying';
+      run('kubectl', [
+        '-n', namespace, 'delete', 'deployment', 'kubently-executor', '--ignore-not-found',
+      ]);
+      run('helm', helmArgs);
+    } else {
+      throw error;
+    }
+  }
   spinner.succeed('Helm release installed');
 
   // 3. Port-forward + wait for API


### PR DESCRIPTION
## Summary
- **Ctrl+C in the debug chat now always exits.** Root cause chain: ora's spinner breaks readline keypress delivery while animating (reproduced in isolation; discardStdin:false doesn't help), so ^C was swallowed exactly when an agent call was in flight. Replaced the spinner with a static status line; SIGINT/ETX handlers hard-exit so in-flight sockets can't keep a zombie process replaying buffered keystrokes.
- **`kubently install` reruns are graceful over the strategy migration.** Chart 1.0.2 sets executor `strategy: Recreate` (single-identity executor must not overlap during rollouts); upgrading a live RollingUpdate deployment hits "rollingUpdate: Forbidden" (helm three-way merge can't delete live-defaulted fields), so the installer detects it, recreates the deployment, retries once.

## Verified
- PTY tests: ^C exits at idle prompt AND mid-operation (was: hung both in-op and post-close)
- Rerun over a real conflicted cluster (kind-kubently): recovered, executor strategy now Recreate, cluster reconnected
- 12 jest tests, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)