### PR TITLE
Queue pasted input in chat (CLI 2.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased] - 2026-07-08
 
 ### Fixed (2026-07-09)
+- **Multi-line paste no longer garbles the chat (CLI 2.3.5)** — lines arriving
+  while an operation is in flight are queued and processed sequentially (echoed
+  at a fresh prompt) instead of spamming "please wait" interleaved with the
+  streaming response
 - **Ctrl+C now exits the debug chat immediately (CLI 2.3.4)** — three layered causes:
   ora's spinner breaks readline keypress flow while animating (even with
   discardStdin false), so Ctrl+C was swallowed mid-operation; replaced with a

--- a/kubently-cli/nodejs/package.json
+++ b/kubently-cli/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubently/cli",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "mcpName": "io.github.kubently/kubently",
   "description": "Modern Node.js CLI for Kubently - Troubleshooting Kubernetes Agentically",
   "type": "module",

--- a/kubently-cli/nodejs/src/commands/debug.ts
+++ b/kubently-cli/nodejs/src/commands/debug.ts
@@ -71,14 +71,28 @@ export async function runDebugSession(
     
     rl.prompt();
 
+    // Lines that arrive while an operation is in flight (multi-line pastes,
+    // impatient typing) queue up and run sequentially instead of spamming
+    // "please wait" interleaved with streamed output.
+    const inputQueue: string[] = [];
+
     rl.on('line', (line: string) => {
       const command = line.trim();
-      
+
       if (!command) {
         if (!isClosing) rl.prompt();
         return;
       }
 
+      if (pendingOperation) {
+        inputQueue.push(command);
+        return;
+      }
+
+      handleCommand(command);
+    });
+
+    function handleCommand(command: string) {
       switch (command.toLowerCase()) {
         case 'exit':
         case 'quit':
@@ -105,12 +119,6 @@ export async function runDebugSession(
            console.log();
            if (!isClosing) rl.prompt();
            return;
-      }
-
-      // CRITICAL: Don't process if already processing
-      if (pendingOperation) {
-        console.log(chalk.yellow('⚠️  Please wait for the current operation to complete.'));
-        return;
       }
 
       // Mark as processing immediately
@@ -149,13 +157,19 @@ export async function runDebugSession(
           pendingOperation = false;
           if (isClosing) {
             rl.close();
+          } else if (inputQueue.length > 0) {
+            // Drain queued lines (e.g. from a multi-line paste) sequentially,
+            // echoing each so the transcript reads like normal input
+            const next = inputQueue.shift()!;
+            console.log(chalk.magenta('kubently> ') + next);
+            handleCommand(next);
           } else {
             // Ensure readline is active and ready for next input
             ensureReadlineActive();
           }
         }
       });
-    });
+    }
 
     // Hard exit on Ctrl+C: rl.close() alone leaves in-flight agent requests
     // (SSE/axios sockets) holding the event loop — the process lingers with the


### PR DESCRIPTION
Multi-line pastes fired a line event per row: first started an operation, the rest each triggered a 'please wait' warning interleaved with streamed output. Mid-operation lines now queue and run sequentially, echoed at a fresh prompt. Verified via PTY test: two pasted questions answered in order, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)