### PR TITLE
CLI evidence helper + configurable fleet fan-out cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] - 2026-08-15 (later)
+
+### Added
+- **Fleet fan-out cap is configurable** — `KUBENTLY_MAX_FLEET_CLUSTERS` env var
+  overrides the default 10-cluster cap per `execute_kubectl_multi` call (read at
+  call time; the cap bounds agent-context growth at ~4KB per cluster)
+- **`scripts/cli-evidence.sh`** — captures a real `kubently debug` session
+  (ANSI-stripped) and posts it as a PR verification-evidence comment via
+  `gh pr comment`; `DRY_RUN=1` prints instead of posting
+
 ## [Unreleased] - 2026-08-15
 
 ### Added

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -45,6 +45,7 @@
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
 | `A2A_EXTERNAL_URL` | - | No | External URL for A2A agent card (e.g., `https://api.example.com/a2a/`) |
+| `KUBENTLY_MAX_FLEET_CLUSTERS` | `10` | No | Max clusters per `execute_kubectl_multi` fan-out call (each cluster adds up to ~4KB to the agent context) |
 | `A2A_SERVER_DEBUG` | `false` | No | Enable A2A debug logging |
 
 ### LLM Configuration (for A2A)

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/fleet.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/fleet.py
@@ -5,10 +5,11 @@ without pulling the langchain/a2a stack that agent.py requires.
 """
 
 import asyncio
+import os
 
 import httpx
 
-MAX_FLEET_CLUSTERS = 10
+MAX_FLEET_CLUSTERS = 10  # default; override per-deploy with KUBENTLY_MAX_FLEET_CLUSTERS
 PER_CLUSTER_OUTPUT_CAP = 4000
 _TRUNCATION_NOTE = "\n[truncated — run execute_kubectl on {cluster_id} for full output]"
 
@@ -100,10 +101,11 @@ async def run_fleet_command(
         clusters = await _resolve_clusters(client, api_url, api_key, cluster_ids)
         if not clusters:
             return "No clusters are currently registered."
-        if len(clusters) > MAX_FLEET_CLUSTERS:
+        max_clusters = int(os.getenv("KUBENTLY_MAX_FLEET_CLUSTERS", str(MAX_FLEET_CLUSTERS)))
+        if len(clusters) > max_clusters:
             return (
                 f"Error: {len(clusters)} clusters requested; fleet fan-out is capped at "
-                f"{MAX_FLEET_CLUSTERS} per call. Narrow the cluster list and batch the query."
+                f"{max_clusters} per call. Narrow the cluster list and batch the query."
             )
         results = await asyncio.gather(
             *(_execute_on_cluster(client, api_url, api_key, c, payload_base) for c in clusters)

--- a/scripts/cli-evidence.sh
+++ b/scripts/cli-evidence.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Post a real `kubently debug` transcript as PR verification evidence.
+#
+# Usage:
+#   scripts/cli-evidence.sh <pr-number> "<question>"
+#   DRY_RUN=1 scripts/cli-evidence.sh - "<question>"   # print transcript, post nothing
+#
+# Env knobs: EVIDENCE_WAIT (agent wait secs, default 90), DRY_RUN.
+# Requires: kubently CLI configured against a live deployment; gh authed.
+set -euo pipefail
+
+PR="${1:?usage: cli-evidence.sh <pr-number> \"<question>\"}"
+QUESTION="${2:?usage: cli-evidence.sh <pr-number> \"<question>\"}"
+
+# Drive a real CLI session: ask, wait for the agent, exit. Strip ANSI/cursor codes.
+RAW=$( { printf '%s\n' "$QUESTION"; sleep "${EVIDENCE_WAIT:-90}"; printf 'exit\n'; } \
+  | kubently debug 2>&1 \
+  | perl -pe 's/\e\[[0-9;]*[A-Za-z]//g; s/\e\][^\a]*\a//g' | tr -d '\r' )
+
+# Trim the banner: keep from the echoed question onward.
+TRANSCRIPT=$(printf '%s\n' "$RAW" | awk -v q="$QUESTION" 'index($0, q){found=1} found')
+[ -n "$TRANSCRIPT" ] || { echo "ERROR: no transcript captured (is the API up?)" >&2; exit 1; }
+
+BODY=$(cat <<EOF
+**CLI verification evidence** — real \`kubently debug\` session against the live deployment:
+
+\`\`\`
+$TRANSCRIPT
+\`\`\`
+EOF
+)
+
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  printf '%s\n' "$BODY"
+else
+  gh pr comment "$PR" --body "$BODY"
+fi

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -145,6 +145,19 @@ async def test_run_fleet_command_cap():
     assert "capped at" in out
 
 
+async def test_run_fleet_command_cap_env_override(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_MAX_FLEET_CLUSTERS", "2")
+    client = _mock_client(
+        ["a", "b", "c"],
+        {c: httpx.Response(200, json={"output": "ok"}) for c in ["a", "b", "c"]},
+    )
+    out = await run_fleet_command(API, KEY, ["a", "b", "c"], PAYLOAD, client=client)
+    assert "capped at 2" in out
+    monkeypatch.setenv("KUBENTLY_MAX_FLEET_CLUSTERS", "3")
+    out = await run_fleet_command(API, KEY, ["a", "b", "c"], PAYLOAD, client=client)
+    assert "=== cluster: c ===" in out
+
+
 async def test_run_fleet_command_no_clusters():
     client = _mock_client([], {})
     out = await run_fleet_command(API, KEY, ["all"], PAYLOAD, client=client)


### PR DESCRIPTION
## Summary
- `scripts/cli-evidence.sh <pr> "<question>"`: drives a real `kubently debug` session (piped stdin), strips ANSI, posts the transcript as a PR comment — makes the verification-evidence pattern from #59 one command. `DRY_RUN=1` prints instead of posting
- `KUBENTLY_MAX_FLEET_CLUSTERS` env var makes the `execute_kubectl_multi` fan-out cap configurable (default 10, read at call time); documented in ENVIRONMENT_VARIABLES.md — the cap exists to bound agent-context growth (~4KB/cluster), so larger fleets can raise it deliberately

## Test Plan
- [x] New unit test: cap env override (capped at 2 → error; raised to 3 → full results); fleet suite 15 passed
- [x] Script dry-run against the live kind deployment captured a clean transcript
- [x] Evidence comment below posted by the script itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)