### PR TITLE
Agent cluster-selection prompt rules (chart 1.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased] - 2026-07-08
 
 ### Fixed (2026-07-09)
+- **Agent no longer asks "which cluster" on single-cluster deployments (chart 1.0.3)** —
+  the system prompt had no cluster-selection guidance, so the agent sometimes
+  offered namespace names (e.g. `kube-system`) as cluster candidates or asked to
+  disambiguate with only one cluster registered. New "Cluster Selection" prompt
+  section: use the sole registered cluster silently; namespaces are never
+  cluster candidates
 - **Multi-line paste no longer garbles the chat (CLI 2.3.5)** — lines arriving
   while an operation is in flight are queued and processed sequentially (echoed
   at a fresh prompt) instead of spamming "please wait" interleaved with the

--- a/deployment/helm/kubently/Chart.yaml
+++ b/deployment/helm/kubently/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubently
 description: Kubently - Troubleshooting Kubernetes Agentically
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "1.0.0"
 home: https://github.com/kubently/kubently
 maintainers:

--- a/deployment/helm/kubently/prompts/system.prompt.yaml
+++ b/deployment/helm/kubently/prompts/system.prompt.yaml
@@ -333,6 +333,13 @@ content: |-
 
   IMPORTANT: Always use systematic debugging approaches and provide clear, actionable solutions.
 
+  ## Cluster Selection
+
+  - Determine the target cluster from the conversation context or list_clusters BEFORE asking the user anything.
+  - If exactly ONE cluster is registered, ALWAYS use it silently — never ask the user to choose.
+  - Ask which cluster to use ONLY when multiple clusters are registered AND the user's question does not identify one.
+  - Namespaces are not clusters: tokens like `kube-system`, `kube-public`, `kube-node-lease`, and `default` are namespace names. NEVER treat them as candidate cluster names or offer them as cluster choices.
+
   # Code References
 
   When referencing specific Kubernetes resources or issues include the pattern `namespace/resource-type/resource-name` to allow the user to easily locate the resource.

--- a/prompts/system.prompt.yaml
+++ b/prompts/system.prompt.yaml
@@ -316,6 +316,13 @@ content: |-
 
   IMPORTANT: Always use systematic debugging approaches and provide clear, actionable solutions.
 
+  ## Cluster Selection
+
+  - Determine the target cluster from the conversation context or list_clusters BEFORE asking the user anything.
+  - If exactly ONE cluster is registered, ALWAYS use it silently — never ask the user to choose.
+  - Ask which cluster to use ONLY when multiple clusters are registered AND the user's question does not identify one.
+  - Namespaces are not clusters: tokens like `kube-system`, `kube-public`, `kube-node-lease`, and `default` are namespace names. NEVER treat them as candidate cluster names or offer them as cluster choices.
+
   # Code References
 
   When referencing specific Kubernetes resources or issues include the pattern `namespace/resource-type/resource-name` to allow the user to easily locate the resource.


### PR DESCRIPTION
## Summary
The system prompt had zero cluster-selection guidance, so the agent improvised — twice observed asking "Which cluster: X or kube?" on single-cluster deployments, treating the kube-system namespace as a cluster candidate. Added a Cluster Selection section (both prompt copies, chart + repo root): exactly one registered cluster → use it silently; namespace tokens are never cluster candidates; only ask when multiple clusters are registered and the question doesn't identify one.

## Verified live (kind-kubently, API restarted with new prompt configmap)
- "how many pods are in kube-system?" (previously: "Which cluster: kind-kubently or kube?") → **"8"**
- "is coredns healthy? yes or no" (previously: "Which cluster?") → **"Yes."**

🤖 Generated with [Claude Code](https://claude.com/claude-code)