### PR TITLE
a2a: selectable checkpointer backend (plain Redis, no RediSearch needed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased] - 2026-08-16
+
+### Added
+- **Selectable checkpointer backend for A2A conversation memory** — new
+  `KUBENTLY_CHECKPOINTER_BACKEND` env var chooses how LangGraph checkpoints are
+  stored: `redisearch` (default, unchanged AsyncRedisSaver path), `plain-redis`
+  (new `PlainRedisSaver` using only core Redis commands — enables cross-request
+  memory on RediSearch-less Redis such as Upstash), `memory` (per-process, for
+  dev/tests), or `none` (explicitly off). Selection lives in
+  `kubently/modules/a2a/protocol_bindings/a2a_server/checkpointer.py`; graceful
+  degradation is preserved — any backend init failure logs a warning and the
+  agent keeps answering single-request diagnoses without memory
+- **`KUBENTLY_CHECKPOINT_TTL_SECONDS`** (default 7 days, `0` disables) bounds
+  checkpoint key growth for the `plain-redis` backend; TTLs are refreshed on
+  every checkpoint write so active conversations never expire mid-flight
+- **Checkpointer tests** (`tests/test_checkpointer.py`) — backend selection,
+  save/restore round-trips, thread isolation, TTL behavior, and end-to-end
+  LangGraph graphs checkpointed on fakeredis (which, like Upstash, has no
+  RediSearch); `fakeredis` added to the `test` extra
+
 ## [Unreleased] - 2026-08-15 (later)
 
 ### Changed

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -48,6 +48,21 @@
 | `KUBENTLY_MAX_FLEET_CLUSTERS` | `10` | No | Max clusters per `execute_kubectl_multi` fan-out call (each cluster adds up to ~4KB to the agent context) |
 | `A2A_SERVER_DEBUG` | `false` | No | Enable A2A debug logging |
 
+### Conversation Memory (A2A Checkpointing)
+
+The A2A agent persists multi-turn conversation state through a LangGraph
+checkpointer. The backend is selectable so checkpointing works on Redis
+servers without the RediSearch module (e.g. Upstash):
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `KUBENTLY_CHECKPOINTER_BACKEND` | `redisearch` | No | Checkpointer backend: `redisearch` (AsyncRedisSaver; requires the RediSearch module), `plain-redis` (core Redis commands only; works on Upstash and any managed Redis), `memory` (per-process, dev/test only), or `none` (disable cross-request memory) |
+| `KUBENTLY_CHECKPOINT_TTL_SECONDS` | `604800` (7 days) | No | TTL for `plain-redis` checkpoint keys; refreshed on every checkpoint write, so active conversations never expire mid-flight. Set to `0` to disable expiry. Ignored by other backends |
+
+Whatever the backend, initialization failure degrades gracefully: the agent
+logs a warning and continues without cross-request memory, and single-request
+diagnoses are unaffected.
+
 ### LLM Configuration (for A2A)
 
 | Variable | Default | Required | Description |

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -10,8 +10,7 @@ import httpx
 from deepagents import create_deep_agent
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.runnables.config import RunnableConfig
-from langgraph.checkpoint.redis.aio import AsyncRedisSaver
-
+from .checkpointer import create_checkpointer
 from .fleet import cap_output
 from .tool_call_interceptor import get_tool_call_interceptor
 
@@ -183,6 +182,9 @@ class KubentlyAgent:
         self.agent = None
         # Memory will be initialized in async context
         self.memory = None
+        # True when checkpointing is intentionally off (backend "none" or no
+        # Redis client), so initialize() doesn't retry on every request.
+        self._memory_disabled = False
         self._initialized = False
         self.system_prompt = None
         # Investigation tracking
@@ -224,26 +226,20 @@ class KubentlyAgent:
 
     async def initialize(self):
         """Initialize the agent with LLM and tools."""
-        if self._initialized and self.memory is not None:
+        if self._initialized and (self.memory is not None or self._memory_disabled):
             return
 
         if self._initialized and self.memory is None:
             logger.info("Agent initialized but memory failed previously, retrying memory setup...")
 
-        # Initialize memory in async context
-        memory_initialized = False
+        # Initialize memory in async context. Backend selection (RediSearch,
+        # plain Redis, in-memory, none) lives in checkpointer.create_checkpointer.
         try:
-
-            if self.redis_client:
-                # Test Redis connection first
-                await self.redis_client.ping()
-                self.memory = AsyncRedisSaver(redis_client=self.redis_client)
-                # Setup is required to initialize indices
-                await self.memory.setup()
-                logger.info("AsyncRedisSaver initialized and setup successfully")
-                memory_initialized = True
+            self.memory = await create_checkpointer(self.redis_client)
+            if self.memory is None:
+                self._memory_disabled = True
         except Exception as e:
-            logger.warning(f"Failed to initialize AsyncRedisSaver: {e}")
+            logger.warning(f"Failed to initialize checkpointer: {e}")
             logger.warning("Continuing without memory persistence")
             self.memory = None
 

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/checkpointer.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/checkpointer.py
@@ -1,0 +1,453 @@
+"""Checkpointer backend selection for the A2A server.
+
+The A2A agent uses a LangGraph checkpointer for cross-request conversation
+memory. Historically the only backend was AsyncRedisSaver from
+langgraph-checkpoint-redis, which requires the RediSearch module (FT.CREATE /
+FT.SEARCH). Managed Redis offerings such as Upstash don't ship RediSearch, so
+this module adds selectable backends:
+
+- ``redisearch`` (default): AsyncRedisSaver, unchanged from previous behavior.
+  Requires a Redis server with the RediSearch module.
+- ``plain-redis``: PlainRedisSaver (defined here), which uses only core Redis
+  commands (HSET/ZADD/EXPIRE) and works on any Redis, including Upstash.
+- ``memory``: LangGraph's InMemorySaver. Per-process only; for local dev/tests.
+- ``none``: explicitly disable checkpointing. Single-request diagnoses still
+  work; multi-turn memory is off.
+
+Selection is via the KUBENTLY_CHECKPOINTER_BACKEND environment variable. If a
+backend fails to initialize the agent degrades gracefully to no memory, same
+as before.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
+
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    WRITES_IDX_MAP,
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    get_checkpoint_id,
+    get_checkpoint_metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+BACKEND_ENV = "KUBENTLY_CHECKPOINTER_BACKEND"
+TTL_ENV = "KUBENTLY_CHECKPOINT_TTL_SECONDS"
+
+DEFAULT_BACKEND = "redisearch"
+# Applies to the plain-redis backend only. 0 disables expiry. The default
+# bounds key growth on managed Redis; the TTL is refreshed on every
+# checkpoint write, so active conversations never expire mid-flight.
+DEFAULT_TTL_SECONDS = 7 * 24 * 3600
+
+# Canonical backend names, with accepted aliases.
+_BACKEND_ALIASES = {
+    "redisearch": "redisearch",
+    "redis": "redisearch",
+    "plain-redis": "plain-redis",
+    "redis-plain": "plain-redis",
+    "plain": "plain-redis",
+    "memory": "memory",
+    "in-memory": "memory",
+    "none": "none",
+    "disabled": "none",
+    "off": "none",
+}
+
+
+def _b64e(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def _b64d(data: str) -> bytes:
+    return base64.b64decode(data.encode("ascii"))
+
+
+def _s(value: Any) -> str:
+    """Normalize a Redis reply to str (client may or may not decode responses)."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return value
+
+
+class PlainRedisSaver(BaseCheckpointSaver[str]):
+    """Async LangGraph checkpoint saver using only core Redis commands.
+
+    No RediSearch required: checkpoints are stored in hashes, ordered per
+    thread by a sorted set of checkpoint IDs (uuid6 IDs sort chronologically).
+    All binary payloads are base64-encoded so the saver works with clients
+    created with decode_responses=True (as Kubently's is).
+
+    Key layout (prefix configurable, default "kubently:ckpt"):
+    - {p}:cp:{thread}:{ns}:{id}        hash: serialized checkpoint + metadata + parent id
+    - {p}:idx:{thread}:{ns}            zset (score 0): checkpoint ids, lex order = time order
+    - {p}:blob:{thread}:{ns}:{ch}:{v}  hash: one channel value at one version
+    - {p}:wr:{thread}:{ns}:{id}        hash: pending writes for a checkpoint
+    - {p}:threadkeys:{thread}          set: every key created for the thread
+      (used for TTL refresh and thread deletion without SCAN)
+
+    Async-only: the A2A server always drives graphs with ainvoke/astream, so
+    the sync BaseCheckpointSaver methods keep their default NotImplementedError.
+    """
+
+    def __init__(
+        self,
+        redis_client: Any,
+        *,
+        prefix: str = "kubently:ckpt",
+        ttl_seconds: int | None = DEFAULT_TTL_SECONDS,
+        serde: Any = None,
+    ) -> None:
+        super().__init__(serde=serde)
+        self._redis = redis_client
+        self._prefix = prefix
+        self._ttl = ttl_seconds if ttl_seconds and ttl_seconds > 0 else None
+
+    # -- key helpers ---------------------------------------------------------
+
+    def _cp_key(self, thread_id: str, ns: str, checkpoint_id: str) -> str:
+        return f"{self._prefix}:cp:{thread_id}:{ns}:{checkpoint_id}"
+
+    def _idx_key(self, thread_id: str, ns: str) -> str:
+        return f"{self._prefix}:idx:{thread_id}:{ns}"
+
+    def _blob_key(self, thread_id: str, ns: str, channel: str, version: Any) -> str:
+        return f"{self._prefix}:blob:{thread_id}:{ns}:{channel}:{version}"
+
+    def _writes_key(self, thread_id: str, ns: str, checkpoint_id: str) -> str:
+        return f"{self._prefix}:wr:{thread_id}:{ns}:{checkpoint_id}"
+
+    def _threadkeys_key(self, thread_id: str) -> str:
+        return f"{self._prefix}:threadkeys:{thread_id}"
+
+    # -- version generation --------------------------------------------------
+
+    def get_next_version(self, current: str | int | float | None, channel: None = None) -> str:
+        if current is None:
+            current_v = 0
+        elif isinstance(current, int):
+            current_v = current
+        else:
+            current_v = int(str(current).split(".")[0])
+        return f"{current_v + 1:032}"
+
+    # -- write path ----------------------------------------------------------
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        thread_id = config["configurable"]["thread_id"]
+        ns = config["configurable"].get("checkpoint_ns", "")
+        checkpoint_id = checkpoint["id"]
+        parent_id = config["configurable"].get("checkpoint_id")
+
+        c = dict(checkpoint)
+        channel_values: dict[str, Any] = c.pop("channel_values", {})
+
+        cp_type, cp_data = self.serde.dumps_typed(c)
+        md_type, md_data = self.serde.dumps_typed(get_checkpoint_metadata(config, metadata))
+
+        cp_key = self._cp_key(thread_id, ns, checkpoint_id)
+        idx_key = self._idx_key(thread_id, ns)
+        wr_key = self._writes_key(thread_id, ns, checkpoint_id)
+        tk_key = self._threadkeys_key(thread_id)
+
+        pipe = self._redis.pipeline(transaction=True)
+        pipe.hset(
+            cp_key,
+            mapping={
+                "checkpoint_type": cp_type,
+                "checkpoint": _b64e(cp_data),
+                "metadata_type": md_type,
+                "metadata": _b64e(md_data),
+                "parent_id": parent_id or "",
+            },
+        )
+        pipe.zadd(idx_key, {checkpoint_id: 0})
+
+        touched = [cp_key, idx_key, wr_key]
+        for channel, version in new_versions.items():
+            blob_key = self._blob_key(thread_id, ns, channel, version)
+            if channel in channel_values:
+                blob_type, blob_data = self.serde.dumps_typed(channel_values[channel])
+            else:
+                blob_type, blob_data = "empty", b""
+            pipe.hset(blob_key, mapping={"type": blob_type, "data": _b64e(blob_data)})
+            touched.append(blob_key)
+
+        pipe.sadd(tk_key, *touched)
+        if self._ttl:
+            # Refresh the whole thread's TTL on activity so an active
+            # conversation never loses older checkpoints mid-conversation.
+            for key in [*touched, tk_key]:
+                pipe.expire(key, self._ttl)
+        await pipe.execute()
+
+        if self._ttl:
+            # Keys created by earlier turns (older checkpoints/blobs) also get
+            # their TTL refreshed, off the hot path of the pipeline above.
+            existing = await self._redis.smembers(tk_key)
+            stale = [_s(k) for k in existing if _s(k) not in set(touched)]
+            if stale:
+                refresh = self._redis.pipeline(transaction=False)
+                for key in stale:
+                    refresh.expire(key, self._ttl)
+                await refresh.execute()
+
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": ns,
+                "checkpoint_id": checkpoint_id,
+            }
+        }
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        thread_id = config["configurable"]["thread_id"]
+        ns = config["configurable"].get("checkpoint_ns", "")
+        checkpoint_id = config["configurable"]["checkpoint_id"]
+        wr_key = self._writes_key(thread_id, ns, checkpoint_id)
+        tk_key = self._threadkeys_key(thread_id)
+
+        pipe = self._redis.pipeline(transaction=True)
+        for idx, (channel, value) in enumerate(writes):
+            write_idx = WRITES_IDX_MAP.get(channel, idx)
+            field = f"{task_id}\x1f{write_idx}"
+            value_type, value_data = self.serde.dumps_typed(value)
+            payload = json.dumps(
+                {
+                    "task_id": task_id,
+                    "idx": write_idx,
+                    "channel": channel,
+                    "type": value_type,
+                    "data": _b64e(value_data),
+                    "task_path": task_path,
+                }
+            )
+            if write_idx >= 0:
+                # Regular writes are idempotent per (task, idx): first wins.
+                pipe.hsetnx(wr_key, field, payload)
+            else:
+                # Special channels (error/interrupt/...) always overwrite.
+                pipe.hset(wr_key, field, payload)
+        pipe.sadd(tk_key, wr_key)
+        if self._ttl:
+            pipe.expire(wr_key, self._ttl)
+            pipe.expire(tk_key, self._ttl)
+        await pipe.execute()
+
+    # -- read path -----------------------------------------------------------
+
+    async def _load_pending_writes(
+        self, thread_id: str, ns: str, checkpoint_id: str
+    ) -> list[tuple[str, str, Any]]:
+        raw = await self._redis.hgetall(self._writes_key(thread_id, ns, checkpoint_id))
+        entries = []
+        for payload in raw.values():
+            entry = json.loads(_s(payload))
+            entries.append(entry)
+        entries.sort(key=lambda e: (e["task_id"], e["idx"]))
+        return [
+            (e["task_id"], e["channel"], self.serde.loads_typed((e["type"], _b64d(e["data"]))))
+            for e in entries
+        ]
+
+    async def _load_channel_values(
+        self, thread_id: str, ns: str, versions: ChannelVersions
+    ) -> dict[str, Any]:
+        if not versions:
+            return {}
+        channels = list(versions.items())
+        pipe = self._redis.pipeline(transaction=False)
+        for channel, version in channels:
+            pipe.hgetall(self._blob_key(thread_id, ns, channel, version))
+        blobs = await pipe.execute()
+        values: dict[str, Any] = {}
+        for (channel, _version), blob in zip(channels, blobs):
+            if not blob:
+                continue
+            blob = {_s(k): _s(v) for k, v in blob.items()}
+            if blob.get("type") == "empty":
+                continue
+            values[channel] = self.serde.loads_typed((blob["type"], _b64d(blob["data"])))
+        return values
+
+    async def _load_tuple(
+        self, thread_id: str, ns: str, checkpoint_id: str
+    ) -> CheckpointTuple | None:
+        raw = await self._redis.hgetall(self._cp_key(thread_id, ns, checkpoint_id))
+        if not raw:
+            return None
+        raw = {_s(k): _s(v) for k, v in raw.items()}
+        checkpoint: Checkpoint = self.serde.loads_typed(
+            (raw["checkpoint_type"], _b64d(raw["checkpoint"]))
+        )
+        metadata: CheckpointMetadata = self.serde.loads_typed(
+            (raw["metadata_type"], _b64d(raw["metadata"]))
+        )
+        checkpoint = {
+            **checkpoint,
+            "channel_values": await self._load_channel_values(
+                thread_id, ns, checkpoint.get("channel_versions", {})
+            ),
+        }
+        parent_id = raw.get("parent_id") or None
+        return CheckpointTuple(
+            config={
+                "configurable": {
+                    "thread_id": thread_id,
+                    "checkpoint_ns": ns,
+                    "checkpoint_id": checkpoint_id,
+                }
+            },
+            checkpoint=checkpoint,
+            metadata=metadata,
+            parent_config=(
+                {
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "checkpoint_ns": ns,
+                        "checkpoint_id": parent_id,
+                    }
+                }
+                if parent_id
+                else None
+            ),
+            pending_writes=await self._load_pending_writes(thread_id, ns, checkpoint_id),
+        )
+
+    async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        thread_id = config["configurable"]["thread_id"]
+        ns = config["configurable"].get("checkpoint_ns", "")
+        checkpoint_id = get_checkpoint_id(config)
+        if not checkpoint_id:
+            latest = await self._redis.zrange(self._idx_key(thread_id, ns), -1, -1)
+            if not latest:
+                return None
+            checkpoint_id = _s(latest[0])
+        return await self._load_tuple(thread_id, ns, checkpoint_id)
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        if config is None:
+            # Listing across all threads requires a key scan; the A2A server
+            # never lists without a thread, so this is intentionally
+            # unsupported to stay SCAN-free on managed Redis.
+            raise NotImplementedError("PlainRedisSaver.alist requires a thread_id in config")
+        thread_id = config["configurable"]["thread_id"]
+        ns = config["configurable"].get("checkpoint_ns", "")
+        config_checkpoint_id = get_checkpoint_id(config)
+        before_id = get_checkpoint_id(before) if before else None
+
+        ids = [_s(i) for i in await self._redis.zrange(self._idx_key(thread_id, ns), 0, -1)]
+        remaining = limit
+        for checkpoint_id in reversed(ids):
+            if config_checkpoint_id and checkpoint_id != config_checkpoint_id:
+                continue
+            if before_id and checkpoint_id >= before_id:
+                continue
+            tup = await self._load_tuple(thread_id, ns, checkpoint_id)
+            if tup is None:
+                continue
+            if filter and not all(tup.metadata.get(k) == v for k, v in filter.items()):
+                continue
+            if remaining is not None:
+                if remaining <= 0:
+                    break
+                remaining -= 1
+            yield tup
+
+    async def adelete_thread(self, thread_id: str) -> None:
+        tk_key = self._threadkeys_key(thread_id)
+        keys = [_s(k) for k in await self._redis.smembers(tk_key)]
+        if keys:
+            await self._redis.delete(*keys)
+        await self._redis.delete(tk_key)
+
+
+def _resolve_backend() -> str:
+    raw = os.getenv(BACKEND_ENV, DEFAULT_BACKEND).strip().lower()
+    backend = _BACKEND_ALIASES.get(raw)
+    if backend is None:
+        raise ValueError(
+            f"Unknown {BACKEND_ENV}={raw!r}. "
+            f"Valid values: redisearch (default), plain-redis, memory, none"
+        )
+    return backend
+
+
+def _resolve_ttl() -> int | None:
+    raw = os.getenv(TTL_ENV, "").strip()
+    if not raw:
+        return DEFAULT_TTL_SECONDS
+    ttl = int(raw)
+    return ttl if ttl > 0 else None
+
+
+async def create_checkpointer(redis_client: Any) -> BaseCheckpointSaver | None:
+    """Build the configured checkpointer backend, or None if unavailable.
+
+    Returns None (rather than raising) when checkpointing is disabled or no
+    Redis client exists — the agent then runs without cross-request memory,
+    exactly as before. Backend initialization errors propagate so the caller
+    can log and degrade.
+    """
+    backend = _resolve_backend()
+
+    if backend == "none":
+        logger.info("Checkpointer explicitly disabled (%s=none)", BACKEND_ENV)
+        return None
+
+    if backend == "memory":
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        logger.info("Using in-memory checkpointer (per-process, dev/test only)")
+        return InMemorySaver()
+
+    if redis_client is None:
+        logger.info("No Redis client available; running without conversation memory")
+        return None
+
+    await redis_client.ping()
+
+    if backend == "plain-redis":
+        saver = PlainRedisSaver(redis_client, ttl_seconds=_resolve_ttl())
+        logger.info(
+            "Using plain-Redis checkpointer (no RediSearch required, ttl=%s)", saver._ttl
+        )
+        return saver
+
+    # Default: RediSearch-backed saver, unchanged from previous behavior.
+    from langgraph.checkpoint.redis.aio import AsyncRedisSaver
+
+    saver = AsyncRedisSaver(redis_client=redis_client)
+    await saver.setup()
+    logger.info("Using RediSearch checkpointer (AsyncRedisSaver)")
+    return saver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ test = [
     "pytest-cov>=5.0.0",
     "httpx>=0.27.0",
     "faker>=33.0.0",
+    "fakeredis>=2.26.0",  # plain-Redis checkpointer tests (tests/test_checkpointer.py)
 ]
 
 docs = [

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -1,0 +1,295 @@
+"""Tests for A2A checkpointer backend selection and the plain-Redis saver.
+
+The plain-Redis backend exists so conversation checkpointing works on Redis
+servers without the RediSearch module (e.g. Upstash). These tests use
+fakeredis, which — like Upstash — has no RediSearch, so they also prove the
+saver needs only core Redis commands.
+"""
+
+import operator
+import sys
+from typing import Annotated, TypedDict
+
+import pytest
+
+pytest.importorskip("langgraph.checkpoint.base")
+fakeredis = pytest.importorskip("fakeredis")
+
+from langgraph.checkpoint.base import empty_checkpoint  # noqa: E402
+
+from kubently.modules.a2a.protocol_bindings.a2a_server.checkpointer import (  # noqa: E402
+    BACKEND_ENV,
+    TTL_ENV,
+    PlainRedisSaver,
+    create_checkpointer,
+)
+
+
+@pytest.fixture
+def redis_client():
+    # decode_responses=True mirrors how kubently/main.py creates its client.
+    return fakeredis.FakeAsyncRedis(decode_responses=True)
+
+
+@pytest.fixture
+def saver(redis_client):
+    return PlainRedisSaver(redis_client, ttl_seconds=None)
+
+
+def thread_config(thread_id="thread-1", checkpoint_id=None):
+    cfg = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    if checkpoint_id:
+        cfg["configurable"]["checkpoint_id"] = checkpoint_id
+    return cfg
+
+
+def make_checkpoint(checkpoint_id, values=None, version=None):
+    # Channel versions are bumped by LangGraph on every write; blobs are keyed
+    # by (channel, version), so distinct checkpoints carry distinct versions.
+    cp = empty_checkpoint()
+    cp["id"] = checkpoint_id
+    cp["channel_values"] = values or {}
+    cp["channel_versions"] = {k: (version or checkpoint_id) for k in (values or {})}
+    return cp
+
+
+# =============================================================================
+# Backend selection
+# =============================================================================
+
+
+class TestBackendSelection:
+    async def test_none_backend_disables_checkpointing(self, monkeypatch, redis_client):
+        monkeypatch.setenv(BACKEND_ENV, "none")
+        assert await create_checkpointer(redis_client) is None
+
+    async def test_memory_backend(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV, "memory")
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        saver = await create_checkpointer(None)
+        assert isinstance(saver, InMemorySaver)
+
+    async def test_plain_redis_backend(self, monkeypatch, redis_client):
+        monkeypatch.setenv(BACKEND_ENV, "plain-redis")
+        saver = await create_checkpointer(redis_client)
+        assert isinstance(saver, PlainRedisSaver)
+
+    async def test_plain_redis_alias(self, monkeypatch, redis_client):
+        monkeypatch.setenv(BACKEND_ENV, "redis-plain")
+        saver = await create_checkpointer(redis_client)
+        assert isinstance(saver, PlainRedisSaver)
+
+    async def test_no_redis_client_degrades_to_none(self, monkeypatch):
+        monkeypatch.delenv(BACKEND_ENV, raising=False)
+        assert await create_checkpointer(None) is None
+        monkeypatch.setenv(BACKEND_ENV, "plain-redis")
+        assert await create_checkpointer(None) is None
+
+    async def test_unknown_backend_raises(self, monkeypatch, redis_client):
+        monkeypatch.setenv(BACKEND_ENV, "postgres")
+        with pytest.raises(ValueError, match="postgres"):
+            await create_checkpointer(redis_client)
+
+    async def test_default_backend_is_redisearch(self, monkeypatch, redis_client):
+        """Unset env var must select AsyncRedisSaver (unchanged default).
+
+        fakeredis has no RediSearch, so setup() failing with an error proves
+        the RediSearch path was actually taken; the agent catches this and
+        degrades to no memory, matching today's Upstash behavior.
+        """
+        pytest.importorskip("langgraph.checkpoint.redis")
+        monkeypatch.delenv(BACKEND_ENV, raising=False)
+        with pytest.raises(Exception):
+            await create_checkpointer(redis_client)
+
+    async def test_ttl_env_parsing(self, monkeypatch, redis_client):
+        monkeypatch.setenv(BACKEND_ENV, "plain-redis")
+        monkeypatch.setenv(TTL_ENV, "3600")
+        saver = await create_checkpointer(redis_client)
+        assert saver._ttl == 3600
+
+        monkeypatch.setenv(TTL_ENV, "0")
+        saver = await create_checkpointer(redis_client)
+        assert saver._ttl is None
+
+
+# =============================================================================
+# PlainRedisSaver: checkpoint save/restore
+# =============================================================================
+
+
+class TestPlainRedisSaver:
+    async def test_get_tuple_empty_thread_returns_none(self, saver):
+        assert await saver.aget_tuple(thread_config("missing")) is None
+
+    async def test_put_then_get_roundtrip(self, saver):
+        cp = make_checkpoint("00000001", {"messages": ["hello"], "count": 1})
+        await saver.aput(
+            thread_config(), cp, {"source": "input", "step": -1}, cp["channel_versions"]
+        )
+
+        tup = await saver.aget_tuple(thread_config())
+        assert tup is not None
+        assert tup.checkpoint["id"] == "00000001"
+        assert tup.checkpoint["channel_values"] == {"messages": ["hello"], "count": 1}
+        assert tup.metadata["source"] == "input"
+        assert tup.parent_config is None
+
+    async def test_latest_checkpoint_wins(self, saver):
+        for i in (1, 2, 3):
+            cp = make_checkpoint(f"0000000{i}", {"count": i})
+            await saver.aput(
+                thread_config(checkpoint_id=f"0000000{i - 1}" if i > 1 else None),
+                cp,
+                {"source": "loop", "step": i},
+                cp["channel_versions"],
+            )
+
+        tup = await saver.aget_tuple(thread_config())
+        assert tup.checkpoint["id"] == "00000003"
+        assert tup.checkpoint["channel_values"]["count"] == 3
+        # Parent linkage preserved
+        assert tup.parent_config["configurable"]["checkpoint_id"] == "00000002"
+
+    async def test_get_specific_checkpoint_id(self, saver):
+        for i in (1, 2):
+            cp = make_checkpoint(f"0000000{i}", {"count": i})
+            await saver.aput(thread_config(), cp, {"step": i}, cp["channel_versions"])
+
+        tup = await saver.aget_tuple(thread_config(checkpoint_id="00000001"))
+        assert tup.checkpoint["channel_values"]["count"] == 1
+
+    async def test_threads_are_isolated(self, saver):
+        cp_a = make_checkpoint("00000001", {"who": "a"})
+        cp_b = make_checkpoint("00000001", {"who": "b"})
+        await saver.aput(thread_config("thread-a"), cp_a, {}, cp_a["channel_versions"])
+        await saver.aput(thread_config("thread-b"), cp_b, {}, cp_b["channel_versions"])
+
+        assert (await saver.aget_tuple(thread_config("thread-a"))).checkpoint[
+            "channel_values"
+        ] == {"who": "a"}
+        assert (await saver.aget_tuple(thread_config("thread-b"))).checkpoint[
+            "channel_values"
+        ] == {"who": "b"}
+
+    async def test_restore_across_saver_instances(self, redis_client):
+        """State survives a new saver instance (i.e. lives in Redis, not RAM)."""
+        saver1 = PlainRedisSaver(redis_client, ttl_seconds=None)
+        cp = make_checkpoint("00000001", {"messages": ["persisted"]})
+        await saver1.aput(thread_config(), cp, {"step": 0}, cp["channel_versions"])
+
+        saver2 = PlainRedisSaver(redis_client, ttl_seconds=None)
+        tup = await saver2.aget_tuple(thread_config())
+        assert tup.checkpoint["channel_values"] == {"messages": ["persisted"]}
+
+    async def test_pending_writes_roundtrip(self, saver):
+        cp = make_checkpoint("00000001", {"count": 0})
+        await saver.aput(thread_config(), cp, {}, cp["channel_versions"])
+        cfg = thread_config(checkpoint_id="00000001")
+        await saver.aput_writes(cfg, [("count", 42), ("other", "x")], task_id="task-1")
+
+        tup = await saver.aget_tuple(thread_config())
+        assert ("task-1", "count", 42) in tup.pending_writes
+        assert ("task-1", "other", "x") in tup.pending_writes
+
+    async def test_alist_order_and_limit(self, saver):
+        for i in (1, 2, 3):
+            cp = make_checkpoint(f"0000000{i}", {"count": i})
+            await saver.aput(thread_config(), cp, {"step": i}, cp["channel_versions"])
+
+        ids = [t.checkpoint["id"] async for t in saver.alist(thread_config())]
+        assert ids == ["00000003", "00000002", "00000001"]
+
+        ids = [t.checkpoint["id"] async for t in saver.alist(thread_config(), limit=2)]
+        assert ids == ["00000003", "00000002"]
+
+        before = thread_config(checkpoint_id="00000003")
+        ids = [t.checkpoint["id"] async for t in saver.alist(thread_config(), before=before)]
+        assert ids == ["00000002", "00000001"]
+
+    async def test_delete_thread(self, saver, redis_client):
+        cp = make_checkpoint("00000001", {"count": 1})
+        await saver.aput(thread_config(), cp, {}, cp["channel_versions"])
+        await saver.aput_writes(
+            thread_config(checkpoint_id="00000001"), [("count", 2)], task_id="t"
+        )
+
+        await saver.adelete_thread("thread-1")
+        assert await saver.aget_tuple(thread_config()) is None
+        assert await redis_client.keys("kubently:ckpt:*") == []
+
+    async def test_ttl_applied_and_refreshed(self, redis_client):
+        saver = PlainRedisSaver(redis_client, ttl_seconds=3600)
+        cp = make_checkpoint("00000001", {"count": 1})
+        await saver.aput(thread_config(), cp, {}, cp["channel_versions"])
+
+        for key in await redis_client.keys("kubently:ckpt:*"):
+            ttl = await redis_client.ttl(key)
+            assert 0 < ttl <= 3600, f"{key} has no TTL"
+
+        # A later checkpoint refreshes TTLs on the older keys too
+        cp2 = make_checkpoint("00000002", {"count": 2})
+        await saver.aput(thread_config(), cp2, {}, cp2["channel_versions"])
+        ttl = await redis_client.ttl("kubently:ckpt:cp:thread-1::00000001")
+        assert 0 < ttl <= 3600
+
+
+# =============================================================================
+# End-to-end: a real LangGraph graph checkpointed on plain Redis
+# =============================================================================
+
+
+class TestGraphIntegration:
+    async def test_multi_turn_state_accumulates(self, redis_client):
+        """Two ainvoke calls on the same thread share state via plain Redis —
+        the cross-request memory scenario that RediSearch-less Redis must support."""
+        from langgraph.graph import END, START, StateGraph
+
+        class State(TypedDict):
+            values: Annotated[list, operator.add]
+
+        builder = StateGraph(State)
+        builder.add_node("node", lambda state: {"values": ["tick"]})
+        builder.add_edge(START, "node")
+        builder.add_edge("node", END)
+
+        saver = PlainRedisSaver(redis_client, ttl_seconds=None)
+        graph = builder.compile(checkpointer=saver)
+        cfg = {"configurable": {"thread_id": "conversation-1"}}
+
+        r1 = await graph.ainvoke({"values": ["turn1"]}, cfg)
+        assert r1["values"] == ["turn1", "tick"]
+
+        # Second request: prior state must be restored from Redis
+        r2 = await graph.ainvoke({"values": ["turn2"]}, cfg)
+        assert r2["values"] == ["turn1", "tick", "turn2", "tick"]
+
+        # A different thread starts clean
+        other = await graph.ainvoke(
+            {"values": ["fresh"]}, {"configurable": {"thread_id": "conversation-2"}}
+        )
+        assert other["values"] == ["fresh", "tick"]
+
+    async def test_state_survives_process_restart_simulation(self, redis_client):
+        """Recompile the graph with a fresh saver over the same Redis —
+        equivalent to an API pod restart mid-conversation."""
+        from langgraph.graph import END, START, StateGraph
+
+        class State(TypedDict):
+            values: Annotated[list, operator.add]
+
+        def build(saver):
+            builder = StateGraph(State)
+            builder.add_node("node", lambda state: {"values": ["tick"]})
+            builder.add_edge(START, "node")
+            builder.add_edge("node", END)
+            return builder.compile(checkpointer=saver)
+
+        cfg = {"configurable": {"thread_id": "conversation-1"}}
+        graph1 = build(PlainRedisSaver(redis_client, ttl_seconds=None))
+        await graph1.ainvoke({"values": ["before"]}, cfg)
+
+        graph2 = build(PlainRedisSaver(redis_client, ttl_seconds=None))
+        r = await graph2.ainvoke({"values": ["after"]}, cfg)
+        assert r["values"] == ["before", "tick", "after", "tick"]


### PR DESCRIPTION
Track E (storage foundation): conversation checkpointing no longer requires the RediSearch module, so multi-turn A2A memory works on plain Redis servers (e.g. Upstash — this is what has kept cross-request memory disabled in the hosted cloud).

- New `checkpointer.py` with a `create_checkpointer` factory and backend selection via `KUBENTLY_CHECKPOINT_BACKEND`: RediSearch saver (existing default), new **PlainRedisSaver** using only core Redis commands, in-memory, or none.
- `PlainRedisSaver` supports TTL via env var; state survives process restarts (covered by tests).
- Graceful degradation preserved: no backend configured → single-request diagnoses work exactly as before; intentional "off" no longer retried on every request.
- 20 tests in `tests/test_checkpointer.py` run against fakeredis (which, like Upstash, has no RediSearch — proving the plain backend needs only core commands). Verified locally: 19 passed, 1 skipped (RediSearch-only case).
- `ENVIRONMENT_VARIABLES.md` + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX)_