### PR TITLE
Fix A2A multi-turn conversations: 'Received multiple non-consecutive system messages'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased] - 2026-07-08
 
+### Fixed (2026-07-17)
+- **Second message in a conversation no longer fails with "Received multiple
+  non-consecutive system messages"** — with a cluster selected, the A2A agent
+  injected the cluster context as a `system` message every turn; the checkpointer
+  replays it mid-history on turn 2+ and langchain-anthropic rejects it. Context
+  is now injected as a `user` message (legal anywhere in history). Affects all
+  multi-turn chats on v2.3.5.
+
 ### Fixed (2026-07-09)
 - **Agent no longer asks "which cluster" on single-cluster deployments (chart 1.0.3)** —
   the system prompt had no cluster-selection guidance, so the agent sometimes

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -508,12 +508,15 @@ class KubentlyAgent:
         # Store thread ID for tool call tracking
         self._current_thread_id = thread_id
 
-        # If cluster_id is specified, inject context at the start
+        # If cluster_id is specified, inject context at the start.
+        # Must be role "user", not "system": the checkpointer appends each turn's
+        # input to the thread history, so a per-turn system message lands mid-
+        # conversation on turn 2+ and langchain-anthropic rejects it with
+        # "Received multiple non-consecutive system messages".
         if cluster_id:
             logger.info(f"Cluster context provided: {cluster_id}")
-            # Prepend a system-style context to inform the agent
             cluster_context = {
-                "role": "system",
+                "role": "user",
                 "content": f"IMPORTANT CONTEXT: The user has selected cluster '{cluster_id}' for this session. "
                            f"Use this cluster_id in all execute_kubectl calls unless the user explicitly "
                            f"requests a different cluster. Do NOT ask which cluster to use - it has been specified."


### PR DESCRIPTION
## Problem

With a cluster selected (CLI passes `metadata.clusterId`), the **second message** in any A2A conversation always failed:

> I encountered an error while processing your request: Received multiple non-consecutive system messages.

Reproduced live on the published v2.3.5 image via `kubently install` → chat → any follow-up message.

## Root cause

`KubentlyAgent.run()` injected the cluster-selection context as a `role: "system"` message on **every** turn. The Redis checkpointer appends each turn's input to the thread history, so from turn 2 onward that system message lands mid-conversation:

```
[System(cluster ctx), Human, AI, ...tools..., System(cluster ctx), Human]
                                              ^^^^^^ rejected
```

langchain-anthropic's `_format_messages` hoists exactly one `SystemMessage` into the API's `system` field and raises `ValueError` on any second one. Turn 1 worked only because deepagents passes the main system prompt out-of-band, leaving a single `SystemMessage` in the list.

## Fix

Inject the cluster context as a `user`-role message instead — legal anywhere in the history. One-word change plus a comment explaining why it must stay that way.

## Verification

- **Formatter-level**: fed langchain-anthropic's `_format_messages` the exact turn-2 sequences — old shape reproduces the error, new shape formats cleanly (consecutive user messages are merged).
- **End-to-end on kind**: deployed via `deployment/scripts/kind-e2e.sh` (image built from this branch), then ran a two-turn A2A conversation on the same `contextId` with `clusterId` metadata. Turn 2 now responds normally and retains turn-1 context (thread memory intact).

Note: this bug ships in the published v2.3.5 image — any multi-turn chat with a cluster selected hits it, so worth a v2.3.6 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)