### PR TITLE
auth: dynamic Redis API keys + forward caller identity into agent tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased] - 2026-08-15 (later)
 
 ### Fixed
+- **Executors can no longer answer another cluster's commands (result injection)**
+  — `/executor/results` stored a result for any `command_id` an authenticated
+  executor submitted, with no check that the command was issued to that
+  executor's cluster. Executors run inside customer clusters (customer-
+  controlled), so a malicious one could inject fabricated kubectl output into
+  another tenant's in-flight diagnosis. Commands are now bound to their target
+  cluster at publish time (`command:cluster:{id}`, TTL-bounded) and results from
+  any other cluster — or for unknown/expired ids — are rejected with 403
 - **Conversation threads are now private to the caller (cross-tenant memory
   leak)** — the A2A `contextId` is client-supplied and was passed straight to
   the LangGraph checkpointer as its thread namespace, so any caller could resume

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,17 @@
   re-run narrowed. Error bodies are capped too
 
 ### Added
+- **Dynamic Redis-backed API keys** — `AuthModule.verify_api_key` now also
+  accepts keys registered at runtime as `api:key:{sha256(key)}` = identity in
+  Redis (only the hash is stored), alongside the static `API_KEYS` env keys.
+  Lets a control plane issue/revoke per-tenant keys without restarts
+- **Agent tools act as the caller** — the A2A/MCP auth wrapper records the
+  caller's validated key in a `current_api_key` contextvar
+  (`kubently.modules.auth.context`), and agent tool calls (`list_clusters`,
+  `execute_kubectl`, `execute_kubectl_multi`) forward it on internal API calls
+  instead of the shared first `API_KEYS` key (which remains the fallback).
+  Least-privilege: a gateway can now scope what each caller's diagnostics may
+  touch
 - **Fleet fan-out cap is configurable** — `KUBENTLY_MAX_FLEET_CLUSTERS` env var
   overrides the default 10-cluster cap per `execute_kubectl_multi` call (read at
   call time; the cap bounds agent-context growth at ~4KB per cluster)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased] - 2026-08-15 (later)
 
 ### Fixed
+- **Conversation threads are now private to the caller (cross-tenant memory
+  leak)** — the A2A `contextId` is client-supplied and was passed straight to
+  the LangGraph checkpointer as its thread namespace, so any caller could resume
+  another caller's conversation (their questions, kubectl output, cluster
+  internals) by reusing their `contextId`. Threads are now prefixed with a hash
+  of the authenticated caller's key; unauthenticated/local invocation is
+  unchanged. Latent rather than exploited in hosted deployments where the Redis
+  checkpointer is unavailable, but live the moment persistent memory is enabled
 - **Mock OAuth provider now speaks RFC 8628** — the device-flow token endpoint
   returned FastAPI-style `{"detail": ...}` errors (428 for pending), so the
   spec-compliant CLI treated `authorization_pending` as fatal and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased] - 2026-08-15 (later)
 
+### Changed
+- **`OPENAI_MAX_TOKENS` (default 4096) now caps the OpenAI path** — previously
+  unbounded, so this is a behaviour change for existing OpenAI self-hosters:
+  very long diagnoses can now truncate (raise the value if so). The cap exists
+  because OpenAI-compatible brokers (OpenRouter) reserve `max_tokens` against
+  the account balance per request and 402 without it
+- **Upgrade note: agent conversation memory resets once** — checkpointer threads
+  are now namespaced per caller (see below), so existing threads land in a new
+  namespace and prior history is not resumed. Only affects deployments running
+  the optional Redis checkpointer
+
 ### Fixed
 - **Executors can no longer answer another cluster's commands (result injection)**
   — `/executor/results` stored a result for any `command_id` an authenticated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased] - 2026-08-15 (later)
 
+### Fixed
+- **Mock OAuth provider now speaks RFC 8628** — the device-flow token endpoint
+  returned FastAPI-style `{"detail": ...}` errors (428 for pending), so the
+  spec-compliant CLI treated `authorization_pending` as fatal and the
+  `kubently login` device flow could never complete against the local harness.
+  Token errors are now HTTP 400 `{"error": "<code>"}` per spec. CLI device flow
+  verified end-to-end: device code → approval → RS256 JWT stored in
+  ~/.kubently/auth.json, signature validated against the provider JWKS.
+  (Harness also needs `python-multipart` for its form endpoints.)
+
 ### Added
 - **Scheduled fleet health digest (#54, chart 1.0.5)** — a Helm CronJob POSTs
   `/webhooks/fleet-report` on a schedule; the agent sweeps every registered

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -56,6 +56,7 @@
 | `OPENAI_API_KEY` | - | If OpenAI | OpenAI API key |
 | `OPENAI_ENDPOINT` | `https://api.openai.com/v1` | No | OpenAI API endpoint |
 | `OPENAI_MODEL_NAME` | `gpt-4o` | No | OpenAI model to use |
+| `OPENAI_MAX_TOKENS` | `4096` | No | Max completion tokens on the OpenAI path (parity with the Anthropic path). Note: previously unbounded — OpenAI-compatible brokers such as OpenRouter reserve `max_tokens` against the account balance per request, so an unbounded value can 402 on small balances. Raise it if long diagnoses are being truncated |
 | `ANTHROPIC_API_KEY` | - | If Anthropic | Anthropic API key |
 | `ANTHROPIC_MODEL_NAME` | `claude-3-5-sonnet-20241022` | No | Anthropic model to use |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | No | Ollama server URL |
@@ -67,6 +68,8 @@
 |----------|---------|----------|-------------|
 | `LANGSMITH_TRACING` | `false` | No | Enable LangSmith tracing for observability |
 | `LANGSMITH_API_KEY` | - | If tracing enabled | LangSmith API key (set via secret) |
+| `POSTHOG_API_KEY` | - | No | Enables PostHog LLM observability (model, tokens, cost, latency per generation). Unset = no telemetry is collected or sent |
+| `POSTHOG_HOST` | `https://us.i.posthog.com` | No | PostHog ingestion host (use `https://eu.i.posthog.com` for the EU region, or your own reverse proxy) |
 | `LANGSMITH_PROJECT` | `default` | No | Project name in LangSmith UI |
 | `LANGSMITH_ENDPOINT` | `https://api.smith.langchain.com` | No | LangSmith API endpoint |
 | `LANGSMITH_SAMPLE_RATE` | `1.0` | No | Sampling rate (0.0-1.0) for trace volume reduction |

--- a/kubently-cli/nodejs/package-lock.json
+++ b/kubently-cli/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kubently/cli",
-  "version": "2.1.6",
+  "version": "2.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kubently/cli",
-      "version": "2.1.6",
+      "version": "2.3.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -394,6 +394,18 @@ async def post_result(payload: CommandResult, cluster_id: str = Depends(verify_e
     if not queue_module:
         raise HTTPException(503, "Service not initialized")
 
+    # An executor may only answer commands issued to ITS cluster. Executors are
+    # operated by the customer whose cluster they run in, so without this check
+    # any authenticated executor could submit a result for another tenant's
+    # in-flight command and inject fabricated kubectl output into their
+    # diagnosis. Unknown/expired command ids are rejected.
+    if not await queue_module.command_belongs_to(payload.command_id, cluster_id):
+        logger.warning(
+            "Rejected result for command %s from cluster %s (not the issuing cluster)",
+            payload.command_id, cluster_id,
+        )
+        raise HTTPException(403, "Command was not issued to this cluster")
+
     # Store result using queue module
     await queue_module.store_result(payload.command_id, payload.dict())
 
@@ -682,6 +694,10 @@ async def execute_command(
         "timeout": request.timeout_seconds or 10,
         "correlation_id": x_correlation_id or request.correlation_id,
     }
+
+    # Bind this command to the target cluster BEFORE publishing, so a result
+    # can only be accepted from the executor that was actually asked.
+    await queue_module.bind_command(command["id"], request.cluster_id)
 
     # Publish command to executor's Redis channel
     channel = f"executor-commands:{request.cluster_id}"

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -696,8 +696,13 @@ async def execute_command(
     }
 
     # Bind this command to the target cluster BEFORE publishing, so a result
-    # can only be accepted from the executor that was actually asked.
-    await queue_module.bind_command(command["id"], request.cluster_id)
+    # can only be accepted from the executor that was actually asked. The TTL is
+    # derived from how long we will actually wait, so an operator who raises
+    # COMMAND_TIMEOUT past the default can't have valid slow results rejected.
+    timeout = x_request_timeout or request.timeout_seconds or config.get("command_timeout")
+    await queue_module.bind_command(
+        command["id"], request.cluster_id, ttl=max(120, int(timeout) * 2)
+    )
 
     # Publish command to executor's Redis channel
     channel = f"executor-commands:{request.cluster_id}"
@@ -705,7 +710,6 @@ async def execute_command(
     logger.info(f"Published command {command['id']} to channel {channel}")
 
     # Wait for result using existing queue mechanism
-    timeout = x_request_timeout or request.timeout_seconds or config.get("command_timeout")
     result = await queue_module.wait_for_result(command["id"], timeout=timeout)
 
     # === OPTIONAL ENHANCEMENT ===

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -49,6 +49,9 @@ def structured_log(log_data: dict, thread_id: str = None):
         logger.info(json.dumps(log_data, indent=2, default=str))
 
 
+_POSTHOG_CLIENT = None  # module-level singleton, see _posthog_llm_callbacks
+
+
 def _namespaced_thread_id(thread_id: str | None) -> str | None:
     """Bind a conversation thread to the authenticated caller.
 
@@ -87,14 +90,27 @@ def _posthog_llm_callbacks():
     key = os.getenv("POSTHOG_API_KEY")
     if not key:
         return []
+
+    global _POSTHOG_CLIENT
+    if _POSTHOG_CLIENT is None:
+        try:
+            from posthog import Posthog
+        except Exception as e:  # SDK missing/too old — never fail the agent for telemetry
+            logger.warning(f"PostHog LLM observability requested but unavailable: {e}")
+            return []
+        # Singleton: the client owns a background flush thread and connection
+        # pool, and initialize() runs per agent construction — a client per call
+        # would leak both.
+        _POSTHOG_CLIENT = Posthog(
+            key, host=os.getenv("POSTHOG_HOST", "https://us.i.posthog.com")
+        )
+
     try:
-        from posthog import Posthog
         from posthog.ai.langchain import CallbackHandler
-    except Exception as e:  # SDK missing or too old — never fail the agent for telemetry
-        logger.warning(f"PostHog LLM observability requested but unavailable: {e}")
+    except Exception as e:
+        logger.warning(f"PostHog LangChain callback unavailable: {e}")
         return []
-    client = Posthog(key, host=os.getenv("POSTHOG_HOST", "https://us.i.posthog.com"))
-    return [CallbackHandler(client=client)]
+    return [CallbackHandler(client=_POSTHOG_CLIENT)]
 
 
 # Dangerous kubectl verbs that require explicit permission

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -215,7 +215,13 @@ class KubentlyAgent:
         elif "openai" in llm_provider or "azure" in llm_provider:
             from langchain_openai import ChatOpenAI
 
-            self.llm = ChatOpenAI(model=os.getenv("OPENAI_MODEL_NAME", "gpt-4o"))
+            # Cap completion tokens (parity with the Anthropic branch's 4096).
+            # Matters for OpenAI-compatible brokers like OpenRouter, which
+            # reserve max_tokens against the account balance per request.
+            self.llm = ChatOpenAI(
+                model=os.getenv("OPENAI_MODEL_NAME", "gpt-4o"),
+                max_tokens=int(os.getenv("OPENAI_MAX_TOKENS", "4096")),
+            )
             logger.info(f"OpenAI initialized: {llm_provider}")
         elif "google" in llm_provider or "gemini" in llm_provider:
             from langchain_google_genai import ChatGoogleGenerativeAI

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import os
@@ -46,6 +47,32 @@ def structured_log(log_data: dict, thread_id: str = None):
 
         # Log as formatted JSON
         logger.info(json.dumps(log_data, indent=2, default=str))
+
+
+def _namespaced_thread_id(thread_id: str | None) -> str | None:
+    """Bind a conversation thread to the authenticated caller.
+
+    The A2A contextId is client-supplied and is used directly as the LangGraph
+    checkpointer's thread namespace, so without this two callers who pick the
+    same contextId share conversation memory. Prefixing with a hash of the
+    caller's API key keeps threads private per caller while staying stable
+    across that caller's turns (which is what makes multi-turn memory work).
+
+    Returns thread_id unchanged when there is no authenticated caller (direct
+    or local invocation), preserving existing single-tenant behaviour.
+    """
+    if not thread_id:
+        return thread_id
+    try:
+        from kubently.modules.auth.context import current_api_key
+
+        key = current_api_key.get()
+    except Exception:
+        key = None
+    if not key:
+        return thread_id
+    caller = hashlib.sha256(key.encode()).hexdigest()[:16]
+    return f"{caller}:{thread_id}"
 
 
 def _posthog_llm_callbacks():
@@ -622,6 +649,14 @@ class KubentlyAgent:
             cluster_id: Target cluster ID from CLI (if specified)
         """
         await self.initialize()
+
+        # SECURITY: thread_id is the checkpointer's namespace, and it comes from
+        # the A2A message's client-supplied contextId. Un-namespaced, any caller
+        # could resume another caller's conversation — replaying their questions,
+        # kubectl output and cluster internals — by guessing/reusing a contextId.
+        # Bind it to the authenticated caller so threads can never collide across
+        # tenants. Falls back to the raw id for unauthenticated/local invocation.
+        thread_id = _namespaced_thread_id(thread_id)
 
         # Store thread ID for tool call tracking
         self._current_thread_id = thread_id

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -259,7 +259,15 @@ class KubentlyAgent:
 
         # Use the auth module utility to extract API key (handles service:key format)
         from kubently.modules.auth import AuthModule
-        api_key = AuthModule.extract_first_api_key()
+        from kubently.modules.auth.context import current_api_key
+
+        internal_api_key = AuthModule.extract_first_api_key()
+
+        def api_key() -> str:
+            # Per-call: prefer the caller's key (set by the auth wrapper at the
+            # A2A/MCP mount) so tool calls execute with the caller's privileges;
+            # fall back to the internal service key (direct/local invocation).
+            return current_api_key.get() or internal_api_key
 
         # Create tool functions for kubectl operations
         from langchain_core.tools import tool
@@ -289,7 +297,7 @@ class KubentlyAgent:
                 try:
                     response = await client.get(
                         f"{api_url}/debug/clusters",
-                        headers={"X-Api-Key": api_key},
+                        headers={"X-Api-Key": api_key()},
                     )
                     if response.status_code == 200:
                         result = response.json()
@@ -458,7 +466,7 @@ class KubentlyAgent:
 
                     response = await client.post(
                         f"{api_url}/debug/execute",
-                        headers={"X-Api-Key": api_key},
+                        headers={"X-Api-Key": api_key()},
                         json=payload,
                     )
 
@@ -548,7 +556,7 @@ class KubentlyAgent:
             )
             try:
                 output = await run_fleet_command(
-                    api_url, api_key, cluster_ids, build_execute_payload(command, namespace)
+                    api_url, api_key(), cluster_ids, build_execute_payload(command, namespace)
                 )
                 await interceptor.record_tool_result(tool_call_id, output)
                 return output

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -48,6 +48,28 @@ def structured_log(log_data: dict, thread_id: str = None):
         logger.info(json.dumps(log_data, indent=2, default=str))
 
 
+def _posthog_llm_callbacks():
+    """PostHog LLM observability, opt-in via POSTHOG_API_KEY.
+
+    Returns a LangChain callback list that reports each generation
+    (model, tokens, cost, latency) to PostHog, or [] when unset. The import is
+    guarded so an absent/older posthog SDK degrades to no-op rather than breaking
+    the agent. Spike scope: fleet-level capture; per-tenant distinct_id (from the
+    caller's identity) is the follow-up.
+    """
+    key = os.getenv("POSTHOG_API_KEY")
+    if not key:
+        return []
+    try:
+        from posthog import Posthog
+        from posthog.ai.langchain import CallbackHandler
+    except Exception as e:  # SDK missing or too old — never fail the agent for telemetry
+        logger.warning(f"PostHog LLM observability requested but unavailable: {e}")
+        return []
+    client = Posthog(key, host=os.getenv("POSTHOG_HOST", "https://us.i.posthog.com"))
+    return [CallbackHandler(client=client)]
+
+
 # Dangerous kubectl verbs that require explicit permission
 DANGEROUS_VERBS = {
     "delete", "create", "apply", "patch", "edit", "scale",
@@ -187,6 +209,11 @@ class KubentlyAgent:
         llm_provider = os.getenv("LLM_PROVIDER", "").lower()
         enable_context_management = os.getenv("ANTHROPIC_CONTEXT_CLEARING", "true").lower() == "true"
 
+        # PostHog LLM observability (optional): when POSTHOG_API_KEY is set, every
+        # generation reports model/tokens/cost/latency to PostHog. Attached to the
+        # model, so it flows through deepagents without touching the graph.
+        posthog_cbs = _posthog_llm_callbacks()
+
         if "anthropic" in llm_provider or "claude" in llm_provider:
             # For Anthropic models, use direct initialization to enable context management
             if enable_context_management:
@@ -201,7 +228,8 @@ class KubentlyAgent:
                     betas=["context-management-2025-06-27"],
                     context_management={
                         "edits": [{"type": "clear_tool_uses_20250919"}]
-                    }
+                    },
+                    callbacks=posthog_cbs,
                 )
                 logger.info(f"Anthropic Claude initialized with context management: {model_name}")
                 logger.info("Context management will automatically clear tool results to prevent context overflow")
@@ -210,7 +238,7 @@ class KubentlyAgent:
                 from langchain_anthropic import ChatAnthropic
 
                 model_name = os.getenv("ANTHROPIC_MODEL_NAME", "claude-sonnet-4-6")
-                self.llm = ChatAnthropic(model=model_name, max_tokens=4096)
+                self.llm = ChatAnthropic(model=model_name, max_tokens=4096, callbacks=posthog_cbs)
                 logger.info(f"Anthropic Claude initialized without context management: {model_name}")
         elif "openai" in llm_provider or "azure" in llm_provider:
             from langchain_openai import ChatOpenAI
@@ -221,12 +249,13 @@ class KubentlyAgent:
             self.llm = ChatOpenAI(
                 model=os.getenv("OPENAI_MODEL_NAME", "gpt-4o"),
                 max_tokens=int(os.getenv("OPENAI_MAX_TOKENS", "4096")),
+                callbacks=posthog_cbs,
             )
             logger.info(f"OpenAI initialized: {llm_provider}")
         elif "google" in llm_provider or "gemini" in llm_provider:
             from langchain_google_genai import ChatGoogleGenerativeAI
 
-            self.llm = ChatGoogleGenerativeAI(model=os.getenv("GOOGLE_MODEL_NAME", "gemini-2.0-flash"))
+            self.llm = ChatGoogleGenerativeAI(model=os.getenv("GOOGLE_MODEL_NAME", "gemini-2.0-flash"), callbacks=posthog_cbs)
             logger.info(f"Google Gemini initialized: {llm_provider}")
         else:
             raise ValueError(

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
@@ -72,6 +72,15 @@ class KubentlyAgentExecutor(AgentExecutor):
 
         logger.info(f"Using contextId: {contextId}, cluster_id: {cluster_id}")
 
+        # Tool calls are recorded by the agent under the CALLER-NAMESPACED thread
+        # id (see agent._namespaced_thread_id), so the interceptor must be queried
+        # with the same value — matching is exact equality. Querying the raw
+        # contextId silently returns [] and the "🔧 Tool Call" stream events
+        # (which test-automation parses) vanish.
+        from .agent import _namespaced_thread_id
+
+        traceThreadId = _namespaced_thread_id(contextId)
+
         if not context.message:
             raise Exception("No message provided")
 
@@ -155,7 +164,7 @@ class KubentlyAgentExecutor(AgentExecutor):
                 if last_tool_check_time is None or last_tool_check_time < current_time:
                     # Get tool calls since last check
                     tool_calls = await interceptor.get_tool_calls_for_thread(
-                        contextId, 
+                        traceThreadId,
                         since_timestamp=last_tool_check_time
                     )
                     
@@ -194,7 +203,7 @@ class KubentlyAgentExecutor(AgentExecutor):
             
             # Emit any remaining tool calls
             final_tool_calls = await interceptor.get_tool_calls_for_thread(
-                contextId, 
+                traceThreadId,
                 since_timestamp=last_tool_check_time
             )
             for tool_call in final_tool_calls:

--- a/kubently/modules/auth/auth.py
+++ b/kubently/modules/auth/auth.py
@@ -159,9 +159,19 @@ class AuthModule:
 
             return True, service_identity
 
-        # Could check Redis for dynamic keys here in future
-        # redis_key = f"api:key:{hashlib.sha256(api_key.encode()).hexdigest()}"
-        # stored_data = await self.redis.get(redis_key)
+        # Dynamic keys (issued at runtime, e.g. per tenant by a control plane):
+        # api:key:{sha256(key)} = identity string. Only the hash is stored.
+        if self.redis is not None:
+            redis_key = f"api:key:{hashlib.sha256(api_key.encode()).hexdigest()}"
+            identity = await self.redis.get(redis_key)
+            if identity:
+                identity = identity.decode("utf-8") if isinstance(identity, bytes) else identity
+                await self._log_event(
+                    "api_key_verified",
+                    {"service_identity": identity, "dynamic": True,
+                     "timestamp": datetime.now(UTC).isoformat()},
+                )
+                return True, identity
 
         return False, None
 

--- a/kubently/modules/auth/context.py
+++ b/kubently/modules/auth/context.py
@@ -1,0 +1,13 @@
+"""Request-scoped auth context.
+
+current_api_key carries the caller's validated API key from the auth layer into
+downstream code (e.g. agent tools making internal HTTP calls), so those calls can
+execute with the caller's privileges instead of a shared internal key. ContextVars
+propagate through asyncio.create_task, so background work spawned from a request
+inherits the caller's key automatically.
+"""
+
+from contextvars import ContextVar
+from typing import Optional
+
+current_api_key: ContextVar[Optional[str]] = ContextVar("current_api_key", default=None)

--- a/kubently/modules/auth/mock_oauth_provider.py
+++ b/kubently/modules/auth/mock_oauth_provider.py
@@ -333,10 +333,24 @@ def create_mock_oauth_app() -> FastAPI:
         """Token endpoint."""
         form = await request.form()
         grant_type = form.get("grant_type")
-        
+
         if grant_type == "urn:ietf:params:oauth:grant-type:device_code":
             device_code = form.get("device_code")
-            return provider.device_token(device_code)
+            try:
+                return provider.device_token(device_code)
+            except HTTPException as e:
+                # RFC 8628 §3.5: token errors are HTTP 400 with {"error": "<code>"} —
+                # NOT FastAPI's {"detail": ...}. Real IdPs (and the CLI's poll loop)
+                # speak the spec shape; without this remap the CLI treats
+                # authorization_pending as fatal instead of continuing to poll.
+                error_map = {
+                    "authorization_pending": "authorization_pending",
+                    "access_denied": "access_denied",
+                    "Device code expired": "expired_token",
+                    "Invalid device_code": "invalid_grant",
+                }
+                code = error_map.get(str(e.detail), "invalid_grant")
+                return JSONResponse(status_code=400, content={"error": code})
         
         elif grant_type == "refresh_token":
             refresh_token = form.get("refresh_token")

--- a/kubently/modules/mcp/server.py
+++ b/kubently/modules/mcp/server.py
@@ -102,6 +102,13 @@ def add_api_key_auth(app, auth_module, public_well_known=False):
         if api_key:
             valid, _ = await auth_module.verify_api_key(api_key)
 
+        if valid:
+            # Expose the caller's key to downstream code (agent tools) so internal
+            # calls can act as the caller instead of the shared internal key.
+            from kubently.modules.auth.context import current_api_key
+
+            current_api_key.set(api_key)
+
         if not valid:
             from starlette.responses import JSONResponse
 

--- a/kubently/modules/queue/queue.py
+++ b/kubently/modules/queue/queue.py
@@ -111,6 +111,26 @@ class QueueModule:
 
         return commands
 
+    async def bind_command(self, command_id: str, cluster_id: str, ttl: int = 120) -> None:
+        """Record which cluster a command was issued to.
+
+        Results are submitted by executors, which are operated by the customer
+        whose cluster they run in. Without this binding any authenticated
+        executor could submit a result for ANY command_id — injecting fabricated
+        kubectl output into another tenant's in-flight diagnosis. TTL covers the
+        command's lifetime; expiry just means late results are rejected.
+        """
+        await self.redis.setex(f"command:cluster:{command_id}", ttl, cluster_id)
+
+    async def command_belongs_to(self, command_id: str, cluster_id: str) -> bool:
+        """True if this command was issued to this cluster (unknown -> False)."""
+        owner = await self.redis.get(f"command:cluster:{command_id}")
+        if owner is None:
+            return False
+        if isinstance(owner, bytes):
+            owner = owner.decode("utf-8")
+        return owner == cluster_id
+
     async def store_result(self, command_id: str, result: dict) -> None:
         """
         Store command execution result.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,10 @@ a2a = [
     # Optional MCP support
     "langchain-mcp-adapters>=0.1.0",
     "mcp>=1.2.0",  # serve Kubently as an MCP server (FastMCP + streamable-http)
+
+    # Optional LLM observability — PostHog LLM analytics via LangChain callback,
+    # active only when POSTHOG_API_KEY is set (agent._posthog_llm_callbacks)
+    "posthog>=6.0.0",
     
     # Async support
     "aiohttp>=3.9.0",

--- a/tests/test_dynamic_api_keys.py
+++ b/tests/test_dynamic_api_keys.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Dynamic (Redis-backed) API keys + caller-key forwarding.
+
+A control plane can issue keys at runtime by writing api:key:{sha256(key)} =
+identity to Redis; AuthModule.verify_api_key must accept them alongside the
+static API_KEYS env keys. The auth wrapper must expose the caller's validated
+key via the current_api_key contextvar so agent tools act as the caller.
+"""
+
+import hashlib
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.auth.auth import AuthModule  # noqa: E402
+from kubently.modules.auth.context import current_api_key  # noqa: E402
+from kubently.modules.mcp.server import add_api_key_auth  # noqa: E402
+
+
+class FakeRedis:
+    """Just enough async Redis for AuthModule: get + audit-log no-ops."""
+
+    def __init__(self, data=None):
+        self.data = data or {}
+
+    async def get(self, key):
+        return self.data.get(key)
+
+    async def lpush(self, *a):
+        pass
+
+    async def ltrim(self, *a):
+        pass
+
+
+def _sha(key: str) -> str:
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_key_accepted(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "static-key")
+    redis = FakeRedis({f"api:key:{_sha('tenant-key-1')}": "tenant:abc"})
+    auth = AuthModule(redis)
+
+    ok, identity = await auth.verify_api_key("tenant-key-1")
+    assert ok and identity == "tenant:abc"
+
+    # Static env keys still work; unknown keys still fail.
+    assert (await auth.verify_api_key("static-key"))[0]
+    assert not (await auth.verify_api_key("nope"))[0]
+
+
+@pytest.mark.asyncio
+async def test_dynamic_key_without_redis(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "static-key")
+    assert not (await AuthModule(None).verify_api_key("tenant-key-1"))[0]
+
+
+@pytest.mark.asyncio
+async def test_auth_wrapper_sets_current_api_key(monkeypatch):
+    monkeypatch.setenv("API_KEYS", "good-key")
+    seen = {}
+
+    async def inner_app(scope, receive, send):
+        seen["key"] = current_api_key.get()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    wrapped = add_api_key_auth(inner_app, AuthModule(FakeRedis()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/a2a/",
+        "headers": [(b"x-api-key", b"good-key")],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b""}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    await wrapped(scope, receive, send)
+    assert seen["key"] == "good-key"
+    assert sent[0]["status"] == 200

--- a/tests/test_result_binding.py
+++ b/tests/test_result_binding.py
@@ -59,3 +59,30 @@ async def test_binding_is_bytes_safe():
     await q.bind_command("cmd-2", "cluster-x")
     assert await q.command_belongs_to("cmd-2", "cluster-x")
     assert not await q.command_belongs_to("cmd-2", "cluster-y")
+
+
+def test_endpoint_enforces_the_binding():
+    """The helper being correct is worthless if the endpoint never calls it.
+
+    Reverting the check in post_result reintroduces the vulnerability while the
+    unit tests above still pass — so assert the wiring explicitly.
+    """
+    from pathlib import Path
+
+    main_src = (Path(__file__).parent.parent / "kubently/main.py").read_text()
+
+    # /debug/execute must bind before publishing.
+    assert "bind_command(" in main_src, "commands are never bound to a cluster"
+    idx_bind = main_src.index("bind_command(")
+    idx_publish = main_src.index("redis_client.publish(channel", idx_bind - 4000)
+    assert idx_bind < idx_publish, "bind must happen before publish (else a race)"
+
+    # /executor/results must reject foreign clusters.
+    idx_results = main_src.index('@app.post("/executor/results")')
+    idx_store = main_src.index("store_result(", idx_results)
+    segment = main_src[idx_results:idx_store]
+    assert "command_belongs_to(" in segment, (
+        "post_result stores a result without verifying the command was issued to "
+        "this executor's cluster — cross-tenant result injection"
+    )
+    assert "403" in segment

--- a/tests/test_result_binding.py
+++ b/tests/test_result_binding.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""An executor may only answer commands issued to its own cluster.
+
+Executors run inside customer clusters, so the customer controls them. Before
+this binding, any authenticated executor could POST /executor/results for ANY
+command_id — injecting fabricated kubectl output into another tenant's in-flight
+diagnosis (the agent would then report that as the other tenant's cluster state).
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from kubently.modules.queue.queue import QueueModule  # noqa: E402
+
+
+class FakeRedis:
+    def __init__(self):
+        self.kv = {}
+
+    async def setex(self, k, ttl, v):
+        self.kv[k] = v
+
+    async def get(self, k):
+        return self.kv.get(k)
+
+
+@pytest.mark.asyncio
+async def test_issuing_cluster_accepted_others_rejected():
+    q = QueueModule(FakeRedis())
+    await q.bind_command("cmd-1", "tenant-a-cluster")
+
+    assert await q.command_belongs_to("cmd-1", "tenant-a-cluster")
+    # The attack: tenant B's executor answering tenant A's command.
+    assert not await q.command_belongs_to("cmd-1", "tenant-b-cluster")
+
+
+@pytest.mark.asyncio
+async def test_unknown_or_expired_command_rejected():
+    """Fails closed: an id we never issued (or whose binding expired) is denied,
+    so a guessed id can't be used to smuggle a result in."""
+    q = QueueModule(FakeRedis())
+    assert not await q.command_belongs_to("never-issued", "any-cluster")
+
+
+@pytest.mark.asyncio
+async def test_binding_is_bytes_safe():
+    """decode_responses=False clients hand back bytes; comparison must still hold."""
+    class BytesRedis(FakeRedis):
+        async def get(self, k):
+            v = self.kv.get(k)
+            return v.encode() if isinstance(v, str) else v
+
+    q = QueueModule(BytesRedis())
+    await q.bind_command("cmd-2", "cluster-x")
+    assert await q.command_belongs_to("cmd-2", "cluster-x")
+    assert not await q.command_belongs_to("cmd-2", "cluster-y")

--- a/tests/test_thread_namespacing.py
+++ b/tests/test_thread_namespacing.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Conversation threads must be private to the authenticated caller.
+
+The A2A contextId is client-supplied and is used directly as the LangGraph
+checkpointer's thread namespace. Un-namespaced, caller A could resume caller B's
+conversation — replaying B's questions, kubectl output and cluster internals —
+just by reusing B's contextId. _namespaced_thread_id binds the thread to the
+caller's validated key.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from kubently.modules.auth.context import current_api_key  # noqa: E402
+
+
+def _load_namespacer():
+    """Import just the helper without pulling in the heavy a2a/langchain stack."""
+    path = (Path(__file__).parent.parent / "kubently/modules/a2a/protocol_bindings"
+            / "a2a_server/agent.py")
+    src = path.read_text()
+    start = src.index("def _namespaced_thread_id")
+    end = src.index("def _posthog_llm_callbacks")
+    ns: dict = {}
+    exec("import hashlib\n" + src[start:end], ns)
+    return ns["_namespaced_thread_id"]
+
+
+_namespaced_thread_id = _load_namespacer()
+
+
+def test_same_context_id_differs_across_callers():
+    """The core isolation property: identical contextId, different callers,
+    different checkpointer namespaces."""
+    token_a = current_api_key.set("tenant-a-key")
+    a = _namespaced_thread_id("shared-context-123")
+    current_api_key.reset(token_a)
+
+    token_b = current_api_key.set("tenant-b-key")
+    b = _namespaced_thread_id("shared-context-123")
+    current_api_key.reset(token_b)
+
+    assert a != b, "two tenants reusing a contextId must not share a thread"
+    assert "shared-context-123" in a and "shared-context-123" in b
+
+
+def test_stable_across_turns_for_same_caller():
+    """Multi-turn memory only works if the namespace is deterministic."""
+    token = current_api_key.set("tenant-a-key")
+    first = _namespaced_thread_id("ctx-1")
+    second = _namespaced_thread_id("ctx-1")
+    current_api_key.reset(token)
+    assert first == second
+
+
+def test_key_not_leaked_into_thread_id():
+    """The namespace is a hash prefix — never the raw credential (thread ids
+    reach logs, traces and Redis keys)."""
+    token = current_api_key.set("super-secret-key")
+    tid = _namespaced_thread_id("ctx-1")
+    current_api_key.reset(token)
+    assert "super-secret-key" not in tid
+
+
+def test_unauthenticated_passthrough_unchanged():
+    """Direct/local invocation (no caller) keeps existing behaviour."""
+    assert current_api_key.get() is None
+    assert _namespaced_thread_id("ctx-1") == "ctx-1"
+    assert _namespaced_thread_id(None) is None

--- a/tests/test_tool_trace_thread_match.py
+++ b/tests/test_tool_trace_thread_match.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Tool-call tracing: the recording side and the query side must agree.
+
+The agent records tool calls under the caller-namespaced thread id; the A2A
+executor queries the interceptor for them to emit "🔧 Tool Call" stream events,
+which test-automation parses. The interceptor matches thread_id by EXACT
+equality, so if one side namespaces and the other doesn't, the lookup silently
+returns [] — no error, just permanently missing tool visibility.
+
+That regression shipped once (agent namespaced, executor still queried the raw
+contextId). These tests pin both halves.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+A2A = Path(__file__).parent.parent / "kubently/modules/a2a/protocol_bindings/a2a_server"
+AGENT_SRC = (A2A / "agent.py").read_text()
+EXECUTOR_SRC = (A2A / "agent_executor.py").read_text()
+
+
+def test_executor_queries_with_namespaced_thread_id():
+    """Every get_tool_calls_for_thread call must use the namespaced id, never
+    the raw client-supplied contextId."""
+    calls = re.findall(
+        r"get_tool_calls_for_thread\(\s*([A-Za-z_][A-Za-z0-9_]*)", EXECUTOR_SRC
+    )
+    assert calls, "expected interceptor queries in agent_executor"
+    for arg in calls:
+        assert arg != "contextId", (
+            "agent_executor queries the interceptor with the raw contextId, but the "
+            "agent records under the namespaced thread id — tool call events will "
+            "silently never be emitted"
+        )
+        assert arg == "traceThreadId", f"unexpected thread id argument: {arg}"
+
+
+def test_executor_derives_trace_id_from_the_same_helper():
+    """Both sides must derive the namespace from one function, so they can't drift."""
+    assert "_namespaced_thread_id" in EXECUTOR_SRC
+    assert "traceThreadId = _namespaced_thread_id(contextId)" in EXECUTOR_SRC
+
+
+def test_agent_records_under_namespaced_id():
+    """The recording side still namespaces (the other half of the contract)."""
+    assert "thread_id = _namespaced_thread_id(thread_id)" in AGENT_SRC
+    idx_ns = AGENT_SRC.index("thread_id = _namespaced_thread_id(thread_id)")
+    idx_store = AGENT_SRC.index("self._current_thread_id = thread_id", idx_ns)
+    assert idx_store > idx_ns, "namespacing must happen before the id is stored"
+
+
+@pytest.mark.asyncio
+async def test_recorded_call_is_retrievable_by_the_queried_id():
+    """End-to-end on the interceptor itself: a call recorded under a namespaced
+    id is found when queried with that same id, and NOT with the raw one."""
+    from kubently.modules.a2a.protocol_bindings.a2a_server.tool_call_interceptor import (
+        get_tool_call_interceptor,
+    )
+
+    interceptor = get_tool_call_interceptor()
+    raw = "ctx-abc"
+    namespaced = f"deadbeefdeadbeef:{raw}"
+
+    await interceptor.record_tool_call(
+        tool_name="execute_kubectl", args={"command": "get pods"}, thread_id=namespaced
+    )
+
+    found = await interceptor.get_tool_calls_for_thread(namespaced)
+    assert any(c["tool_name"] == "execute_kubectl" for c in found)
+
+    missed = await interceptor.get_tool_calls_for_thread(raw)
+    assert not any(c["tool_name"] == "execute_kubectl" for c in missed), (
+        "querying the raw contextId must not find namespaced records — this is "
+        "exactly the silent-empty-result failure mode"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -256,6 +256,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "backrefs"
 version = "7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1107,6 +1116,7 @@ a2a = [
     { name = "langsmith" },
     { name = "mcp" },
     { name = "openai" },
+    { name = "posthog" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "starlette" },
@@ -1170,6 +1180,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "openai", marker = "extra == 'a2a'", specifier = ">=1.50.0" },
+    { name = "posthog", marker = "extra == 'a2a'", specifier = ">=6.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic", marker = "extra == 'a2a'", specifier = ">=2.0.0" },
@@ -2072,6 +2083,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/77/3737f60571995ba07677b058bb1523b7c26f28570806b8ffaf83a66df18c/posthog-7.39.1.tar.gz", hash = "sha256:0d184596e35057457fc1094883646fd23de2d6338db8b9c3ea770643fb55d8a2", size = 428586, upload-time = "2026-08-14T13:50:24.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/79/ee5c01937bfb0c80415929e25aa1e8296c48e26fc9a10fe1d9f665f0f478/posthog-7.39.1-py3-none-any.whl", hash = "sha256:e76e82fe571314a0a9bc11d039fd1a1a8d210cd0f737899d41b31f61b73bf08c", size = 504259, upload-time = "2026-08-14T13:50:22.896Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

1. **Dynamic API keys**: `AuthModule.verify_api_key` now also checks Redis `api:key:{sha256(key)}` → identity (only the hash is stored), alongside static `API_KEYS`. This implements the commented-out TODO already in the code, and lets an external control plane issue/revoke keys without restarts.
2. **Caller-key forwarding**: the A2A/MCP auth wrapper stores the validated caller key in a `current_api_key` contextvar; agent tools (`list_clusters`, `execute_kubectl`, `execute_kubectl_multi`) send it on internal `/debug/*` calls instead of the shared first-`API_KEYS` god-key. Fallback to the internal key is unchanged for direct/local use.

## Why

Today every agent tool call authenticates as the internal service key, so any authenticated A2A caller can execute on any registered cluster. With the caller's own key on internal calls, a gateway (e.g. a hosted multi-tenant deployment) can enforce per-caller cluster scoping at the HTTP layer — least privilege, no fork.

## Testing

- New `tests/test_dynamic_api_keys.py`: dynamic key accepted/rejected, no-Redis fallback, wrapper sets the contextvar
- Full unit suite: 141 passed, 1 skipped (pre-existing `langgraph.checkpoint.redis` optional-dep skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)