### PR TITLE
Scheduled fleet health digest (#54), output caps (#58), and two correctness fixes the E2E caught

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@
   scheduled path. Tuning the digest wording needs no `helm upgrade`
 
 ### Fixed
+- **`SLACK_WEBHOOK_URL` can be sourced from a secret, and no longer lands in a
+  ConfigMap** — the webhook URL is a credential (anyone holding it can post to
+  your channel), but it was only settable as an `api.env` values string, which
+  the chart also rendered verbatim into `kubently-api-config` where any
+  `get configmap` reader could see it. New `api.slackWebhook.existingSecret` /
+  `secretKey` sources it from a Kubernetes secret and takes precedence over the
+  values field; either way it is now excluded from the ConfigMap
 - **Alertmanager diagnoses can no longer vanish before they post** — the webhook
   fired `asyncio.create_task(...)` per alert without keeping a reference, and
   asyncio holds only *weak* references to tasks, so a diagnosis running for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,72 @@
 ## [Unreleased] - 2026-08-15 (later)
 
 ### Added
+- **Scheduled fleet health digest (#54, chart 1.0.5)** — a Helm CronJob POSTs
+  `/webhooks/fleet-report` on a schedule; the agent sweeps every registered
+  cluster with fleet fan-out and posts one Slack digest, healthy clusters
+  collapsed to a single line. Off by default (`fleetReport.enabled`). Reuses the
+  Alertmanager path's `SLACK_WEBHOOK_URL` and lazy-agent import, so the API still
+  boots without the a2a stack
+- **The digest query is user-owned** — loaded through the existing
+  `get_prompt()` mechanism as `prompts/fleet_report.prompt.yaml`, so it is
+  customizable at three levels: `fleetReport.query` in values (rendered into the
+  prompt ConfigMap), `KUBENTLY_FLEET_REPORT_PROMPT_FILE` for a fully custom file,
+  or a `query` field in the request body for a single call
+- **Run it once, three ways** — `{"dry_run": true}` runs the digest
+  synchronously, returns it to the caller and posts *nothing* (no
+  `SLACK_WEBHOOK_URL` needed); POST with no body posts once for real; and
+  `kubectl create job --from=cronjob/kubently-fleet-report` exercises the actual
+  scheduled path. Tuning the digest wording needs no `helm upgrade`
+
+### Fixed
+- **Alertmanager diagnoses can no longer vanish before they post** — the webhook
+  fired `asyncio.create_task(...)` per alert without keeping a reference, and
+  asyncio holds only *weak* references to tasks, so a diagnosis running for
+  minutes could be garbage-collected mid-flight. The symptom was the worst kind:
+  the Slack message simply never arrives, with nothing in the log. Tasks are now
+  held in a module-level set and released by a done-callback (same pattern as the
+  fleet digest endpoint)
+- **An unreachable cluster no longer reads as a healthy one** — `/debug/execute`
+  answers **HTTP 200** with `{"status": "timeout", "output": null}` when no
+  executor picks the command up, and both the fan-out and single-cluster paths
+  trusted the status code alone. The null output then collapsed to
+  `(no matching resources)`, so a cluster that was down was reported to the agent
+  as a cluster with nothing wrong — the worst failure mode a fleet health tool
+  has. Both paths now check the response body's `status`/`error` and surface
+  `ERROR: Command execution timeout`; the digest renders it as
+  "Cluster unreachable — health unknown". Found by E2E against a stale cluster
+  registration
+- **The agent no longer hunts for broken pods with a filter that cannot match
+  them** — a crashlooping pod has `status.phase=Running`, so
+  `--field-selector status.phase!=Running,status.phase!=Succeeded` silently skips
+  it; it only catches Pending-phase problems like ImagePullBackOff. That guidance
+  appeared in **9 places** — the system prompt's token-efficiency rules, its
+  "Finding Problematic Pods" examples (whose `custom-columns` example printed
+  `.status.phase` and so lied the same way), its Fleet Queries section, and the
+  `execute_kubectl` / `execute_kubectl_multi` docstrings. All now steer to
+  `-o wide` and container-level readiness/restarts/waiting-reason, and name the
+  trap explicitly. `--field-selector status.phase=Pending` is still recommended
+  for scheduling problems, where phase is the right signal. In E2E this took a
+  fleet sweep from 1 problem found to 4, surfacing pods with 910 and 1258
+  restarts that had been invisible
+- **The two copies of the system prompt no longer drift** — `prompts/` (used in
+  local dev and baked into the image) had fallen 49 lines behind
+  `deployment/helm/kubently/prompts/` (mounted as a ConfigMap, so it is what
+  actually runs in a cluster). Local dev was being told to call a `todo_write`
+  tool that had been renamed `write_todos`, and was missing the entire
+  "SYMPTOM vs ROOT CAUSE" section. The root copy is now the chart copy, and
+  `tests/test_prompt_guidance.py` fails the build if they diverge again or if the
+  phase-filter guidance returns
+- **Single-cluster `execute_kubectl` output is now capped (#58)** — fleet fan-out
+  truncated per-cluster output at 4KB, but the single-cluster path had no cap
+  anywhere (executor → `/debug/execute` → tool result), so one `get pods -A -o json`
+  on a busy cluster could inject tens of KB into the agent's context — and the
+  checkpointer replays full history every turn, so the cost compounded across the
+  conversation. Results are now hard-capped at 20,000 chars
+  (`KUBENTLY_MAX_OUTPUT_CHARS` to override) with a hint telling the agent how to
+  re-run narrowed. Error bodies are capped too
+
+### Added
 - **Fleet fan-out cap is configurable** — `KUBENTLY_MAX_FLEET_CLUSTERS` env var
   overrides the default 10-cluster cap per `execute_kubectl_multi` call (read at
   call time; the cap bounds agent-context growth at ~4KB per cluster)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,43 @@ receivers:
 Each firing alert is diagnosed by the agent and the result is posted to Slack —
 the bot often explains the root cause before you've opened your laptop.
 
+### Scheduled fleet health digest
+
+Alerts are reactive. A digest sweeps *every* registered cluster on a schedule and
+posts one summary to the same Slack webhook — healthy clusters collapse to a
+single line, so what's left is what needs you.
+
+```yaml
+fleetReport:
+  enabled: true
+  schedule: "0 13 * * 1-5"   # weekday mornings
+```
+
+Preview it before you schedule it — `dry_run` returns the digest and posts
+nothing:
+
+```bash
+curl -X POST https://<your-kubently-host>/webhooks/fleet-report \
+  -H "X-API-Key: <your-api-key>" -H 'Content-Type: application/json' \
+  -d '{"dry_run": true}'
+```
+
+The digest question is yours to change. Pass `query` in that request to try one
+immediately, then keep the wording you like via `fleetReport.query` in values:
+
+```yaml
+fleetReport:
+  query: |-
+    Check every cluster for pods restarting more than 5 times and for PVCs above
+    85% usage. One line per healthy cluster. No preamble.
+```
+
+To run the real scheduled path once — image, secrets, in-cluster URL and all:
+
+```bash
+kubectl create job --from=cronjob/kubently-fleet-report fleet-report-test -n kubently
+```
+
 **📖 See [QUICK_START.md](docs/QUICK_START.md) for full quick-start guide**
 
 **📚 See [GETTING_STARTED.md](docs/GETTING_STARTED.md) for production deployment**

--- a/deployment/helm/kubently/Chart.yaml
+++ b/deployment/helm/kubently/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubently
 description: Kubently - Troubleshooting Kubernetes Agentically
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "1.0.0"
 home: https://github.com/kubently/kubently
 maintainers:

--- a/deployment/helm/kubently/prompts/fleet_report.prompt.yaml
+++ b/deployment/helm/kubently/prompts/fleet_report.prompt.yaml
@@ -1,0 +1,36 @@
+version: 1
+name: kubently_fleet_health_digest
+# NOTE: `role` must literally be "system" (PromptSpec validator in
+# kubently/modules/config/prompts.py). The role passed to get_prompt()
+# ("fleet_report") only selects the KUBENTLY_FLEET_REPORT_PROMPT_FILE env var.
+role: system
+metadata:
+  owner: kubently
+  description: Query driving the scheduled fleet health digest posted to Slack
+variables: []
+content: |-
+  Check the health of every registered cluster.
+
+  For each cluster, report:
+  - pods whose containers are not ready, or are restarting, or are in a waiting
+    state such as CrashLoopBackOff, ImagePullBackOff, ErrImagePull or
+    CreateContainerConfigError. Include the restart count and the reason.
+  - Warning events from the last hour
+  - nodes that are not Ready
+
+  IMPORTANT: do NOT find failing pods with
+  `--field-selector status.phase!=Running,status.phase!=Succeeded`. A pod stuck
+  in CrashLoopBackOff has `status.phase=Running`, so that filter silently misses
+  the most common failure there is. Select on readiness and restarts instead —
+  for example `get pods -A -o wide` and look at the READY and STATUS columns, or
+  `-o custom-columns` over `.status.containerStatuses[*].ready` and
+  `.restartCount`.
+
+  Format the answer for Slack:
+  - one short section per cluster, cluster name first
+  - a cluster with nothing wrong gets a single line saying it is healthy
+  - no preamble, no closing summary
+  - if the entire fleet is healthy, say so in one line and stop
+
+  Prioritise problems that look new or are getting worse. Do not suggest fixes
+  unless the cause is obvious from what you already gathered.

--- a/deployment/helm/kubently/prompts/fleet_report.prompt.yaml
+++ b/deployment/helm/kubently/prompts/fleet_report.prompt.yaml
@@ -26,9 +26,19 @@ content: |-
   `-o custom-columns` over `.status.containerStatuses[*].ready` and
   `.restartCount`.
 
-  Format the answer for Slack:
-  - one short section per cluster, cluster name first
-  - a cluster with nothing wrong gets a single line saying it is healthy
+  Format the answer as Slack mrkdwn. This is NOT markdown — these render as
+  literal characters and must never appear:
+  - tables (`| col | col |`) — Slack has no table support; use one line per pod
+  - `**double asterisk**` for bold — Slack bold is `*single asterisk*`
+  - `---` or `===` rules, and `#` headings — Slack renders none of them
+  - `[text](url)` links — Slack uses `<url|text>`
+
+  Use only: `*bold*`, `_italic_`, `` `code` ``, ``` ```blocks``` ```, and `•`
+  or `-` bullets. Structure:
+  - one short section per cluster, `*cluster-name*` on its own line first
+  - one line per problem underneath, starting with `•`
+  - a cluster with nothing wrong gets a single line: `*name* — healthy`
+  - a blank line between clusters (this is the separator; do not draw a rule)
   - no preamble, no closing summary
   - if the entire fleet is healthy, say so in one line and stop
 

--- a/deployment/helm/kubently/prompts/system.prompt.yaml
+++ b/deployment/helm/kubently/prompts/system.prompt.yaml
@@ -85,7 +85,8 @@ content: |-
   - IMPORTANT: Always start with kubectl get events to understand recent cluster activity
   - **TOKEN EFFICIENCY FIRST**: Minimize output tokens by using targeted kubectl flags
   - Use `-o custom-columns` or `--field-selector` to retrieve only needed fields
-  - Prefer `--field-selector` to filter resources (e.g., `status.phase!=Running` for problematic pods)
+  - Prefer targeted output (`-o wide`, `-o custom-columns`, `-l <selector>`) over dumping full objects
+  - CRITICAL: never hunt for broken pods with `--field-selector status.phase!=Running`. A pod stuck in CrashLoopBackOff has `status.phase=Running`, so that filter hides the most common failure there is. Filter on readiness, restart count, or the container waiting reason instead. (`--field-selector status.phase=Pending` is still correct for scheduling problems specifically.)
   - Use `-o json` ONLY when you need to parse complex nested data programmatically
   - For simple status queries, use default output, wide, or custom-columns
   - Check pod status and describe resources for detailed information
@@ -179,12 +180,23 @@ content: |-
   # Token-Efficient kubectl Patterns
 
   ## Finding Problematic Pods (TOKEN EFFICIENT)
-  ```bash
-  # Use field selectors to filter - returns only problematic pods
-  kubectl get pods -A --field-selector status.phase!=Running,status.phase!=Succeeded
 
-  # Custom columns for specific data only
-  kubectl get pods -A -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,RESTARTS:.status.containerStatuses[0].restartCount
+  CRITICAL: `status.phase` is NOT a health signal. A pod whose container is stuck in
+  CrashLoopBackOff still reports `phase=Running`, so BOTH
+  `--field-selector status.phase!=Running` and `-o custom-columns=STATUS:.status.phase`
+  will report a crash-looping pod as fine. Use readiness, restart count, and the
+  container waiting reason instead.
+
+  ```bash
+  # BEST first call: READY shows 0/1 and STATUS shows the real reason
+  # (CrashLoopBackOff, ImagePullBackOff, Error). Cheap, and it catches everything.
+  kubectl get pods -A -o wide
+
+  # Container-level truth: readiness, restarts, and why it is waiting
+  kubectl get pods -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,READY:.status.containerStatuses[*].ready,RESTARTS:.status.containerStatuses[*].restartCount,REASON:.status.containerStatuses[*].state.waiting.reason
+
+  # Scheduling problems specifically - Pending IS a real phase, so this one is correct
+  kubectl get pods -A --field-selector status.phase=Pending
 
   # Default output with grep (tool can parse this easily)
   kubectl get pods -A | grep -v Running
@@ -345,7 +357,7 @@ content: |-
 
   - When the user asks about MULTIPLE clusters or the whole fleet ("across all clusters", "which clusters have X", "fleet-wide"), use execute_kubectl_multi with cluster_ids=["all"] (or the named subset) instead of sequential execute_kubectl calls.
   - Fleet results are a triage view: per-cluster output is truncated. Drill into a specific cluster with execute_kubectl when you need detail.
-  - Keep fleet commands filtered and token-efficient (e.g. --field-selector status.phase!=Running); never dump unfiltered resources from every cluster.
+  - Keep fleet commands filtered and token-efficient (e.g. `-o wide`, `-o custom-columns`, `-l <selector>`); never dump unfiltered resources from every cluster. Do NOT use `--field-selector status.phase!=Running` for fleet health sweeps — CrashLoopBackOff pods have `phase=Running`, so a whole cluster can look healthy while pods crash on a loop.
   - For single-cluster questions keep using execute_kubectl.
 
   # Code References

--- a/deployment/helm/kubently/templates/api-configmap.yaml
+++ b/deployment/helm/kubently/templates/api-configmap.yaml
@@ -8,6 +8,11 @@ metadata:
     app.kubernetes.io/component: api
 data:
   {{- range $key, $value := .Values.api.env }}
+  {{- /* SLACK_WEBHOOK_URL is a credential; a ConfigMap is world-readable to
+         anyone with `get configmap`. It reaches the pod via the Deployment's
+         env (from api.slackWebhook.existingSecret, ideally). */}}
+  {{- if ne $key "SLACK_WEBHOOK_URL" }}
   {{ $key }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/deployment/helm/kubently/templates/api-deployment.yaml
+++ b/deployment/helm/kubently/templates/api-deployment.yaml
@@ -172,6 +172,8 @@ spec:
         {{- end }}
         - name: KUBENTLY_A2A_PROMPT_FILE
           value: "/etc/kubently/prompts/system.prompt.yaml"
+        - name: KUBENTLY_FLEET_REPORT_PROMPT_FILE
+          value: "/etc/kubently/prompts/fleet_report.prompt.yaml"
         volumeMounts:
         - name: prompt-config
           mountPath: /etc/kubently/prompts

--- a/deployment/helm/kubently/templates/api-deployment.yaml
+++ b/deployment/helm/kubently/templates/api-deployment.yaml
@@ -167,8 +167,22 @@ spec:
               key: LANGSMITH_API_KEY
               optional: true
         {{- range $key, $value := .Values.api.env }}
+        {{- if ne $key "SLACK_WEBHOOK_URL" }}
         - name: {{ $key }}
           value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        {{- /* A webhook URL is a credential: prefer a secret, and never let a
+               values-file copy silently win over one. */}}
+        {{- if .Values.api.slackWebhook.existingSecret }}
+        - name: SLACK_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.api.slackWebhook.existingSecret }}
+              key: {{ .Values.api.slackWebhook.secretKey }}
+        {{- else if .Values.api.env.SLACK_WEBHOOK_URL }}
+        - name: SLACK_WEBHOOK_URL
+          value: {{ .Values.api.env.SLACK_WEBHOOK_URL | quote }}
         {{- end }}
         - name: KUBENTLY_A2A_PROMPT_FILE
           value: "/etc/kubently/prompts/system.prompt.yaml"

--- a/deployment/helm/kubently/templates/api-prompt-configmap.yaml
+++ b/deployment/helm/kubently/templates/api-prompt-configmap.yaml
@@ -9,4 +9,18 @@ metadata:
 data:
   system.prompt.yaml: |
 {{ .Files.Get "prompts/system.prompt.yaml" | indent 4 }}
+  fleet_report.prompt.yaml: |
+{{- if .Values.fleetReport.query }}
+    version: 1
+    name: kubently_fleet_health_digest
+    role: system
+    metadata:
+      owner: kubently
+      description: Fleet health digest query (overridden via fleetReport.query)
+    variables: []
+    content: |-
+{{ .Values.fleetReport.query | indent 6 }}
+{{- else }}
+{{ .Files.Get "prompts/fleet_report.prompt.yaml" | indent 4 }}
+{{- end }}
 {{- end }}

--- a/deployment/helm/kubently/templates/fleet-report-cronjob.yaml
+++ b/deployment/helm/kubently/templates/fleet-report-cronjob.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.api.enabled .Values.fleetReport.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "kubently.fullname" . }}-fleet-report
+  labels:
+    {{- include "kubently.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-report
+spec:
+  schedule: {{ .Values.fleetReport.schedule | quote }}
+  suspend: {{ .Values.fleetReport.suspend }}
+  # A digest takes minutes; never let a slow run stack on the next schedule.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # The endpoint ACKs 202 and diagnoses in the background, so this Job only
+      # needs to land the POST.
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            {{- include "kubently.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: fleet-report
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: trigger
+            # Reuses the API image (already pulled on the node, ships httpx)
+            # rather than adding a curl image to the deployment's pull set.
+            image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+            env:
+            - name: API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.existingSecret | default (printf "%s-api-keys" (include "kubently.fullname" .)) }}
+                  key: keys
+            - name: KUBENTLY_API_URL
+              value: "http://{{ include "kubently.fullname" . }}-api:{{ .Values.api.service.port }}"
+            command:
+            - python
+            - -c
+            - |
+              import os, sys, httpx
+              # API_KEYS holds every configured key (comma- or newline-separated);
+              # any one of them authenticates this call.
+              key = next(k.strip() for k in os.environ["API_KEYS"].replace(",", "\n").split("\n") if k.strip())
+              key = key.split(":")[-1]  # tolerate the "service:key" form
+              r = httpx.post(
+                  f"{os.environ['KUBENTLY_API_URL']}/webhooks/fleet-report",
+                  headers={"X-API-Key": key},
+                  timeout=30,
+              )
+              print(r.status_code, r.text)
+              sys.exit(0 if r.status_code == 202 else 1)
+{{- end }}

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -44,10 +44,19 @@ api:
   # Example: apiKeys: ["abc123...", "def456..."]
   apiKeys: []
   
+  # Slack incoming-webhook URL — enables both proactive paths:
+  # /webhooks/alertmanager -> Slack diagnosis, and the fleetReport digest below.
+  #
+  # The URL is a credential: anyone holding it can post to your channel, so
+  # create a secret rather than putting it in a values file.
+  #   kubectl create secret generic kubently-slack \
+  #     --from-literal=url='https://hooks.slack.com/services/...' -n kubently
+  slackWebhook:
+    existingSecret: ""   # e.g. "kubently-slack" (takes precedence over api.env)
+    secretKey: "url"
+
   env:
     LOG_LEVEL: "INFO"
-    # SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/..."  # enables both proactive paths:
-    #   /webhooks/alertmanager -> Slack diagnosis, and the fleetReport digest below
     MAX_COMMANDS_PER_FETCH: "10"
     COMMAND_TIMEOUT: "30"
     SESSION_TTL: "300"

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -46,12 +46,39 @@ api:
   
   env:
     LOG_LEVEL: "INFO"
-    # SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/..."  # enables /webhooks/alertmanager -> Slack diagnosis
+    # SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/..."  # enables both proactive paths:
+    #   /webhooks/alertmanager -> Slack diagnosis, and the fleetReport digest below
     MAX_COMMANDS_PER_FETCH: "10"
     COMMAND_TIMEOUT: "30"
     SESSION_TTL: "300"
     PORT: "8080"
     API_PORT: "8080"
+
+# ============================================================================
+# Scheduled Fleet Health Digest
+# ============================================================================
+# A CronJob POSTs /webhooks/fleet-report on a schedule; the agent sweeps every
+# registered cluster and posts one digest to SLACK_WEBHOOK_URL (set above).
+#
+# Try it before you schedule it — neither needs a helm upgrade:
+#   # preview the digest, post nothing:
+#   curl -X POST $API/webhooks/fleet-report -H "X-API-Key: $KEY" \
+#     -H 'Content-Type: application/json' -d '{"dry_run": true}'
+#   # run the real scheduled path once:
+#   kubectl create job --from=cronjob/kubently-fleet-report fleet-report-test -n kubently
+fleetReport:
+  enabled: false
+  # Create the CronJob but never fire it on schedule (manual triggering only).
+  suspend: false
+  # Weekday mornings. Interpreted in the cluster's timezone (UTC by default).
+  schedule: "0 13 * * 1-5"
+  # Override the digest query. Empty = the shipped prompts/fleet_report.prompt.yaml.
+  # Per-call overrides for iterating: POST {"query": "...", "dry_run": true}.
+  # Example:
+  #   query: |-
+  #     Check every cluster for pods restarting more than 5 times and for PVCs
+  #     above 85% usage. One line per healthy cluster. No preamble.
+  query: ""
 
 # ============================================================================
 # Executor Configuration

--- a/docs/superpowers/specs/2026-08-15-fleet-health-digest-design.md
+++ b/docs/superpowers/specs/2026-08-15-fleet-health-digest-design.md
@@ -1,0 +1,237 @@
+# Scheduled Fleet Health Digest Design
+
+**Date:** 2026-08-15
+**Status:** Draft
+**Issue:** #54
+**Depends on:** #53 (fleet fan-out, shipped)
+
+## Problem
+
+The proactive path is reactive only: Alertmanager fires → `/webhooks/alertmanager`
+→ agent diagnosis → Slack. Nothing tells an operator about a fleet that is quietly
+degrading — a cluster where pods have been `CrashLoopBackOff` for a day but no
+alert rule covers it, or a cluster that stopped reporting entirely.
+
+Fleet fan-out (#53) made "what is broken across every cluster" a single agent call.
+Nothing calls it on a schedule.
+
+## Approach
+
+Three pieces, each reusing something that already exists.
+
+### 1. Trigger: Helm CronJob → HTTP endpoint
+
+`CronJob` in the chart POSTs to a new endpoint on the API Service. Kubernetes is
+already the scheduler; an in-process scheduler would mean a new dependency
+(APScheduler et al.) **and** leader election, because the API runs multiple
+replicas behind a Service and every replica would otherwise fire its own digest.
+
+The endpoint is independently useful: `curl -X POST .../webhooks/fleet-report`
+runs the digest on demand, which is also how the E2E test drives it.
+
+CronJob uses the API image (already pulled on the node, ships `httpx`) rather
+than adding a `curl` image to the deployment's pull set.
+
+### 2. Endpoint: `POST /webhooks/fleet-report`
+
+Lives in `kubently/modules/webhook/` (new `fleet_report.py`), registered by the
+same router factory pattern as `alertmanager.py`:
+
+- `Depends(verify_api_key)` — same API-key auth, no new auth path
+- Optional JSON body, both fields absent by default:
+  `{"query": "<override>", "dry_run": true}`
+- 503 if `SLACK_WEBHOOK_URL` is unset — **except** under `dry_run`, which never
+  posts and so has no such precondition
+- **Scheduled mode** (no `dry_run`): ACKs **202 immediately**, diagnosis runs in
+  `asyncio.create_task`. A fleet sweep takes minutes and a CronJob holding an
+  HTTP connection that long is a timeout waiting to happen. The CronJob's success
+  means "digest started"; failures surface in API logs and in the absence of a
+  Slack post
+- **Dry-run mode**: runs **synchronously** and returns `200` with
+  `{"query": ..., "answer": ...}` — the caller is a human who wants to read the
+  digest, and waiting is the entire point. Nothing is posted to Slack
+- The heavy `KubentlyAgent` import stays inside the background task (and inside
+  the dry-run handler), preserving the property that the API boots without the
+  a2a stack
+
+### 3. The scan: one `ask_kubently` call, not a scan engine
+
+The digest asks the agent one fleet-health question and posts the answer. No
+per-cluster orchestration code: the agent already has `execute_kubectl_multi` and
+the "Fleet Queries" prompt section that steers it there, and fan-out already
+collapses empty per-cluster results to one line — so a healthy fleet is cheap in
+tokens before the model ever sees it.
+
+#### The query is user-owned, not hardcoded
+
+Digest wording is exactly the thing every team wants different — one shop cares
+about PVC pressure, another about cert expiry, another wants it in their own
+language. The query is therefore a **prompt file**, loaded through the config
+module's existing `get_prompt()` (`kubently/modules/config/prompts.py`), not a
+string constant:
+
+```python
+get_prompt(role="fleet_report", default_filename="fleet_report.prompt.yaml")
+```
+
+That mechanism already gives us, for free, everything customization needs:
+
+| Layer | How | For |
+|---|---|---|
+| Ship a sane default | `prompts/fleet_report.prompt.yaml`, mounted via the chart's existing prompt ConfigMap pattern | everyone |
+| Edit the wording | `fleetReport.query` in `values.yaml` → rendered into that ConfigMap's `content` | most users |
+| Full control | `KUBENTLY_FLEET_REPORT_PROMPT_FILE` → any mounted file, with the spec's variable substitution | power users |
+| Try a wording *right now* | `query` in the POST body | iterating |
+
+The last row is the one that makes the other three usable: you iterate with
+`dry_run` + `query` against a live fleet until the digest reads right, then paste
+the winner into `values.yaml`. No `helm upgrade` per attempt.
+
+Note the spec format's `role` field must literally be `system` (validator in
+`prompts.py:25`); the `role="fleet_report"` argument only selects the env-var
+name. Worth a comment in the shipped file so nobody "fixes" it.
+
+Default content, roughly:
+
+```
+Check the health of every registered cluster. For each one, report pods that are
+not Running or Succeeded and any recent Warning events.
+Format the answer for Slack: one short section per cluster; a cluster with
+nothing wrong gets a single line saying it is healthy.
+If the whole fleet is healthy, say so in one line and stop.
+```
+
+**Trade-off, stated plainly:** one agent call for the whole fleet produces a
+shallower digest than N per-cluster investigations would. It is also ~1/N the LLM
+cost and finishes in one agent run instead of N. Start here; if digests read as
+too shallow, the upgrade path is a second pass that re-asks per cluster only for
+clusters the first pass flagged. That is a prompt-and-loop change, not a
+re-architecture.
+
+**Known ceiling:** fan-out is capped at 10 clusters per call
+(`KUBENTLY_MAX_FLEET_CLUSTERS`). Above the cap the agent is told to batch, and
+whether it reliably does so across a 30-cluster fleet is exactly what the first
+real deployment will tell us. Documented, not pre-solved.
+
+### Slack post
+
+Reuses the alert path's shape — one `httpx.POST` to `SLACK_WEBHOOK_URL`:
+
+```
+:satellite: *Kubently fleet health digest*
+
+<agent answer>
+```
+
+One message, not one per cluster: a daily digest that pages five separate
+messages into a channel is how the feature gets muted.
+
+### 4. Running it once
+
+Nobody should have to wait until 13:00 Monday to find out whether their digest
+works, and nobody should have to point a test run at a real Slack channel. Three
+ways in, no new code beyond the `dry_run` flag:
+
+**Preview it, post nothing** — the loop you actually use while tuning wording:
+
+```bash
+curl -X POST http://localhost:8080/webhooks/fleet-report \
+  -H "X-API-Key: $KUBENTLY_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"dry_run": true, "query": "List every cluster with a pod restarting more than 5 times."}'
+```
+
+Returns the rendered digest as JSON. No Slack, no schedule, no redeploy.
+
+**Post it for real, once** — proves the Slack wiring end to end:
+
+```bash
+curl -X POST http://localhost:8080/webhooks/fleet-report -H "X-API-Key: $KUBENTLY_API_KEY"
+```
+
+**Fire the actual CronJob once** — proves the *scheduled* path (image, service
+account, in-cluster URL, API key mount), which the two curls above bypass:
+
+```bash
+kubectl create job --from=cronjob/kubently-fleet-report fleet-report-test -n kubently
+```
+
+That last one is why the trigger is a CronJob rather than an in-process
+scheduler: `--from=cronjob` is a free, native one-shot of the real thing. An
+in-process scheduler would have needed us to build a manual-trigger path
+ourselves.
+
+Pairs with `fleetReport.suspend` below: install with `enabled: true,
+suspend: true` to get the CronJob object without a schedule, trigger it by hand
+until happy, then unsuspend.
+
+## Helm
+
+```yaml
+fleetReport:
+  enabled: false            # opt-in
+  suspend: false            # create the CronJob but don't run it (manual triggering only)
+  schedule: "0 13 * * 1-5"  # weekday mornings; UTC unless the cluster says otherwise
+  query: ""                 # override the shipped digest prompt; empty = use prompts/fleet_report.prompt.yaml
+```
+
+Renders `templates/fleet-report-cronjob.yaml` only when `fleetReport.enabled`
+**and** an API key exist. `SLACK_WEBHOOK_URL` is the existing `values.yaml:49`
+env var — unchanged, and now serves both proactive paths.
+
+`fleetReport.query`, when non-empty, replaces the `content:` of the prompt
+ConfigMap entry; the API mounts it at `/etc/kubently/prompts/` where `get_prompt`
+already looks. Changing it is a `helm upgrade` + pod restart, same as any prompt
+change today.
+
+`concurrencyPolicy: Forbid` and `successfulJobsHistoryLimit: 1` so a slow digest
+never stacks on the next schedule.
+
+## Not doing
+
+- **No per-cluster Slack threading / message-per-cluster.** One message.
+- **No digest state in Redis** (no "changed since yesterday" diffing). It is a
+  snapshot. Diffing needs a retention story and an "is this the same problem"
+  comparison; neither is worth it before anyone has read a digest.
+- **No new API surface for scan results.** The digest exists in Slack and in the
+  audit log (#55 will surface the latter); it is not a queryable object. Dry-run
+  returns its answer to the caller and keeps nothing.
+- **No per-cluster query overrides.** One query for the fleet. Per-cluster
+  wording means a map in values and a merge order to explain; if someone needs
+  cluster-specific checks, two CronJobs with different queries and explicit
+  cluster lists already does it.
+- **No dedup against Alertmanager.** A firing alert and the digest may both
+  mention the same pod. Fixing that means correlating alert identity across two
+  async paths — revisit if it actually annoys someone.
+
+## Testing
+
+- **Unit** (`tests/test_fleet_report.py`, import-light like `test_fleet.py`):
+  Slack payload shape, the `SLACK_WEBHOOK_URL`-unset 503, that the endpoint
+  returns 202 without awaiting diagnosis (mocked agent), and query resolution
+  precedence — body `query` > `fleet_report.prompt.yaml` > built-in fallback.
+- **kind E2E**: induce a failure (a deliberately broken Deployment), POST the
+  endpoint, assert the Slack payload names the failing workload and its cluster.
+  Mock the Slack endpoint with a local receiver rather than posting to a real
+  workspace.
+- **Dry-run E2E**: same induced failure, `dry_run: true`, assert a 200 with the
+  answer **and** that the mock Slack receiver got nothing — a dry run that
+  quietly posts is the one bug in this feature that burns a user's real channel.
+- **Healthy-fleet case**: same E2E on a clean cluster asserts the short all-clear,
+  which is the regression test for "the digest got chatty."
+- **Scheduled path**: `kubectl create job --from=cronjob/...` in the kind E2E, so
+  the CronJob's own wiring (image, API key mount, in-cluster URL) is covered and
+  not just the endpoint.
+
+## Acceptance criteria
+
+From #54:
+
+- [ ] Digest posts on schedule against a kind cluster with an induced failure
+- [ ] Healthy-only fleet produces a short all-clear message
+
+Added:
+
+- [ ] `dry_run: true` returns the digest and posts nothing to Slack
+- [ ] A `query` in the request body overrides the configured prompt for that call
+- [ ] `fleetReport.query` in values changes the digest without code changes
+- [ ] `kubectl create job --from=cronjob/kubently-fleet-report` runs a real digest

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -193,6 +193,16 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Failed to mount alertmanager webhook: {e}")
 
+    # Proactive mode: scheduled fleet health digest -> Slack. Same lazy-agent
+    # pattern; triggered by the chart's CronJob or by hand (dry_run to preview).
+    try:
+        from kubently.modules.webhook import create_fleet_report_router
+
+        app.include_router(create_fleet_report_router(verify_dual_auth, redis_client=redis_client))
+        logger.info("Fleet report endpoint mounted at /webhooks/fleet-report")
+    except Exception as e:
+        logger.warning(f"Failed to mount fleet report endpoint: {e}")
+
     logger.info("Kubently API started successfully")
 
     yield

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -11,6 +11,7 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.runnables.config import RunnableConfig
 from langgraph.checkpoint.redis.aio import AsyncRedisSaver
 
+from .fleet import cap_output
 from .tool_call_interceptor import get_tool_call_interceptor
 
 # Configure logging
@@ -326,7 +327,10 @@ class KubentlyAgent:
 
             TOKEN EFFICIENCY FIRST:
             - Minimize output tokens by using targeted kubectl flags
-            - Use "--field-selector" to filter resources (e.g., "status.phase!=Running")
+            - Use "--field-selector" for genuine field lookups (e.g., "status.phase=Pending"
+              for scheduling problems, "involvedObject.name=<pod>" for events)
+            - NEVER use "--field-selector status.phase!=Running" to find broken pods: a
+              CrashLoopBackOff pod reports phase=Running, so that filter hides it
             - Use "-o custom-columns" to retrieve only needed fields
             - Use "-o wide" for quick overview with essential columns
             - Use "describe" instead of "-o json" for comprehensive resource details
@@ -334,8 +338,9 @@ class KubentlyAgent:
             - Default output is usually sufficient and most token-efficient
 
             TOKEN-EFFICIENT EXAMPLES:
-            - Find problematic pods: "get pods -A --field-selector status.phase!=Running,status.phase!=Succeeded"
-            - Custom columns: "get pods -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,RESTARTS:.status.containerStatuses[0].restartCount"
+            - Find problematic pods: "get pods -A -o wide" (READY shows 0/1, STATUS shows
+              CrashLoopBackOff/ImagePullBackOff/Error — catches every failure mode)
+            - Custom columns: "get pods -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,RESTARTS:.status.containerStatuses[*].restartCount,REASON:.status.containerStatuses[*].state.waiting.reason"
             - Wide format: "get pods -o wide"
             - Describe (comprehensive): "describe pod pod-name"
             - Events (default output): "get events --sort-by='.lastTimestamp'"
@@ -462,7 +467,21 @@ class KubentlyAgent:
                     )
                     if response.status_code == 200:
                         result = response.json()
-                        output = result.get("output", "")
+                        # HTTP 200 does not mean the command ran: an unreachable
+                        # executor returns 200 with status=timeout, output=null.
+                        # Surface that as an error instead of empty output, which
+                        # the agent would otherwise read as "nothing is wrong".
+                        exec_status, exec_error = result.get("status"), result.get("error")
+                        if exec_error or (exec_status and exec_status != "success"):
+                            error_msg = cap_output(
+                                f"Error: {exec_error or f'command status: {exec_status}'}"
+                            )
+                            await interceptor.record_tool_result(tool_call_id, None, error_msg)
+                            return error_msg
+                        # Cap before anything downstream sees it: the model, the
+                        # interceptor trace and the investigation log all get the
+                        # same bounded text the agent actually reasons over.
+                        output = cap_output(result.get("output") or "")
                         debug_print(f"Tool successful: {output[:100]}...")
 
                         # Update investigation tracking with findings
@@ -472,7 +491,7 @@ class KubentlyAgent:
                         await interceptor.record_tool_result(tool_call_id, output)
                         return output
                     else:
-                        error_msg = f"Error: HTTP {response.status_code}: {response.text}"
+                        error_msg = cap_output(f"Error: HTTP {response.status_code}: {response.text}")
                         debug_print(f"Tool failed: {error_msg}")
                         await interceptor.record_tool_result(tool_call_id, None, error_msg)
                         return error_msg
@@ -501,8 +520,10 @@ class KubentlyAgent:
             long outputs are truncated — drill into a specific cluster with
             execute_kubectl when you need full output.
 
-            Keep fleet commands filtered and token-efficient (e.g.
-            "get pods --field-selector status.phase!=Running").
+            Keep fleet commands filtered and token-efficient (e.g. "get pods -A -o wide").
+            Do NOT sweep for failures with "--field-selector status.phase!=Running":
+            CrashLoopBackOff pods report phase=Running, so entire clusters come back
+            looking healthy while their pods crash on a loop.
 
             Args:
                 cluster_ids: Target clusters, or ["all"] for every registered cluster

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/fleet.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/fleet.py
@@ -1,4 +1,4 @@
-"""Fleet fan-out: run one read-only kubectl command across many clusters concurrently.
+"""Fleet fan-out plus the shared output-size caps for kubectl tool results.
 
 Deliberately import-light (stdlib + httpx only) so unit tests can import it
 without pulling the langchain/a2a stack that agent.py requires.
@@ -11,7 +11,26 @@ import httpx
 
 MAX_FLEET_CLUSTERS = 10  # default; override per-deploy with KUBENTLY_MAX_FLEET_CLUSTERS
 PER_CLUSTER_OUTPUT_CAP = 4000
+SINGLE_CLUSTER_OUTPUT_CAP = 20000  # default; override with KUBENTLY_MAX_OUTPUT_CHARS
 _TRUNCATION_NOTE = "\n[truncated — run execute_kubectl on {cluster_id} for full output]"
+_NARROW_HINT = (
+    "\n[truncated at {cap} chars — re-run narrowed: --field-selector, "
+    "-o custom-columns=..., -o jsonpath=..., -l <selector>, or --tail for logs]"
+)
+
+
+def cap_output(text: str, cap: int | None = None) -> str:
+    """Hard-cap one tool result so a single careless call can't flood agent context.
+
+    The checkpointer replays full history every turn, so an uncapped result costs
+    tokens on every subsequent turn, not just the one that produced it.
+    """
+    if cap is None:
+        cap = int(os.getenv("KUBENTLY_MAX_OUTPUT_CHARS", str(SINGLE_CLUSTER_OUTPUT_CAP)))
+    text = text or ""
+    if len(text) <= cap:
+        return text
+    return text[:cap] + _NARROW_HINT.format(cap=cap)
 
 
 def build_execute_payload(command: str, namespace: str = "default") -> dict:
@@ -80,7 +99,15 @@ async def _execute_on_cluster(
             json={**payload_base, "cluster_id": cluster_id},
         )
         if resp.status_code == 200:
-            return (cluster_id, True, resp.json().get("output", ""))
+            # HTTP 200 does NOT mean the command ran: an unreachable executor
+            # comes back 200 with status=timeout and output=null. Trusting the
+            # status code alone turns "cluster is down" into an empty result,
+            # which collapses to "(no matching resources)" and reads as healthy.
+            data = resp.json()
+            status, error = data.get("status"), data.get("error")
+            if error or (status and status != "success"):
+                return (cluster_id, False, error or f"command status: {status}")
+            return (cluster_id, True, data.get("output") or "")
         return (cluster_id, False, f"HTTP {resp.status_code}: {resp.text[:200]}")
     except Exception as e:  # per-cluster isolation: one bad cluster never sinks the batch
         return (cluster_id, False, str(e))

--- a/kubently/modules/webhook/__init__.py
+++ b/kubently/modules/webhook/__init__.py
@@ -1,1 +1,2 @@
 from .alertmanager import create_router  # noqa: F401
+from .fleet_report import create_router as create_fleet_report_router  # noqa: F401

--- a/kubently/modules/webhook/alertmanager.py
+++ b/kubently/modules/webhook/alertmanager.py
@@ -49,8 +49,12 @@ def build_query(alert: dict) -> str:
 
 
 def format_slack_message(alert: dict, answer: str) -> dict:
+    from .fleet_report import to_slack_mrkdwn
+
     name = alert.get("labels", {}).get("alertname", "alert")
-    return {"text": f":rotating_light: *Kubently diagnosis for `{name}`*\n\n{answer}"}
+    return {
+        "text": f":rotating_light: *Kubently diagnosis for `{name}`*\n\n{to_slack_mrkdwn(answer)}"
+    }
 
 
 async def _diagnose_and_post(agent_factory, alert: dict, slack_url: str) -> None:

--- a/kubently/modules/webhook/alertmanager.py
+++ b/kubently/modules/webhook/alertmanager.py
@@ -44,7 +44,10 @@ def build_query(alert: dict) -> str:
     lead = " ".join(parts) + (f": {summary}" if summary else "")
     return (
         f"{lead}. Diagnose the root cause and suggest a fix. "
-        "Be concise; this will be posted to Slack."
+        "Be concise; this will be posted to Slack. Format as Slack mrkdwn, which "
+        "is NOT markdown: bold is *single asterisk* (never **double**), there are "
+        "no `#` headings, no `---` rules and no tables. Code fences take no "
+        "language hint — use ``` alone, not ```bash."
     )
 
 

--- a/kubently/modules/webhook/alertmanager.py
+++ b/kubently/modules/webhook/alertmanager.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 
 MAX_ALERTS_PER_PAYLOAD = 3  # ponytail: cap fan-out per webhook; add Redis-keyed dedup if Slack gets noisy
 
+# asyncio holds only weak references to tasks, so a fire-and-forget task can be
+# garbage-collected mid-flight. A diagnosis runs for minutes; without a strong ref
+# the symptom is "the Slack message just never arrives", with nothing in the log.
+_background: set[asyncio.Task] = set()
+
 
 def firing_alerts(payload) -> list[dict]:
     alerts = payload.get("alerts") if isinstance(payload, dict) else None
@@ -82,7 +87,9 @@ def create_router(verify_api_key, redis_client=None) -> APIRouter:
         payload = await request.json()
         alerts = firing_alerts(payload)
         for alert in alerts[:MAX_ALERTS_PER_PAYLOAD]:
-            asyncio.create_task(_diagnose_and_post(_agent, alert, slack_url))
+            task = asyncio.create_task(_diagnose_and_post(_agent, alert, slack_url))
+            _background.add(task)
+            task.add_done_callback(_background.discard)
         if len(alerts) > MAX_ALERTS_PER_PAYLOAD:
             logger.warning(
                 "Alertmanager payload had %d firing alerts; diagnosing first %d",

--- a/kubently/modules/webhook/fleet_report.py
+++ b/kubently/modules/webhook/fleet_report.py
@@ -1,0 +1,121 @@
+"""Scheduled fleet health digest -> Slack incoming webhook.
+
+A CronJob (or a human with curl) POSTs here; the agent sweeps every registered
+cluster via its fleet fan-out tool and the digest is posted to SLACK_WEBHOOK_URL.
+
+Two response contracts on one endpoint, chosen by the caller:
+  - scheduled: ACK 202 immediately, diagnosis runs in the background (a sweep
+    takes minutes; a CronJob holding the connection that long would time out)
+  - dry_run:   run synchronously, return the digest to the caller, post nothing
+"""
+
+import asyncio
+import logging
+import os
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+# asyncio holds only weak references to tasks, so a fire-and-forget task can be
+# garbage-collected mid-flight. A digest runs for minutes; without a strong ref
+# the symptom is "the Slack message just never arrives", with nothing in the log.
+_background: set[asyncio.Task] = set()
+
+# Used only if the prompt file is missing/unparseable; get_prompt falls back to
+# its own generic system prompt otherwise, which is not a digest query.
+FALLBACK_QUERY = (
+    "Check the health of every registered cluster. Report pods that are not "
+    "Running or Succeeded and recent Warning events. Format for Slack: one short "
+    "section per cluster, healthy clusters get a single line. If the whole fleet "
+    "is healthy, say so in one line and stop."
+)
+
+
+def resolve_query(body_query: str | None = None) -> str:
+    """Digest query, most specific source first.
+
+    body `query` (per-call, for iterating) > fleet_report.prompt.yaml (mounted by
+    the chart, populated from fleetReport.query) > built-in fallback.
+    """
+    if body_query and body_query.strip():
+        return body_query.strip()
+    try:
+        from kubently.modules.config import get_prompt
+        from kubently.modules.config.prompts import DEFAULT_PROMPT
+
+        prompt = get_prompt(role="fleet_report", default_filename="fleet_report.prompt.yaml")
+    except Exception:
+        logger.exception("Fleet report prompt load failed; using built-in query")
+        return FALLBACK_QUERY
+    # get_prompt returns DEFAULT_PROMPT when it finds no file. That is a generic
+    # system prompt, not a digest query, so treat it as "no prompt configured".
+    if not prompt or prompt == DEFAULT_PROMPT:
+        logger.warning("No fleet_report prompt file found; using built-in digest query")
+        return FALLBACK_QUERY
+    return prompt
+
+
+def format_slack_message(answer: str) -> dict:
+    return {"text": f":satellite: *Kubently fleet health digest*\n\n{answer}"}
+
+
+async def _run_digest(agent_factory, query: str) -> str:
+    from kubently.modules.mcp import tools
+
+    result = await tools.ask_kubently(agent_factory(), query, None, None)
+    return result["answer"]
+
+
+async def _digest_and_post(agent_factory, query: str, slack_url: str) -> None:
+    try:
+        answer = await _run_digest(agent_factory, query)
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(slack_url, json=format_slack_message(answer))
+            resp.raise_for_status()
+        logger.info("Posted fleet health digest to Slack")
+    except Exception:
+        logger.exception("Fleet health digest failed")
+
+
+def create_router(verify_api_key, redis_client=None) -> APIRouter:
+    """Router factory. The agent (and its heavy langchain import) is only touched
+    once a digest actually runs, so the API boots without the a2a stack."""
+    router = APIRouter()
+    state: dict = {"agent": None}
+
+    def _agent():
+        if state["agent"] is None:
+            from kubently.modules.a2a.protocol_bindings.a2a_server.agent import KubentlyAgent
+
+            state["agent"] = KubentlyAgent(redis_client=redis_client)
+        return state["agent"]
+
+    @router.post("/webhooks/fleet-report")
+    async def fleet_report(request: Request, auth=Depends(verify_api_key)):
+        try:
+            body = await request.json()
+        except Exception:  # no body at all is the normal scheduled case
+            body = {}
+        if not isinstance(body, dict):
+            raise HTTPException(400, "Body must be a JSON object")
+
+        query = resolve_query(body.get("query"))
+
+        if body.get("dry_run"):
+            # Synchronous: the caller is a human who wants to read the digest.
+            # No SLACK_WEBHOOK_URL requirement — a dry run never posts.
+            answer = await _run_digest(_agent, query)
+            return {"dryRun": True, "query": query, "answer": answer}
+
+        slack_url = os.environ.get("SLACK_WEBHOOK_URL")
+        if not slack_url:
+            raise HTTPException(503, "SLACK_WEBHOOK_URL is not configured")
+        task = asyncio.create_task(_digest_and_post(_agent, query, slack_url))
+        _background.add(task)
+        task.add_done_callback(_background.discard)
+        return JSONResponse(status_code=202, content={"accepted": True})
+
+    return router

--- a/kubently/modules/webhook/fleet_report.py
+++ b/kubently/modules/webhook/fleet_report.py
@@ -12,6 +12,7 @@ Two response contracts on one endpoint, chosen by the caller:
 import asyncio
 import logging
 import os
+import re
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -58,8 +59,29 @@ def resolve_query(body_query: str | None = None) -> str:
     return prompt
 
 
+def to_slack_mrkdwn(text: str) -> str:
+    """Normalise the markdown-isms LLMs reach for into Slack mrkdwn.
+
+    Slack mrkdwn is not markdown: `**bold**`, `---` rules and `#` headings all
+    render as literal characters. The prompt asks for mrkdwn, but prompt
+    compliance is probabilistic and this message goes out unattended, so the
+    common three get fixed on the way out.
+
+    ponytail: tables are left alone — rewriting them needs real parsing, and the
+    prompt forbids them. If tables keep showing up, convert here rather than
+    adding more prompt text.
+    """
+    text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text, flags=re.S)  # **bold** -> *bold*
+    # [ \t] not \s: \s matches newlines, which would swallow the blank lines
+    # around a rule and glue two cluster sections together.
+    text = re.sub(r"(?m)^[ \t]*(?:---+|===+)[ \t]*$\n?", "", text)  # horizontal rules
+    text = re.sub(r"(?m)^[ \t]*#{1,6}[ \t]+(.*)$", r"*\1*", text)  # # heading -> *heading*
+    text = re.sub(r"\[([^\]]+)\]\((https?://[^)]+)\)", r"<\2|\1>", text)  # links
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
+
+
 def format_slack_message(answer: str) -> dict:
-    return {"text": f":satellite: *Kubently fleet health digest*\n\n{answer}"}
+    return {"text": f":satellite: *Kubently fleet health digest*\n\n{to_slack_mrkdwn(answer)}"}
 
 
 async def _run_digest(agent_factory, query: str) -> str:

--- a/kubently/modules/webhook/fleet_report.py
+++ b/kubently/modules/webhook/fleet_report.py
@@ -59,25 +59,42 @@ def resolve_query(body_query: str | None = None) -> str:
     return prompt
 
 
+_FENCE = re.compile(r"(```.*?```)", re.S)
+
+
+def _mrkdwn_prose(text: str) -> str:
+    text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text, flags=re.S)  # **bold** -> *bold*
+    # [ \t] not \s: \s matches newlines, which would swallow the blank lines
+    # around a rule and glue two cluster sections together.
+    text = re.sub(r"(?m)^[ \t]*(?:---+|===+)[ \t]*$\n?", "", text)  # horizontal rules
+    text = re.sub(r"(?m)^[ \t]*#{1,6}[ \t]+(.*)$", r"*\1*", text)  # # heading -> *heading*
+    return re.sub(r"\[([^\]]+)\]\((https?://[^)]+)\)", r"<\2|\1>", text)  # links
+
+
 def to_slack_mrkdwn(text: str) -> str:
     """Normalise the markdown-isms LLMs reach for into Slack mrkdwn.
 
     Slack mrkdwn is not markdown: `**bold**`, `---` rules and `#` headings all
     render as literal characters. The prompt asks for mrkdwn, but prompt
     compliance is probabilistic and this message goes out unattended, so the
-    common three get fixed on the way out.
+    common ones get fixed on the way out.
+
+    Fenced blocks are passed through untouched apart from their language hint:
+    inside them `# ...` is a shell comment, not a heading, and rewriting it to
+    `*...*` hands the reader commands that break when pasted.
 
     ponytail: tables are left alone — rewriting them needs real parsing, and the
     prompt forbids them. If tables keep showing up, convert here rather than
     adding more prompt text.
     """
-    text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text, flags=re.S)  # **bold** -> *bold*
-    # [ \t] not \s: \s matches newlines, which would swallow the blank lines
-    # around a rule and glue two cluster sections together.
-    text = re.sub(r"(?m)^[ \t]*(?:---+|===+)[ \t]*$\n?", "", text)  # horizontal rules
-    text = re.sub(r"(?m)^[ \t]*#{1,6}[ \t]+(.*)$", r"*\1*", text)  # # heading -> *heading*
-    text = re.sub(r"\[([^\]]+)\]\((https?://[^)]+)\)", r"<\2|\1>", text)  # links
-    return re.sub(r"\n{3,}", "\n\n", text).strip()
+    parts = _FENCE.split(text or "")
+    for i, part in enumerate(parts):
+        if part.startswith("```"):
+            # Slack has no language hints; ```bash renders "bash" as content.
+            parts[i] = re.sub(r"\A```[ \t]*[A-Za-z0-9_+-]*[ \t]*\n", "```\n", part)
+        else:
+            parts[i] = _mrkdwn_prose(part)
+    return re.sub(r"\n{3,}", "\n\n", "".join(parts)).strip()
 
 
 def format_slack_message(answer: str) -> dict:

--- a/prompts/fleet_report.prompt.yaml
+++ b/prompts/fleet_report.prompt.yaml
@@ -1,0 +1,36 @@
+version: 1
+name: kubently_fleet_health_digest
+# NOTE: `role` must literally be "system" (PromptSpec validator in
+# kubently/modules/config/prompts.py). The role passed to get_prompt()
+# ("fleet_report") only selects the KUBENTLY_FLEET_REPORT_PROMPT_FILE env var.
+role: system
+metadata:
+  owner: kubently
+  description: Query driving the scheduled fleet health digest posted to Slack
+variables: []
+content: |-
+  Check the health of every registered cluster.
+
+  For each cluster, report:
+  - pods whose containers are not ready, or are restarting, or are in a waiting
+    state such as CrashLoopBackOff, ImagePullBackOff, ErrImagePull or
+    CreateContainerConfigError. Include the restart count and the reason.
+  - Warning events from the last hour
+  - nodes that are not Ready
+
+  IMPORTANT: do NOT find failing pods with
+  `--field-selector status.phase!=Running,status.phase!=Succeeded`. A pod stuck
+  in CrashLoopBackOff has `status.phase=Running`, so that filter silently misses
+  the most common failure there is. Select on readiness and restarts instead —
+  for example `get pods -A -o wide` and look at the READY and STATUS columns, or
+  `-o custom-columns` over `.status.containerStatuses[*].ready` and
+  `.restartCount`.
+
+  Format the answer for Slack:
+  - one short section per cluster, cluster name first
+  - a cluster with nothing wrong gets a single line saying it is healthy
+  - no preamble, no closing summary
+  - if the entire fleet is healthy, say so in one line and stop
+
+  Prioritise problems that look new or are getting worse. Do not suggest fixes
+  unless the cause is obvious from what you already gathered.

--- a/prompts/fleet_report.prompt.yaml
+++ b/prompts/fleet_report.prompt.yaml
@@ -26,9 +26,19 @@ content: |-
   `-o custom-columns` over `.status.containerStatuses[*].ready` and
   `.restartCount`.
 
-  Format the answer for Slack:
-  - one short section per cluster, cluster name first
-  - a cluster with nothing wrong gets a single line saying it is healthy
+  Format the answer as Slack mrkdwn. This is NOT markdown — these render as
+  literal characters and must never appear:
+  - tables (`| col | col |`) — Slack has no table support; use one line per pod
+  - `**double asterisk**` for bold — Slack bold is `*single asterisk*`
+  - `---` or `===` rules, and `#` headings — Slack renders none of them
+  - `[text](url)` links — Slack uses `<url|text>`
+
+  Use only: `*bold*`, `_italic_`, `` `code` ``, ``` ```blocks``` ```, and `•`
+  or `-` bullets. Structure:
+  - one short section per cluster, `*cluster-name*` on its own line first
+  - one line per problem underneath, starting with `•`
+  - a cluster with nothing wrong gets a single line: `*name* — healthy`
+  - a blank line between clusters (this is the separator; do not draw a rule)
   - no preamble, no closing summary
   - if the entire fleet is healthy, say so in one line and stop
 

--- a/prompts/system.prompt.yaml
+++ b/prompts/system.prompt.yaml
@@ -85,7 +85,8 @@ content: |-
   - IMPORTANT: Always start with kubectl get events to understand recent cluster activity
   - **TOKEN EFFICIENCY FIRST**: Minimize output tokens by using targeted kubectl flags
   - Use `-o custom-columns` or `--field-selector` to retrieve only needed fields
-  - Prefer `--field-selector` to filter resources (e.g., `status.phase!=Running` for problematic pods)
+  - Prefer targeted output (`-o wide`, `-o custom-columns`, `-l <selector>`) over dumping full objects
+  - CRITICAL: never hunt for broken pods with `--field-selector status.phase!=Running`. A pod stuck in CrashLoopBackOff has `status.phase=Running`, so that filter hides the most common failure there is. Filter on readiness, restart count, or the container waiting reason instead. (`--field-selector status.phase=Pending` is still correct for scheduling problems specifically.)
   - Use `-o json` ONLY when you need to parse complex nested data programmatically
   - For simple status queries, use default output, wide, or custom-columns
   - Check pod status and describe resources for detailed information
@@ -95,13 +96,13 @@ content: |-
 
   # Task Management
 
-  You have access to the todo_write tool to help you manage debugging workflows. Use this tool at the START of complex investigations to plan your approach, then ONLY update it when you've COMPLETED the investigation or found the answer.
+  You have access to the write_todos tool to help you manage debugging workflows. Use this tool at the START of complex investigations to plan your approach, then ONLY update it when you've COMPLETED the investigation or found the answer.
 
-  IMPORTANT: Do NOT call todo_write after every kubectl command. This wastes tokens and slows down debugging. Only use it:
+  IMPORTANT: Do NOT call write_todos after every kubectl command. This wastes tokens and slows down debugging. Only use it:
   - Once at the START to plan (if the issue is complex)
   - Once at the END to mark completed (if you used it at the start)
 
-  For simple issues (1-3 kubectl commands), skip todo_write entirely.
+  For simple issues (1-3 kubectl commands), skip write_todos entirely.
 
   Examples:
 
@@ -121,7 +122,7 @@ content: |-
   <example>
   user: Find out why services can't reach the database
 
-  assistant: I'll systematically debug the service connectivity to your database. Let me use the todo_write tool to plan our investigation:
+  assistant: I'll systematically debug the service connectivity to your database. Let me use the write_todos tool to plan our investigation:
   - Check service and endpoint configuration
   - Verify network policies
   - Test DNS resolution
@@ -137,7 +138,7 @@ content: |-
   <example>
   user: My deployment isn't scaling properly
 
-  assistant: I'll debug your deployment scaling issue. Let me use the todo_write tool to organize our investigation:
+  assistant: I'll debug your deployment scaling issue. Let me use the write_todos tool to organize our investigation:
   - Check deployment status and replica count
   - Examine HPA (Horizontal Pod Autoscaler) if configured
   - Review resource requests and limits
@@ -159,7 +160,7 @@ content: |-
 
   The user will primarily request you perform Kubernetes debugging and troubleshooting tasks. This includes diagnosing pod failures, service connectivity issues, resource constraints, configuration problems, and more. For these tasks the following steps are recommended:
 
-  - Use the todo_write tool to plan the debugging approach if the issue requires multiple investigation steps
+  - Use the write_todos tool to plan the debugging approach if the issue requires multiple investigation steps
   - Use systematic debugging approaches starting with kubectl get events
   - Check resource status, descriptions, and logs
   - Investigate related resources (ConfigMaps, Secrets, Services, Ingresses)
@@ -179,12 +180,23 @@ content: |-
   # Token-Efficient kubectl Patterns
 
   ## Finding Problematic Pods (TOKEN EFFICIENT)
-  ```bash
-  # Use field selectors to filter - returns only problematic pods
-  kubectl get pods -A --field-selector status.phase!=Running,status.phase!=Succeeded
 
-  # Custom columns for specific data only
-  kubectl get pods -A -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,RESTARTS:.status.containerStatuses[0].restartCount
+  CRITICAL: `status.phase` is NOT a health signal. A pod whose container is stuck in
+  CrashLoopBackOff still reports `phase=Running`, so BOTH
+  `--field-selector status.phase!=Running` and `-o custom-columns=STATUS:.status.phase`
+  will report a crash-looping pod as fine. Use readiness, restart count, and the
+  container waiting reason instead.
+
+  ```bash
+  # BEST first call: READY shows 0/1 and STATUS shows the real reason
+  # (CrashLoopBackOff, ImagePullBackOff, Error). Cheap, and it catches everything.
+  kubectl get pods -A -o wide
+
+  # Container-level truth: readiness, restarts, and why it is waiting
+  kubectl get pods -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,READY:.status.containerStatuses[*].ready,RESTARTS:.status.containerStatuses[*].restartCount,REASON:.status.containerStatuses[*].state.waiting.reason
+
+  # Scheduling problems specifically - Pending IS a real phase, so this one is correct
+  kubectl get pods -A --field-selector status.phase=Pending
 
   # Default output with grep (tool can parse this easily)
   kubectl get pods -A | grep -v Running
@@ -228,17 +240,34 @@ content: |-
 
   ## Critical Behaviors
 
-  ### WHEN TO STOP AND RESPOND:
-  IMPORTANT: You MUST stop investigating and provide your answer when ANY of these conditions are met:
-  - You found the root cause (e.g., CrashLoopBackOff with clear error in logs)
-  - You gathered enough evidence to explain the issue
-  - You've made 5+ tool calls - synthesize what you know and respond
-  - The user asked a simple question that doesn't need deep investigation
+  ### SYMPTOM vs ROOT CAUSE (read before you stop):
+  IMPORTANT: A symptom is NOT a root cause. Stop when you have explained WHY the symptom
+  occurs, not merely THAT it occurs. These are symptoms that REQUIRE one more level of
+  investigation before you answer:
+  - "Service has 0 endpoints" / "no backend pods" -> you MUST then determine why: do pods
+    matching the service selector exist? are they Running? AND is a NetworkPolicy blocking
+    traffic? Do not conclude "missing pods" until you have confirmed no matching pods exist
+    AND checked for NetworkPolicies in the namespace (`kubectl get networkpolicy -n <ns>`).
+  - "Connection refused / timeout / traffic not reaching" -> check selector match, endpoints,
+    AND NetworkPolicies (ingress and egress) before concluding.
+  - "Pod Pending" -> determine the specific reason (resources, taints, PVC, scheduling) from events.
+  - "CreateContainerConfigError" -> identify the exact missing ConfigMap/Secret/key.
+  - "No pods / namespace looks empty" -> do NOT conclude "nothing is deployed". Check
+    Deployments/ReplicaSets (`kubectl get deploy,rs -n <ns>`) and their events/conditions:
+    a Deployment with 0 ready pods usually means pods can't be created (missing
+    ServiceAccount, failed admission, quota, or scheduling). Find that reason.
 
-  DO NOT keep investigating indefinitely. After finding an issue, STOP and tell the user what you found.
+  ### WHEN TO STOP AND RESPOND:
+  Stop investigating and answer when ANY of these is true:
+  - You found the ROOT CAUSE (the underlying reason, not just a symptom) with supporting evidence.
+  - You have made ~8 tool calls and have a well-supported explanation - synthesize and respond.
+  - The user asked a simple question that doesn't need deep investigation.
+
+  DO NOT keep investigating indefinitely once the root cause is established. But DO NOT stop at
+  the first symptom either - confirm the underlying cause first.
 
   ### DO:
-  - Stop and respond once you identify the issue
+  - Stop and respond once you identify the root cause (not merely a symptom)
   - Check events, logs, and descriptions
   - Look at timestamps and correlate events
   - Consider recent changes or deployments
@@ -246,7 +275,7 @@ content: |-
 
   ### DON'T:
   - Keep calling tools after you've found the answer
-  - Use todo_write after every kubectl command
+  - Use write_todos after every kubectl command
   - Assume resource names match namespace names
   - Trust a single data point without context
   - Ignore warning events
@@ -311,7 +340,7 @@ content: |-
   - execute_kubectl: Run kubectl commands for investigation and fixes
   - execute_kubectl_multi: Run one read-only kubectl command across many clusters in parallel (fleet queries)
   - list_clusters: Get available Kubernetes clusters
-  - todo_write: Manage debugging workflow tasks to track systematic investigation progress
+  - write_todos: Manage debugging workflow tasks to track systematic investigation progress
 
   IMPORTANT: Focus on Kubernetes debugging and troubleshooting. Help users understand and fix cluster issues efficiently.
 
@@ -328,7 +357,7 @@ content: |-
 
   - When the user asks about MULTIPLE clusters or the whole fleet ("across all clusters", "which clusters have X", "fleet-wide"), use execute_kubectl_multi with cluster_ids=["all"] (or the named subset) instead of sequential execute_kubectl calls.
   - Fleet results are a triage view: per-cluster output is truncated. Drill into a specific cluster with execute_kubectl when you need detail.
-  - Keep fleet commands filtered and token-efficient (e.g. --field-selector status.phase!=Running); never dump unfiltered resources from every cluster.
+  - Keep fleet commands filtered and token-efficient (e.g. `-o wide`, `-o custom-columns`, `-l <selector>`); never dump unfiltered resources from every cluster. Do NOT use `--field-selector status.phase!=Running` for fleet health sweeps — CrashLoopBackOff pods have `phase=Running`, so a whole cluster can look healthy while pods crash on a loop.
   - For single-cluster questions keep using execute_kubectl.
 
   # Code References

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -8,7 +8,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from kubently.modules.a2a.protocol_bindings.a2a_server.fleet import (  # noqa: E402
     PER_CLUSTER_OUTPUT_CAP,
+    SINGLE_CLUSTER_OUTPUT_CAP,
     build_execute_payload,
+    cap_output,
     format_fleet_results,
     format_section,
 )
@@ -61,6 +63,25 @@ def test_format_section_truncates_at_cap():
     assert "[truncated — run execute_kubectl on prod-east for full output]" in s
     # header + capped body + truncation note; nowhere near the raw size
     assert len(s) < PER_CLUSTER_OUTPUT_CAP + 200
+
+
+def test_cap_output_passes_through_small():
+    assert cap_output("pod-a Running") == "pod-a Running"
+    assert cap_output("") == ""
+    assert cap_output(None) == ""
+
+
+def test_cap_output_truncates_with_narrowing_hint():
+    out = cap_output("x" * (SINGLE_CLUSTER_OUTPUT_CAP + 5000))
+    assert "--field-selector" in out
+    assert f"truncated at {SINGLE_CLUSTER_OUTPUT_CAP} chars" in out
+    assert len(out) < SINGLE_CLUSTER_OUTPUT_CAP + 200
+
+
+def test_cap_output_env_override(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_MAX_OUTPUT_CHARS", "10")
+    assert cap_output("x" * 9) == "x" * 9
+    assert cap_output("x" * 50).startswith("x" * 10 + "\n[truncated at 10 chars")
 
 
 def test_format_fleet_results_joins_sections():
@@ -136,6 +157,45 @@ async def test_run_fleet_command_error_isolation():
     out = await run_fleet_command(API, KEY, ["a", "b"], PAYLOAD, client=client)
     assert "=== cluster: a ===\nERROR: HTTP 500" in out
     assert "=== cluster: b ===\nfine" in out
+
+
+async def test_run_fleet_command_reports_unreachable_cluster_as_error():
+    """An executor that never answers must not read as a healthy cluster.
+
+    /debug/execute answers HTTP 200 with status=timeout and output=null when no
+    executor picks the command up. Trusting the status code turned that into an
+    empty result, which collapses to "(no matching resources)" — i.e. a cluster
+    that is down reported as one with nothing wrong. Shape copied from a real
+    response against a stale cluster registration.
+    """
+    client = _mock_client(
+        ["live", "stale"],
+        {
+            "live": httpx.Response(200, json={"status": "success", "output": "pod-a Running"}),
+            "stale": httpx.Response(
+                200,
+                json={
+                    "status": "timeout",
+                    "output": None,
+                    "error": "Command execution timeout",
+                },
+            ),
+        },
+    )
+    out = await run_fleet_command(API, KEY, ["live", "stale"], PAYLOAD, client=client)
+    assert "=== cluster: stale ===\nERROR: Command execution timeout" in out
+    assert "no matching resources" not in out
+    assert "=== cluster: live ===\npod-a Running" in out
+
+
+async def test_run_fleet_command_empty_output_still_collapses():
+    """A genuinely empty success is still the cheap one-liner (guards the fix
+    above from swinging too far and flagging healthy clusters as errors)."""
+    client = _mock_client(
+        ["a"], {"a": httpx.Response(200, json={"status": "success", "output": ""})}
+    )
+    out = await run_fleet_command(API, KEY, ["a"], PAYLOAD, client=client)
+    assert out == "=== cluster: a === (no matching resources)"
 
 
 async def test_run_fleet_command_cap():

--- a/tests/test_fleet_report.py
+++ b/tests/test_fleet_report.py
@@ -111,6 +111,36 @@ def test_to_slack_mrkdwn_converts_headings():
     assert to_slack_mrkdwn("## Fleet status") == "*Fleet status*"
 
 
+# Verbatim from a real Alertmanager diagnosis posted to Slack. The `#` lines are
+# shell comments, not headings: rewriting them to *bold* handed the reader
+# commands that break when pasted, and the ```bash hint rendered as content.
+E2E_DIAGNOSIS = """*Investigate:*
+```bash
+# Check if a postgres service/pod exists in the payments namespace
+kubectl get svc,pod -n payments -l app=postgres
+# Check DB connection config (env vars / secrets on the deployment)
+kubectl describe deployment checkout-api -n payments
+```
+"""
+
+
+def test_to_slack_mrkdwn_leaves_code_blocks_alone():
+    out = to_slack_mrkdwn(E2E_DIAGNOSIS)
+    assert "# Check if a postgres service/pod exists" in out, "shell comment was mangled"
+    assert "# Check DB connection config" in out
+    assert "*Check if" not in out, "heading rule fired inside a fenced block"
+    assert "```bash" not in out, "Slack renders the language hint as content"
+    assert "```\n# Check if" in out
+
+
+def test_to_slack_mrkdwn_still_fixes_prose_around_code_blocks():
+    """Protecting fences must not stop the prose either side being normalised."""
+    out = to_slack_mrkdwn("**Root Cause:** boom\n\n```sh\n# keep me\n```\n\n## Next steps")
+    assert "*Root Cause:*" in out and "**" not in out
+    assert "# keep me" in out
+    assert "*Next steps*" in out
+
+
 def test_to_slack_mrkdwn_leaves_valid_mrkdwn_alone():
     """Must not mangle output that was already correct."""
     good = "*prod-east*\n• `ns/pod/api` — `CrashLoopBackOff`, 5 restarts\n\n*prod-west* — healthy"

--- a/tests/test_fleet_report.py
+++ b/tests/test_fleet_report.py
@@ -15,6 +15,7 @@ from kubently.modules.webhook.fleet_report import (
     create_router,
     format_slack_message,
     resolve_query,
+    to_slack_mrkdwn,
 )
 
 CHART_PROMPT = os.path.join(os.path.dirname(__file__), "..", "prompts", "fleet_report.prompt.yaml")
@@ -76,6 +77,44 @@ def test_format_slack_message():
     msg = format_slack_message("prod-east: healthy")
     assert msg["text"].startswith(":satellite: *Kubently fleet health digest*")
     assert "prod-east: healthy" in msg["text"]
+
+
+# Verbatim from a real digest run — Slack renders every one of these as literal
+# characters, so this is what the channel would actually have shown.
+E2E_ANSWER = """---
+
+**kind**
+
+:warning: `digest-test/pod/broken-payments` — not ready, `CrashLoopBackOff`
+
+---
+
+**kind-exec-only** — healthy
+
+See [the runbook](https://example.com/runbook) for next steps.
+"""
+
+
+def test_to_slack_mrkdwn_fixes_real_digest_output():
+    out = to_slack_mrkdwn(E2E_ANSWER)
+    assert "**" not in out, "double-asterisk bold renders literally in Slack"
+    assert "*kind*" in out and "*kind-exec-only* — healthy" in out
+    assert not any(line.strip() in ("---", "===") for line in out.splitlines())
+    assert "<https://example.com/runbook|the runbook>" in out
+    assert "[the runbook]" not in out
+    # Removing a rule must not eat the blank line it sat between: that blank
+    # line IS the section separator once the rule is gone.
+    assert "\n\n*kind-exec-only*" in out, "cluster sections got glued together"
+
+
+def test_to_slack_mrkdwn_converts_headings():
+    assert to_slack_mrkdwn("## Fleet status") == "*Fleet status*"
+
+
+def test_to_slack_mrkdwn_leaves_valid_mrkdwn_alone():
+    """Must not mangle output that was already correct."""
+    good = "*prod-east*\n• `ns/pod/api` — `CrashLoopBackOff`, 5 restarts\n\n*prod-west* — healthy"
+    assert to_slack_mrkdwn(good) == good
 
 
 # --- endpoint ---------------------------------------------------------------

--- a/tests/test_fleet_report.py
+++ b/tests/test_fleet_report.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Unit tests for the scheduled fleet health digest endpoint."""
+
+import os
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.webhook import fleet_report
+from kubently.modules.webhook.fleet_report import (
+    FALLBACK_QUERY,
+    create_router,
+    format_slack_message,
+    resolve_query,
+)
+
+CHART_PROMPT = os.path.join(os.path.dirname(__file__), "..", "prompts", "fleet_report.prompt.yaml")
+
+
+def _client(monkeypatch, answer="prod-east: healthy", slack_calls=None):
+    """App with the agent + Slack post stubbed out (no LLM, no network)."""
+
+    async def fake_run_digest(agent_factory, query):
+        return f"{answer} [q={query[:30]}]"
+
+    async def fake_digest_and_post(agent_factory, query, slack_url):
+        result = await fake_run_digest(agent_factory, query)
+        if slack_calls is not None:
+            slack_calls.append((slack_url, result))
+
+    monkeypatch.setattr(fleet_report, "_run_digest", fake_run_digest)
+    monkeypatch.setattr(fleet_report, "_digest_and_post", fake_digest_and_post)
+
+    app = FastAPI()
+    app.include_router(create_router(lambda: True))
+    return TestClient(app)
+
+
+# --- query resolution -------------------------------------------------------
+
+
+def test_resolve_query_body_wins(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_FLEET_REPORT_PROMPT_FILE", CHART_PROMPT)
+    assert resolve_query("just list crashing pods") == "just list crashing pods"
+
+
+def test_resolve_query_blank_body_falls_through(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_FLEET_REPORT_PROMPT_FILE", CHART_PROMPT)
+    q = resolve_query("   ")
+    assert "Check the health of every registered cluster" in q
+
+
+def test_resolve_query_reads_prompt_file(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_FLEET_REPORT_PROMPT_FILE", CHART_PROMPT)
+    q = resolve_query(None)
+    assert "one short section per cluster" in q
+    assert q != FALLBACK_QUERY
+
+
+def test_resolve_query_falls_back_when_no_file(monkeypatch, tmp_path):
+    # Point every lookup path at nothing: get_prompt returns DEFAULT_PROMPT,
+    # which is a system prompt, not a digest query.
+    monkeypatch.setenv("KUBENTLY_FLEET_REPORT_PROMPT_FILE", str(tmp_path / "missing.yaml"))
+    monkeypatch.setenv("KUBENTLY_PROMPT_FILE", str(tmp_path / "missing.yaml"))
+    monkeypatch.chdir(tmp_path)
+    assert resolve_query(None) == FALLBACK_QUERY
+
+
+# --- Slack payload ----------------------------------------------------------
+
+
+def test_format_slack_message():
+    msg = format_slack_message("prod-east: healthy")
+    assert msg["text"].startswith(":satellite: *Kubently fleet health digest*")
+    assert "prod-east: healthy" in msg["text"]
+
+
+# --- endpoint ---------------------------------------------------------------
+
+
+def test_scheduled_post_acks_202_and_schedules_slack_post(monkeypatch):
+    """202 without awaiting, and the Slack post really does get scheduled.
+
+    The second assertion is what makes the dry-run test below meaningful: it
+    proves this harness can observe a post at all, so `calls == []` there is
+    evidence of dry-run behaviour and not just an inert background task.
+    """
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/x")
+    calls = []
+    client = _client(monkeypatch, slack_calls=calls)
+    resp = client.post("/webhooks/fleet-report")
+    assert resp.status_code == 202
+    assert resp.json() == {"accepted": True}
+    assert calls and calls[0][0] == "https://hooks.slack.test/x"
+
+
+def test_scheduled_post_requires_slack_url(monkeypatch):
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    client = _client(monkeypatch)
+    assert client.post("/webhooks/fleet-report").status_code == 503
+
+
+def test_dry_run_returns_answer_and_posts_nothing(monkeypatch):
+    """The one bug in this feature that would burn a real Slack channel."""
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/x")
+    calls = []
+    client = _client(monkeypatch, slack_calls=calls)
+    resp = client.post("/webhooks/fleet-report", json={"dry_run": True})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["dryRun"] is True
+    assert "prod-east: healthy" in body["answer"]
+    assert calls == []
+
+
+def test_dry_run_works_without_slack_url(monkeypatch):
+    """A dry run never posts, so it must not require Slack to be configured."""
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    client = _client(monkeypatch)
+    assert client.post("/webhooks/fleet-report", json={"dry_run": True}).status_code == 200
+
+
+def test_dry_run_uses_body_query(monkeypatch):
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    client = _client(monkeypatch)
+    resp = client.post(
+        "/webhooks/fleet-report", json={"dry_run": True, "query": "only cert expiry"}
+    )
+    assert "only cert expiry" in resp.json()["query"]
+
+
+def test_non_object_body_rejected(monkeypatch):
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/x")
+    client = _client(monkeypatch)
+    assert client.post("/webhooks/fleet-report", json=["nope"]).status_code == 400

--- a/tests/test_prompt_guidance.py
+++ b/tests/test_prompt_guidance.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Guards on shipped prompt content.
+
+Prompts are product behaviour, but nothing compiles them, so regressions here are
+invisible until an agent quietly gives a wrong answer. These two guards cover the
+failures that actually happened:
+
+1. `status.phase!=Running` guidance, which hides CrashLoopBackOff pods.
+2. The root and chart copies of the system prompt drifting apart.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+REPO = os.path.join(os.path.dirname(__file__), "..")
+ROOT_PROMPT = os.path.join(REPO, "prompts", "system.prompt.yaml")
+CHART_PROMPT = os.path.join(REPO, "deployment", "helm", "kubently", "prompts", "system.prompt.yaml")
+ROOT_DIGEST = os.path.join(REPO, "prompts", "fleet_report.prompt.yaml")
+CHART_DIGEST = os.path.join(
+    REPO, "deployment", "helm", "kubently", "prompts", "fleet_report.prompt.yaml"
+)
+AGENT = os.path.join(
+    REPO, "kubently", "modules", "a2a", "protocol_bindings", "a2a_server", "agent.py"
+)
+
+# The trap: a pod stuck in CrashLoopBackOff reports status.phase=Running, so any
+# guidance steering the agent to select on "phase is not Running" hides the single
+# most common Kubernetes failure. Confirmed on a live cluster: a deployment with 4
+# restarts returned zero rows, and the agent duly reported the cluster healthy.
+BAD_FILTER = "status.phase!=Running"
+
+
+WARNING_WORDS = ("never", "not use", "do not", "critical", "misses", "hides", "instead")
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def _unwarned_mentions(path):
+    """Lines mentioning the bad filter with no warning nearby.
+
+    Warning *about* the trap is the point; recommending it is the bug. The
+    surrounding lines count as context because the warnings wrap across lines.
+    """
+    lines = _read(path).splitlines()
+    bad = []
+    for i, line in enumerate(lines):
+        if BAD_FILTER not in line:
+            continue
+        window = " ".join(lines[max(0, i - 3) : i + 4]).lower()
+        if not any(w in window for w in WARNING_WORDS):
+            bad.append(f"{os.path.basename(path)}:{i + 1}: {line.strip()}")
+    return bad
+
+
+def test_no_phase_not_running_guidance_in_prompts():
+    unwarned = []
+    for path in (ROOT_PROMPT, CHART_PROMPT, ROOT_DIGEST, CHART_DIGEST):
+        unwarned += _unwarned_mentions(path)
+    assert not unwarned, "prompt recommends the CrashLoopBackOff-blind filter:\n" + "\n".join(
+        unwarned
+    )
+
+
+def test_no_phase_not_running_guidance_in_agent_tools():
+    unwarned = _unwarned_mentions(AGENT)
+    assert not unwarned, "agent tool docstring recommends the filter:\n" + "\n".join(unwarned)
+
+
+def test_prompt_copies_do_not_drift():
+    """The chart copy is mounted over the image's baked-in copy, so the chart is
+    what runs in a cluster while the root copy is what runs in local dev. They
+    drifted by 49 lines once — long enough for local dev to be told about a
+    `todo_write` tool that had been renamed."""
+    for root, chart in ((ROOT_PROMPT, CHART_PROMPT), (ROOT_DIGEST, CHART_DIGEST)):
+        assert _read(root) == _read(chart), (
+            f"{os.path.basename(root)} differs between prompts/ and "
+            f"deployment/helm/kubently/prompts/ — the chart copy is what runs in-cluster; "
+            f"copy it to the root so local dev matches"
+        )

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -95,6 +95,45 @@ def test_webhook_accepts_firing_alerts(monkeypatch):
     assert resp.json() == {"accepted": 1}
 
 
+def test_background_task_reference_retained_while_in_flight(monkeypatch):
+    """asyncio keeps only weak refs to tasks, so a fire-and-forget diagnosis can be
+    garbage-collected mid-run — the Slack message then silently never arrives.
+
+    Asserting from *inside* the running task is the invariant that matters: at
+    that moment the task must be reachable from the module's strong-ref set.
+    Tasks are all created in one synchronous loop before any of them runs, so a
+    capped 3-alert payload must have all 3 held at once.
+    """
+    import kubently.modules.webhook.alertmanager as am
+
+    observed = []
+
+    async def fake_diag(agent_factory, alert, url):
+        observed.append(len(am._background))
+
+    monkeypatch.setattr(am, "_diagnose_and_post", fake_diag)
+    many = {"alerts": [PAYLOAD["alerts"][0]] * 10}
+    client = TestClient(make_app(monkeypatch))
+    assert client.post("/webhooks/alertmanager", json=many).status_code == 202
+
+    assert observed, "background task never ran"
+    assert min(observed) >= 1, "a task ran with no strong reference held"
+    assert max(observed) == am.MAX_ALERTS_PER_PAYLOAD, "not every task was retained"
+
+
+def test_background_tasks_released_after_completion(monkeypatch):
+    """The done-callback must drain the set, or it grows without bound."""
+    import kubently.modules.webhook.alertmanager as am
+
+    async def fake_diag(agent_factory, alert, url):
+        pass
+
+    monkeypatch.setattr(am, "_diagnose_and_post", fake_diag)
+    client = TestClient(make_app(monkeypatch))
+    client.post("/webhooks/alertmanager", json=PAYLOAD)
+    assert am._background == set()
+
+
 def test_webhook_caps_alert_fanout(monkeypatch):
     import kubently.modules.webhook.alertmanager as am
 


### PR DESCRIPTION
Closes #54. Closes #58.

Two roadmap items, plus two bugs the E2E surfaced that were quietly undermining both.

## What's here

**Scheduled fleet health digest (#54)** — a Helm CronJob POSTs `/webhooks/fleet-report`; the agent sweeps every registered cluster with fleet fan-out and posts one Slack digest, healthy clusters collapsed to a single line. Off by default.

The digest query is user-owned, at three levels: `fleetReport.query` in values, `KUBENTLY_FLEET_REPORT_PROMPT_FILE` for a custom file, or a `query` field in the request body. And it can be run once, three ways, none needing a `helm upgrade`:

```bash
# preview the digest, post nothing (needs no SLACK_WEBHOOK_URL)
curl -X POST $API/webhooks/fleet-report -H "X-API-Key: $KEY" \
  -H 'Content-Type: application/json' -d '{"dry_run": true}'

# exercise the real scheduled path, image and secrets included
kubectl create job --from=cronjob/kubently-fleet-report fleet-report-test -n kubently
```

**Output caps (#58)** — fan-out truncated per-cluster output at 4KB but the single-cluster path had no cap at all, so one `get pods -A -o json` could inject tens of KB. The checkpointer replays full history every turn, so that cost compounded across the whole conversation.

## The two bugs the E2E found

Both share a signature worth naming: **a negative result that looks identical to a clean result.** "No rows matched" and "the cluster never answered" both render as silence, and silence reads as health.

**An unreachable cluster reported as healthy.** `/debug/execute` answers **HTTP 200** with `{"status": "timeout", "output": null}` when no executor picks the command up. Both paths trusted the status code, so null output collapsed to `(no matching resources)`:

> before: `*kind-kubently* — healthy`
> after: `*kind-kubently* — :x: Cluster unreachable (command timeout). Health unknown.`

**The canonical "find broken pods" idiom cannot find broken pods.** A CrashLoopBackOff pod reports `status.phase=Running`, so `--field-selector status.phase!=Running,status.phase!=Succeeded` skips it — it only catches Pending-phase problems like ImagePullBackOff. This guidance appeared in **9 places** across the system prompt and tool docstrings, including the Fleet Queries section. The `custom-columns` example printing `.status.phase` lied the same way.

On a live 3-cluster fleet this took one sweep **from 1 problem found to 4**, surfacing pods at **910** and **1258** restarts that had been invisible. `--field-selector status.phase=Pending` is kept for scheduling problems, where phase is the right signal.

## Also fixed

- **Background diagnosis tasks could be garbage-collected mid-run.** asyncio holds only weak references, so a multi-minute Alertmanager diagnosis could vanish — the Slack message simply never arrives, nothing in the log.
- **The two system-prompt copies had drifted 49 lines.** `prompts/` (local dev, baked into the image) was behind `deployment/helm/kubently/prompts/` (ConfigMap-mounted, so it's what actually runs). Local dev was told to call a `todo_write` tool renamed to `write_todos`. The chart copy was newer, so root now matches it — syncing the other way would have reverted the better prompt.

## Verification

201 unit tests pass. Every fix was checked by reverting it and confirming the test fails:

| Regression reintroduced | Caught by |
|---|---|
| Drop the executor status check | `test_run_fleet_command_reports_unreachable_cluster_as_error` |
| Drop `_background.add(task)` | `assert 0 >= 1` — task ran with no strong reference |
| Drop the done-callback | leaked task left in the set |
| Restore phase-filter guidance | all 3 `test_prompt_guidance.py` guards |
| Let the prompt copies drift | drift guard |

**E2E on a live 3-cluster kind fleet** (kind, kind-exec-only, and a deliberately stale registration):

- Induced a crashloop (`phase=Running`, the exact hidden case) → agent ran `get pods -o wide` and found it
- Fleet question with no digest prompt helping → fanned out with `get pods -A -o wide`, zero uses of the blind filter, found every crashlooper *and* reported the stale cluster as timed out
- 3 dry runs → mock Slack receiver got **0** posts
- Real POST → 202 ACK, digest arrived ~70s later
- `kubectl create job --from=cronjob` → Job Complete in 3s, digest delivered
- `fleetReport.query` in values → ConfigMap → PromptSpec → query, round-tripped intact

Design notes: [docs/superpowers/specs/2026-08-15-fleet-health-digest-design.md](docs/superpowers/specs/2026-08-15-fleet-health-digest-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)