### PR TITLE
Read-only Prometheus toolset routed through the executor channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [Unreleased] - 2026-08-16
+
+### Added
+- **Prometheus metrics toolset (Track C1a)** — the agent gets a read-only
+  `query_prometheus` tool (instant + range PromQL) for the questions kubectl
+  can't answer: latency, saturation, OOM trends, restarts-over-time. First
+  non-kubectl evidence source, so the pattern is set deliberately: queries ride
+  the existing outbound channel (API `/debug/prometheus` -> Redis pub/sub ->
+  executor SSE -> result POST) via a new `tool` field on the command envelope,
+  and the executor enforces its own allowlist locally — GET only, exactly
+  `/api/v1/query` and `/api/v1/query_range`, base URL exclusively from the
+  executor's own `PROMETHEUS_URL` env (the control plane never supplies a URL,
+  so a stolen API key cannot aim the executor at arbitrary endpoints)
+- **Off by default, and invisible when off** — a single Helm value
+  (`prometheus.url`) wires the executor env and switches the agent tool on;
+  when unset the tool is not registered and the system prompt's metrics
+  guidance (injected through a new `{{metrics_guidance}}` prompt variable) is
+  omitted, so the model is never told about a tool it cannot call
+- **Metric results are capped before they leave the executor** — series count
+  (`PROMETHEUS_MAX_SERIES`, 50), total samples per range result
+  (`PROMETHEUS_MAX_SAMPLES`, 2000; evenly downsampled with endpoints kept so
+  trends survive), and a character backstop — with every truncation announced
+  in the payload the model reads, plus the shared `cap_output` context guard
+  on the agent side
+
 ## [Unreleased] - 2026-08-15 (later)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ helm install kubently deployment/helm -f deployment/helm/test-values.yaml
 - **Test Automation**: Comprehensive testing framework with 20+ Kubernetes scenarios
 - **CLI Tools**: Modern Node.js CLI for interactive debugging
 
+### Agent Toolset
+
+The diagnostic agent investigates with a small set of read-only tools:
+
+- **`list_clusters`** — enumerate registered clusters
+- **`execute_kubectl`** — read-only kubectl against one cluster (whitelist-enforced on the executor)
+- **`execute_kubectl_multi`** — one read-only kubectl command fanned out across many clusters
+- **`query_prometheus`** *(optional)* — instant and range PromQL queries for latency, saturation, OOM-trend and restarts-over-time evidence. Enabled by setting `prometheus.url` in Helm values (unset by default); queries execute on each cluster's executor through the same outbound channel as kubectl commands
+
 ## Documentation
 
 ### Getting Started

--- a/deployment/helm/kubently/prompts/system.prompt.yaml
+++ b/deployment/helm/kubently/prompts/system.prompt.yaml
@@ -1,10 +1,16 @@
-version: 3
+version: 4
 name: kubently_thorough_investigation
 role: system
 metadata:
   owner: kubently
   description: System prompt for thorough Kubernetes debugging with enhanced investigation patterns
-variables: []
+variables:
+  # Injected by the agent ONLY when the query_prometheus tool is registered
+  # (PROMETHEUS_URL set); defaults to empty so unconfigured deployments never
+  # reference a metrics tool the model cannot call.
+  - name: metrics_guidance
+    required: false
+    default: ""
 content: |-
   # Kubently System Prompt
 
@@ -359,6 +365,8 @@ content: |-
   - Fleet results are a triage view: per-cluster output is truncated. Drill into a specific cluster with execute_kubectl when you need detail.
   - Keep fleet commands filtered and token-efficient (e.g. `-o wide`, `-o custom-columns`, `-l <selector>`); never dump unfiltered resources from every cluster. Do NOT use `--field-selector status.phase!=Running` for fleet health sweeps — CrashLoopBackOff pods have `phase=Running`, so a whole cluster can look healthy while pods crash on a loop.
   - For single-cluster questions keep using execute_kubectl.
+
+  {{metrics_guidance}}
 
   # Code References
 

--- a/deployment/helm/kubently/templates/api-deployment.yaml
+++ b/deployment/helm/kubently/templates/api-deployment.yaml
@@ -184,6 +184,13 @@ spec:
         - name: SLACK_WEBHOOK_URL
           value: {{ .Values.api.env.SLACK_WEBHOOK_URL | quote }}
         {{- end }}
+        {{- /* Presence of PROMETHEUS_URL switches on the agent's
+               query_prometheus tool + prompt guidance. The API never dials
+               this URL itself — queries run on each cluster's executor. */}}
+        {{- if (.Values.prometheus).url }}
+        - name: PROMETHEUS_URL
+          value: {{ .Values.prometheus.url | quote }}
+        {{- end }}
         - name: KUBENTLY_A2A_PROMPT_FILE
           value: "/etc/kubently/prompts/system.prompt.yaml"
         - name: KUBENTLY_FLEET_REPORT_PROMPT_FILE

--- a/deployment/helm/kubently/templates/executor-deployment.yaml
+++ b/deployment/helm/kubently/templates/executor-deployment.yaml
@@ -81,6 +81,12 @@ spec:
         - name: KUBENTLY_WHITELIST_DB
           value: "/var/lib/kubently/whitelist.db"
         {{- end }}
+        {{- /* Prometheus metrics tool: URL the executor queries (read-only).
+               Parenthesized lookup is nil-safe for old values files. */}}
+        {{- if (.Values.prometheus).url }}
+        - name: PROMETHEUS_URL
+          value: {{ .Values.prometheus.url | quote }}
+        {{- end }}
         {{- /* Capability reporting configuration (optional feature) */}}
         {{- if .Values.executor.capabilities }}
         {{- if .Values.executor.capabilities.enabled }}

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -90,6 +90,27 @@ fleetReport:
   query: ""
 
 # ============================================================================
+# Prometheus Metrics Tool (optional)
+# ============================================================================
+# Gives the diagnostic agent a read-only PromQL tool (query_prometheus) for
+# latency, saturation, OOM-trend and restart-over-time questions.
+#
+# The URL must be reachable FROM THE EXECUTOR POD — queries are executed by the
+# executor inside the monitored cluster (same outbound channel as kubectl
+# commands), never by the central API. Example for kube-prometheus-stack:
+#   url: "http://prometheus-operated.monitoring.svc.cluster.local:9090"
+#
+# Leave empty (default) to disable: the agent does not register the tool, the
+# system prompt never mentions metrics, and the executor rejects metric
+# queries with a clear "not configured" error.
+#
+# Split deployments (central API + remote executors): set prometheus.url on
+# BOTH installs. On an executor install it is the URL the executor queries; on
+# the API install it only enables the tool (the control plane never dials it).
+prometheus:
+  url: ""
+
+# ============================================================================
 # Executor Configuration
 # ============================================================================
 # The executor runs IN the cluster being monitored and executes kubectl

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -48,6 +48,16 @@
 | `KUBENTLY_MAX_FLEET_CLUSTERS` | `10` | No | Max clusters per `execute_kubectl_multi` fan-out call (each cluster adds up to ~4KB to the agent context) |
 | `A2A_SERVER_DEBUG` | `false` | No | Enable A2A debug logging |
 
+### Prometheus Metrics Tool (optional)
+
+When `PROMETHEUS_URL` is set on the API server, the agent registers the read-only `query_prometheus` tool and injects metrics guidance into the system prompt. When unset (default), the tool does not exist and the prompt never mentions metrics.
+
+The API never dials this URL itself — queries execute on each cluster's executor against the executor's own `PROMETHEUS_URL` (see Executor Configuration below). On the API side the variable only switches the tool on.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `PROMETHEUS_URL` | - | No | Presence enables the `query_prometheus` agent tool. Set via Helm `prometheus.url` |
+
 ### LLM Configuration (for A2A)
 
 | Variable | Default | Required | Description |
@@ -91,6 +101,18 @@
 | `WHITELIST_PATH` | `/etc/kubently/whitelist.yaml` | No | Path to whitelist configuration |
 | `REFRESH_INTERVAL` | `30` | No | Whitelist refresh interval in seconds |
 | `TIMEOUT_SECONDS` | `30` | No | Command execution timeout |
+
+### Prometheus Metrics Tool (optional)
+
+The executor performs metric queries locally (read-only GETs against `/api/v1/query` and `/api/v1/query_range` only). The base URL comes exclusively from this local configuration — the control plane never supplies one. When unset (default), metric queries are answered with a clear "not configured" error.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `PROMETHEUS_URL` | - | No | Prometheus base URL reachable from the executor pod, e.g. `http://prometheus-operated.monitoring.svc.cluster.local:9090`. Set via Helm `prometheus.url` |
+| `PROMETHEUS_TIMEOUT` | `30` | No | Query timeout in seconds |
+| `PROMETHEUS_MAX_SERIES` | `50` | No | Max series returned per query (excess truncated with a note) |
+| `PROMETHEUS_MAX_SAMPLES` | `2000` | No | Max total samples per range-query result (evenly downsampled with a note) |
+| `PROMETHEUS_MAX_OUTPUT_CHARS` | `20000` | No | Hard cap on serialized result size |
 
 ## Deployment-Specific Variables
 

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -33,6 +33,7 @@ from kubently.modules.api import (
     CreateSessionRequest,
     ExecuteCommandRequest,
     ExecutionStatus,
+    PrometheusQueryRequest,
     SessionResponse,
     SessionStatus,
 )
@@ -713,6 +714,92 @@ async def execute_command(
         session_id=request.session_id,
         cluster_id=request.cluster_id,
         status=result.get("status", ExecutionStatus.SUCCESS),
+        correlation_id=x_correlation_id or request.correlation_id,
+        output=result.get("output"),
+        error=result.get("error"),
+        execution_time_ms=result.get("execution_time_ms"),
+        executed_at=result.get("executed_at"),
+    )
+
+
+@app.post("/debug/prometheus", response_model=CommandResponse)
+async def execute_prometheus_query(
+    request: PrometheusQueryRequest,
+    auth_info: Tuple[bool, Optional[str]] = Depends(verify_api_key),
+    x_correlation_id: Optional[str] = Header(None, description="Correlation ID for A2A tracking"),
+):
+    """
+    Run a read-only PromQL query on a cluster's Prometheus.
+
+    The query rides the same outbound channel as kubectl commands (Redis
+    pub/sub -> executor SSE -> result POST): the executor inside the target
+    cluster performs the HTTP GET against its locally configured
+    PROMETHEUS_URL. This API never contacts Prometheus directly and never
+    forwards a URL — only the validated query parameters.
+
+    Returns:
+        200: Query result (or executor-side error, e.g. Prometheus not configured)
+        404: Cluster not found
+        401: Unauthorized
+    """
+    if not redis_client or not queue_module:
+        raise HTTPException(503, "Service not initialized")
+
+    # Same cluster validation as /debug/execute: fail fast with the list of
+    # valid clusters instead of queueing a command nothing will pick up.
+    token_key = f"executor:token:{request.cluster_id}"
+    if not await redis_client.exists(token_key):
+        valid_clusters = sorted(
+            (k.decode() if isinstance(k, bytes) else k).replace("executor:token:", "")
+            for k in await redis_client.keys("executor:token:*")
+        )
+        error_msg = f"Cluster '{request.cluster_id}' not found."
+        if valid_clusters:
+            error_msg += f" Available clusters: {', '.join(valid_clusters)}"
+        else:
+            error_msg += " No clusters are currently registered."
+        raise HTTPException(404, error_msg)
+
+    cluster_active_key = f"cluster:active:{request.cluster_id}"
+    await redis_client.setex(cluster_active_key, 60, "1")
+
+    command = {
+        "id": str(uuid.uuid4()),
+        "tool": "prometheus",
+        "request": {
+            "query_type": request.query_type.value,
+            "query": request.query,
+            "time": request.time,
+            "start": request.start,
+            "end": request.end,
+            "step": request.step,
+        },
+        "timeout": request.timeout_seconds or 30,
+        "correlation_id": x_correlation_id or request.correlation_id,
+    }
+
+    channel = f"executor-commands:{request.cluster_id}"
+    await redis_client.publish(channel, json.dumps(command))
+    logger.info(f"Published prometheus query {command['id']} to channel {channel}")
+
+    timeout = request.timeout_seconds or config.get("command_timeout")
+    result = await queue_module.wait_for_result(command["id"], timeout=timeout)
+
+    if not result:
+        return CommandResponse(
+            command_id=command["id"],
+            session_id=None,
+            cluster_id=request.cluster_id,
+            status=ExecutionStatus.TIMEOUT,
+            correlation_id=x_correlation_id or request.correlation_id,
+            error="Prometheus query timeout (no executor picked it up in time)",
+        )
+
+    return CommandResponse(
+        command_id=command["id"],
+        session_id=None,
+        cluster_id=request.cluster_id,
+        status=ExecutionStatus.SUCCESS if result.get("success") else ExecutionStatus.FAILURE,
         correlation_id=x_correlation_id or request.correlation_id,
         output=result.get("output"),
         error=result.get("error"),

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -228,10 +228,16 @@ class KubentlyAgent:
                 "anthropic-claude, openai, google-gemini."
             )
 
-        # Load system prompt from configuration
+        # Load system prompt from configuration. Metrics guidance is injected
+        # only when the query_prometheus tool is registered, so the prompt
+        # never references a tool the model cannot call.
         from kubently.modules.config import get_prompt
 
-        self.system_prompt = get_prompt(role="a2a")
+        from .prometheus import metrics_guidance
+
+        self.system_prompt = get_prompt(
+            role="a2a", variables={"metrics_guidance": metrics_guidance()}
+        )
 
         # Initialize tools for kubectl operations
         await self._initialize_tools()
@@ -561,6 +567,121 @@ class KubentlyAgent:
         # (write_todos via TodoListMiddleware), so the previous hand-rolled
         # todo_write tool + TodoManager were removed.
         self.tools = [list_clusters, execute_kubectl, execute_kubectl_multi]
+
+        from kubently.modules.a2a.protocol_bindings.a2a_server.prometheus import (
+            build_prometheus_payload,
+            prometheus_tool_enabled,
+        )
+
+        if prometheus_tool_enabled():
+
+            @tool
+            async def query_prometheus(
+                cluster_id: str,
+                query: str,
+                query_type: str = "instant",
+                start: str | None = None,
+                end: str | None = None,
+                step: str | None = None,
+                time: str | None = None,
+            ) -> str:
+                """Run a read-only PromQL query against a cluster's Prometheus.
+
+                Use metrics when kubectl can't answer the question: latency and
+                error rates, CPU/memory saturation trends, OOM pressure, restart
+                frequency over time, capacity headroom. The query executes inside
+                the target cluster (via its executor), so use the in-cluster view
+                of Prometheus.
+
+                Query types:
+                - "instant" (default): current value. Optionally set `time`
+                  (RFC3339 or unix seconds) to evaluate at a point in the past.
+                - "range": values over a window. Requires `start`, `end` (RFC3339
+                  or unix seconds) and `step` (e.g. "60s", "5m"). Keep windows
+                  short (30m-2h) and steps coarse — results are capped.
+
+                EFFICIENT PromQL (results are capped; truncation is noted in the
+                output when it happens):
+                - Always filter by labels (namespace, pod, container) — never
+                  query a bare metric name with no selector
+                - Aggregate: sum/avg by (pod) (rate(metric{...}[5m]))
+                - Rank with topk(5, ...) instead of returning everything
+                - Use rate()/increase() over counters
+
+                Args:
+                    cluster_id: Target cluster (same IDs as execute_kubectl)
+                    query: PromQL expression
+                    query_type: "instant" or "range"
+                    start: Range start (RFC3339 or unix seconds)
+                    end: Range end (RFC3339 or unix seconds)
+                    step: Range resolution (e.g. "60s", "5m")
+                    time: Optional evaluation time for instant queries
+
+                Returns:
+                    Compact JSON result ({"resultType": ..., "result": [...]}),
+                    with a "kubently_truncation" note when caps were applied,
+                    or an error message (e.g. Prometheus not configured on that
+                    cluster — fall back to kubectl evidence in that case).
+                """
+                debug_print(
+                    f"query_prometheus called: cluster_id={cluster_id}, "
+                    f"query_type={query_type}, query={query}"
+                )
+                tool_call_id = await interceptor.record_tool_call(
+                    tool_name="query_prometheus",
+                    args={
+                        "cluster_id": cluster_id,
+                        "query": query,
+                        "query_type": query_type,
+                        "start": start,
+                        "end": end,
+                        "step": step,
+                        "time": time,
+                    },
+                    thread_id=getattr(self, "_current_thread_id", None),
+                )
+
+                payload = build_prometheus_payload(
+                    query, query_type=query_type, start=start, end=end, step=step, time=time
+                )
+                payload["cluster_id"] = cluster_id
+
+                async with httpx.AsyncClient(timeout=45.0) as client:
+                    try:
+                        response = await client.post(
+                            f"{api_url}/debug/prometheus",
+                            headers={"X-Api-Key": api_key},
+                            json=payload,
+                        )
+                        if response.status_code != 200:
+                            error_msg = cap_output(
+                                f"Error: HTTP {response.status_code}: {response.text}"
+                            )
+                            await interceptor.record_tool_result(tool_call_id, None, error_msg)
+                            return error_msg
+
+                        result = response.json()
+                        exec_status, exec_error = result.get("status"), result.get("error")
+                        if exec_error or (exec_status and exec_status != "success"):
+                            error_msg = cap_output(
+                                f"Error: {exec_error or f'query status: {exec_status}'}"
+                            )
+                            await interceptor.record_tool_result(tool_call_id, None, error_msg)
+                            return error_msg
+
+                        # Executor already caps series/samples; this is the
+                        # context-budget backstop shared with kubectl results.
+                        output = cap_output(result.get("output") or "")
+                        await interceptor.record_tool_result(tool_call_id, output)
+                        return output
+                    except Exception as e:
+                        error_msg = f"Error executing Prometheus query: {e!s}"
+                        await interceptor.record_tool_result(tool_call_id, None, error_msg)
+                        return error_msg
+
+            self.tools.append(query_prometheus)
+            logger.info("Prometheus metrics tool registered (PROMETHEUS_URL is set)")
+
         logger.info(f"Initialized {len(self.tools)} tools")
 
     async def run(

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/prometheus.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/prometheus.py
@@ -1,0 +1,88 @@
+"""Agent-side plumbing for the Prometheus metrics tool.
+
+Deliberately import-light (stdlib only) so unit tests can import it without
+pulling the langchain/a2a stack that agent.py requires.
+
+Availability contract: the query_prometheus tool is registered ONLY when
+PROMETHEUS_URL is set in the A2A server's environment, and the matching
+metrics guidance is injected into the system prompt through the
+{{metrics_guidance}} prompt variable at the same time. When unset, neither
+exists, so the model is never told about a tool it cannot call.
+
+Note the A2A server never dials PROMETHEUS_URL itself — queries execute on the
+target cluster's executor against the executor's own locally configured URL.
+On the control plane the variable only switches the tool on.
+"""
+
+import os
+
+PROMETHEUS_URL_ENV = "PROMETHEUS_URL"
+
+
+def prometheus_tool_enabled() -> bool:
+    """Whether the query_prometheus tool should be registered."""
+    return bool(os.getenv(PROMETHEUS_URL_ENV, "").strip())
+
+
+def build_prometheus_payload(
+    query: str,
+    query_type: str = "instant",
+    start: str | None = None,
+    end: str | None = None,
+    step: str | None = None,
+    time: str | None = None,
+    timeout_seconds: int = 30,
+) -> dict:
+    """Build the /debug/prometheus request body (minus cluster_id)."""
+    return {
+        "query": query,
+        "query_type": query_type,
+        "start": start,
+        "end": end,
+        "step": step,
+        "time": time,
+        "timeout_seconds": timeout_seconds,
+    }
+
+
+# Injected into the system prompt (via the {{metrics_guidance}} variable) only
+# when the tool is registered, so an unconfigured deployment's prompt never
+# references metrics.
+METRICS_PROMPT_SECTION = """\
+## Metrics (Prometheus)
+
+You have a query_prometheus tool for PromQL queries against each cluster's Prometheus.
+Metrics answer questions kubectl cannot: trends and rates over time.
+
+REACH FOR METRICS WHEN the question involves:
+- Latency / error rates ("is the service slow?", "are requests failing?")
+- Resource saturation and trends (CPU throttling, memory growth toward OOM, disk filling)
+- Restarts or OOMKills OVER TIME (kubectl shows the current count; metrics show when and how often)
+- Capacity questions ("will this node run out of memory?")
+- Confirming a root cause with data (e.g. memory climbing to the limit before each restart)
+
+Use instant queries for "right now" values; range queries for trends. Keep range
+windows short (30m-2h) and steps coarse (60s+) unless you need finer detail.
+
+WRITE EFFICIENT PromQL — results are capped (series and samples are truncated
+with a note when exceeded), so unfiltered queries waste your budget:
+- ALWAYS filter by labels: `container_memory_working_set_bytes{namespace="x", pod=~"api-.*"}`
+- Aggregate before returning: `sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="x"}[5m]))`
+- Use topk() to rank offenders: `topk(5, rate(kube_pod_container_status_restarts_total[1h]))`
+- rate()/increase() over counters, never raw counter values
+- NEVER query a bare metric name with no selector — that can return thousands of series
+
+Useful patterns:
+- Restart trend: `increase(kube_pod_container_status_restarts_total{namespace="x"}[1h])`
+- OOM pressure: `container_memory_working_set_bytes / on(pod,container) kube_pod_container_resource_limits{resource="memory"}`
+- CPU throttling: `rate(container_cpu_cfs_throttled_periods_total{namespace="x"}[5m])`
+- P99 latency (histograms): `histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))`
+
+If the tool reports Prometheus is not configured for a cluster, continue with
+kubectl evidence — do not retry the metrics tool on that cluster.
+"""
+
+
+def metrics_guidance() -> str:
+    """The prompt section to inject — empty when the tool is not registered."""
+    return METRICS_PROMPT_SECTION if prometheus_tool_enabled() else ""

--- a/kubently/modules/api/__init__.py
+++ b/kubently/modules/api/__init__.py
@@ -15,6 +15,8 @@ from .models import (
     CreateSessionRequest,
     ExecuteCommandRequest,
     ExecutionStatus,
+    PrometheusQueryRequest,
+    PrometheusQueryType,
     SessionResponse,
     SessionStatus,
 )
@@ -22,6 +24,8 @@ from .models import (
 __all__ = [
     "CreateSessionRequest",
     "ExecuteCommandRequest",
+    "PrometheusQueryRequest",
+    "PrometheusQueryType",
     "SessionResponse",
     "CommandResponse",
     "CommandResult",

--- a/kubently/modules/api/models.py
+++ b/kubently/modules/api/models.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Enums
 
@@ -175,6 +175,80 @@ class ExecuteCommandRequest(BaseModel):
             raise ValueError(f"Unrecognized or unsafe flag in extra_args: {arg}")
         
         return v
+
+
+class PrometheusQueryType(str, Enum):
+    """Types of Prometheus queries (maps to the two allowed read-only API paths)."""
+
+    INSTANT = "instant"
+    RANGE = "range"
+
+
+# Prometheus timestamps: RFC3339 or unix seconds; step/timeout: Prometheus
+# duration (e.g. "30s", "5m") or a bare number of seconds.
+_PROM_TIME_PATTERN = re.compile(
+    r"^\d+(\.\d+)?$|^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$"
+)
+_PROM_DURATION_PATTERN = re.compile(r"^\d+(\.\d+)?(ms|s|m|h|d|w|y)?$")
+
+
+class PrometheusQueryRequest(BaseModel):
+    """Request to run a read-only PromQL query on a cluster's Prometheus.
+
+    The query executes on the cluster's executor against its locally configured
+    PROMETHEUS_URL — this API never dials Prometheus itself and never forwards
+    a URL, only the validated query parameters.
+    """
+
+    cluster_id: str = Field(..., description="Target cluster identifier")
+    query: str = Field(
+        ..., min_length=1, max_length=4000, description="PromQL expression"
+    )
+    query_type: PrometheusQueryType = Field(
+        default=PrometheusQueryType.INSTANT, description="instant or range query"
+    )
+    time: Optional[str] = Field(
+        None, max_length=64, description="Evaluation time for instant queries (RFC3339 or unix)"
+    )
+    start: Optional[str] = Field(
+        None, max_length=64, description="Range start (RFC3339 or unix); required for range"
+    )
+    end: Optional[str] = Field(
+        None, max_length=64, description="Range end (RFC3339 or unix); required for range"
+    )
+    step: Optional[str] = Field(
+        None, max_length=32, description="Range resolution step (e.g. '30s', '5m'); required for range"
+    )
+    timeout_seconds: Optional[int] = Field(default=30, description="Query timeout", ge=1, le=60)
+    correlation_id: Optional[str] = Field(
+        None, description="Correlation ID for A2A request tracking"
+    )
+
+    @field_validator("time", "start", "end")
+    @classmethod
+    def validate_timestamp(cls, v):
+        if v is not None and not _PROM_TIME_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid timestamp '{v}': use RFC3339 (2026-08-16T12:00:00Z) or unix seconds"
+            )
+        return v
+
+    @field_validator("step")
+    @classmethod
+    def validate_step(cls, v):
+        if v is not None and not _PROM_DURATION_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid step '{v}': use a Prometheus duration like '30s', '5m', '1h'"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def validate_range_fields(self):
+        if self.query_type == PrometheusQueryType.RANGE:
+            missing = [f for f in ("start", "end", "step") if not getattr(self, f)]
+            if missing:
+                raise ValueError(f"Range query requires: {', '.join(missing)}")
+        return self
 
 
 # Response Models (API Output)
@@ -466,6 +540,8 @@ __all__ = [
     # Request models
     "CreateSessionRequest",
     "ExecuteCommandRequest",
+    "PrometheusQueryRequest",
+    "PrometheusQueryType",
     # Response models
     "SessionResponse",
     "CommandResponse",

--- a/kubently/modules/executor/prometheus.py
+++ b/kubently/modules/executor/prometheus.py
@@ -140,8 +140,9 @@ class PrometheusRunner:
         except requests.exceptions.Timeout:
             return self._error(
                 f"Prometheus query timed out after {self.timeout}s. "
-                "Narrow the query (shorter range, larger step, tighter selectors)."
-            , status="TIMEOUT")
+                "Narrow the query (shorter range, larger step, tighter selectors).",
+                status="TIMEOUT",
+            )
         except requests.exceptions.RequestException as e:
             return self._error(f"Could not reach Prometheus at {self.base_url}: {e}")
 

--- a/kubently/modules/executor/prometheus.py
+++ b/kubently/modules/executor/prometheus.py
@@ -1,0 +1,226 @@
+"""Read-only Prometheus query runner for the Kubently executor.
+
+The control plane cannot reach an in-cluster Prometheus, so metric queries
+travel the same outbound channel as kubectl commands: API -> Redis pub/sub ->
+executor SSE -> result POST. This module is the executor-side terminus of that
+path.
+
+Security model (mirrors the kubectl whitelist philosophy — the executor, not
+the caller, decides what it will execute):
+
+- The base URL comes ONLY from local executor configuration (PROMETHEUS_URL).
+  The control plane never supplies a URL, so a compromised API key cannot turn
+  the executor into an SSRF proxy.
+- Only two fixed, read-only HTTP API paths are reachable: /api/v1/query and
+  /api/v1/query_range. GET only. Nothing else is constructible from a request.
+- When PROMETHEUS_URL is unset the runner reports "unavailable" without making
+  any network call.
+
+Results are capped (series count, total samples, output characters) before
+they leave the executor, so an unbounded PromQL result never floods Redis, the
+API, or the model's context. Truncation is always announced in the output so
+the model knows it is looking at a partial result.
+
+Deliberately import-light (stdlib + requests) to match sse_executor.py.
+"""
+
+import json
+import logging
+import os
+
+import requests
+
+logger = logging.getLogger("kubently-prometheus")
+
+# The complete surface area: query_type -> API path. GET only, nothing else.
+ALLOWED_QUERY_PATHS = {
+    "instant": "/api/v1/query",
+    "range": "/api/v1/query_range",
+}
+
+DEFAULT_TIMEOUT_SECONDS = 30
+DEFAULT_MAX_SERIES = 50
+DEFAULT_MAX_SAMPLES = 2000
+DEFAULT_MAX_OUTPUT_CHARS = 20000
+
+UNAVAILABLE_MESSAGE = (
+    "Prometheus is not configured on this cluster's executor "
+    "(PROMETHEUS_URL is unset). Metrics are unavailable here; "
+    "continue the investigation with kubectl."
+)
+
+
+def _thin_samples(values: list, keep: int) -> list:
+    """Keep `keep` evenly spaced samples, always including first and last.
+
+    Preserves the shape of a trend (the reason the model asked for a range
+    query) instead of returning only the oldest window.
+    """
+    if keep <= 0:
+        return []
+    if len(values) <= keep:
+        return values
+    if keep == 1:
+        return [values[-1]]
+    step = (len(values) - 1) / (keep - 1)
+    indices = {round(i * step) for i in range(keep)}
+    indices.add(len(values) - 1)
+    return [values[i] for i in sorted(indices)]
+
+
+class PrometheusRunner:
+    """Executes validated instant/range queries against a locally configured
+    Prometheus and returns results in the executor's standard result shape."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        timeout: int | None = None,
+        max_series: int | None = None,
+        max_samples: int | None = None,
+        max_output_chars: int | None = None,
+    ):
+        self.base_url = (
+            base_url if base_url is not None else os.environ.get("PROMETHEUS_URL", "")
+        ).strip().rstrip("/")
+        self.timeout = timeout or int(
+            os.environ.get("PROMETHEUS_TIMEOUT", str(DEFAULT_TIMEOUT_SECONDS))
+        )
+        self.max_series = max_series or int(
+            os.environ.get("PROMETHEUS_MAX_SERIES", str(DEFAULT_MAX_SERIES))
+        )
+        self.max_samples = max_samples or int(
+            os.environ.get("PROMETHEUS_MAX_SAMPLES", str(DEFAULT_MAX_SAMPLES))
+        )
+        self.max_output_chars = max_output_chars or int(
+            os.environ.get("PROMETHEUS_MAX_OUTPUT_CHARS", str(DEFAULT_MAX_OUTPUT_CHARS))
+        )
+
+    @property
+    def available(self) -> bool:
+        return bool(self.base_url)
+
+    def run(self, request: dict) -> dict:
+        """Run one query request and return the executor result shape:
+        {"success", "output", "error", "status", "return_code"}."""
+        if not self.available:
+            return self._error(UNAVAILABLE_MESSAGE, status="UNAVAILABLE")
+
+        query_type = request.get("query_type", "instant")
+        path = ALLOWED_QUERY_PATHS.get(query_type)
+        if path is None:
+            return self._error(
+                f"Unsupported query_type '{query_type}'. "
+                f"Allowed: {', '.join(sorted(ALLOWED_QUERY_PATHS))}."
+            )
+
+        query = request.get("query")
+        if not query or not isinstance(query, str):
+            return self._error("Missing PromQL 'query' string.")
+
+        params = {"query": query}
+        if query_type == "range":
+            missing = [k for k in ("start", "end", "step") if not request.get(k)]
+            if missing:
+                return self._error(
+                    f"Range query requires start, end and step (missing: {', '.join(missing)})."
+                )
+            params["start"] = str(request["start"])
+            params["end"] = str(request["end"])
+            params["step"] = str(request["step"])
+        elif request.get("time"):
+            params["time"] = str(request["time"])
+
+        try:
+            response = requests.get(
+                f"{self.base_url}{path}",
+                params=params,
+                timeout=self.timeout,
+            )
+        except requests.exceptions.Timeout:
+            return self._error(
+                f"Prometheus query timed out after {self.timeout}s. "
+                "Narrow the query (shorter range, larger step, tighter selectors)."
+            , status="TIMEOUT")
+        except requests.exceptions.RequestException as e:
+            return self._error(f"Could not reach Prometheus at {self.base_url}: {e}")
+
+        try:
+            body = response.json()
+        except ValueError:
+            return self._error(
+                f"Prometheus returned non-JSON (HTTP {response.status_code}): "
+                f"{response.text[:200]}"
+            )
+
+        if response.status_code != 200 or body.get("status") != "success":
+            # Prometheus puts PromQL errors in errorType/error with HTTP 400.
+            detail = body.get("error") or f"HTTP {response.status_code}"
+            error_type = body.get("errorType")
+            prefix = f"Prometheus query failed ({error_type}): " if error_type else \
+                "Prometheus query failed: "
+            return self._error(prefix + str(detail))
+
+        output = self._format_capped(body.get("data") or {})
+        return {
+            "success": True,
+            "output": output,
+            "error": None,
+            "status": "SUCCESS",
+            "return_code": 0,
+        }
+
+    def _format_capped(self, data: dict) -> str:
+        """Serialize the result, capping series count and total samples.
+
+        Truncation notes are embedded in the payload the model reads, so a
+        partial result is never mistaken for the whole picture.
+        """
+        result_type = data.get("resultType")
+        result = data.get("result")
+        notes = []
+
+        if isinstance(result, list):
+            total_series = len(result)
+            if total_series > self.max_series:
+                result = result[: self.max_series]
+                notes.append(
+                    f"showing {self.max_series} of {total_series} series — "
+                    "aggregate (sum/avg by (...)) or use topk() to reduce cardinality"
+                )
+
+            # Matrix results carry per-series "values"; spread the sample
+            # budget across the kept series and thin evenly to keep the trend.
+            series_with_values = [s for s in result if isinstance(s, dict) and "values" in s]
+            total_samples = sum(len(s.get("values") or []) for s in series_with_values)
+            if series_with_values and total_samples > self.max_samples:
+                per_series = max(2, self.max_samples // len(series_with_values))
+                for s in series_with_values:
+                    s["values"] = _thin_samples(s.get("values") or [], per_series)
+                notes.append(
+                    f"downsampled from {total_samples} to "
+                    f"~{self.max_samples} samples (evenly spaced, endpoints kept) — "
+                    "use a larger step or shorter range for full resolution"
+                )
+
+        payload = {"resultType": result_type, "result": result}
+        if notes:
+            payload["kubently_truncation"] = notes
+        output = json.dumps(payload, separators=(",", ":"))
+
+        if len(output) > self.max_output_chars:
+            output = output[: self.max_output_chars] + (
+                f'\n[truncated at {self.max_output_chars} chars — result too large even '
+                "after series/sample caps; aggregate the query further]"
+            )
+        return output
+
+    @staticmethod
+    def _error(message: str, status: str = "FAILED") -> dict:
+        return {
+            "success": False,
+            "output": None,
+            "error": message,
+            "status": status,
+            "return_code": -1,
+        }

--- a/kubently/modules/executor/sse_executor.py
+++ b/kubently/modules/executor/sse_executor.py
@@ -37,6 +37,8 @@ try:
 except ImportError:
     WHITELIST_AVAILABLE = False
 
+from kubently.modules.executor.prometheus import PrometheusRunner
+
 # Configure logging
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO"),
@@ -90,6 +92,13 @@ class SSEKubentlyExecutor:
             logger.warning("⚠️  Using HTTP without TLS - this should only be used for local development!")
         elif self.api_url.startswith("https://"):
             logger.info("✅ Using HTTPS with TLS encryption")
+
+        # Optional Prometheus query runner. Configured entirely from local env
+        # (PROMETHEUS_URL etc.) — the control plane never supplies a URL. When
+        # unset, prometheus commands get a clear "unavailable" error back.
+        self._prometheus = PrometheusRunner()
+        if self._prometheus.available:
+            logger.info(f"Prometheus tool enabled: {self._prometheus.base_url}")
 
         # Command queue for processing
         self.command_queue = Queue()
@@ -215,8 +224,9 @@ class SSEKubentlyExecutor:
 
         start_time = time.time()
 
-        # Execute kubectl command
-        result = self._run_kubectl(command.get("args", []))
+        # Dispatch on the command's tool. kubectl is the default so command
+        # envelopes from older API versions (no "tool" field) keep working.
+        result = self._run_tool(command)
 
         # Add execution metadata
         result["command_id"] = command_id
@@ -241,6 +251,29 @@ class SSEKubentlyExecutor:
 
         except Exception as e:
             logger.error(f"Failed to submit result for {command_id}: {e}")
+
+    def _run_tool(self, command: dict) -> dict:
+        """
+        Route a command envelope to its tool runner.
+
+        Each tool enforces its own allowlist locally: kubectl commands go
+        through the DynamicCommandWhitelist, prometheus queries are limited to
+        two read-only GET paths against the locally configured base URL.
+        """
+        tool = command.get("tool", "kubectl")
+
+        if tool == "kubectl":
+            return self._run_kubectl(command.get("args", []))
+        if tool == "prometheus":
+            return self._prometheus.run(command.get("request") or {})
+
+        logger.warning(f"Rejected command with unknown tool: {tool}")
+        return {
+            "success": False,
+            "error": f"Unknown tool '{tool}'. This executor supports: kubectl, prometheus.",
+            "status": "BLOCKED",
+            "return_code": -1,
+        }
 
     def _run_kubectl(self, args: list[str]) -> dict:
         """

--- a/prompts/system.prompt.yaml
+++ b/prompts/system.prompt.yaml
@@ -1,10 +1,16 @@
-version: 3
+version: 4
 name: kubently_thorough_investigation
 role: system
 metadata:
   owner: kubently
   description: System prompt for thorough Kubernetes debugging with enhanced investigation patterns
-variables: []
+variables:
+  # Injected by the agent ONLY when the query_prometheus tool is registered
+  # (PROMETHEUS_URL set); defaults to empty so unconfigured deployments never
+  # reference a metrics tool the model cannot call.
+  - name: metrics_guidance
+    required: false
+    default: ""
 content: |-
   # Kubently System Prompt
 
@@ -359,6 +365,8 @@ content: |-
   - Fleet results are a triage view: per-cluster output is truncated. Drill into a specific cluster with execute_kubectl when you need detail.
   - Keep fleet commands filtered and token-efficient (e.g. `-o wide`, `-o custom-columns`, `-l <selector>`); never dump unfiltered resources from every cluster. Do NOT use `--field-selector status.phase!=Running` for fleet health sweeps — CrashLoopBackOff pods have `phase=Running`, so a whole cluster can look healthy while pods crash on a loop.
   - For single-cluster questions keep using execute_kubectl.
+
+  {{metrics_guidance}}
 
   # Code References
 

--- a/tests/test_prometheus_executor.py
+++ b/tests/test_prometheus_executor.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+Tests for the executor-side Prometheus query runner.
+
+The runner is the security boundary for the first non-kubectl evidence source:
+it must only ever GET the two whitelisted query paths against the LOCALLY
+configured base URL (never one supplied by the control plane), report cleanly
+when unconfigured, and cap results before they leave the executor.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.executor.prometheus import (
+    ALLOWED_QUERY_PATHS,
+    PrometheusRunner,
+    _thin_samples,
+)
+from kubently.modules.executor.sse_executor import SSEKubentlyExecutor
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+def prom_success(result, result_type="vector"):
+    return {"status": "success", "data": {"resultType": result_type, "result": result}}
+
+
+@pytest.fixture
+def capture_get(monkeypatch):
+    """Capture requests.get calls and return a canned response."""
+    calls = {}
+
+    def install(response):
+        def fake_get(url, params=None, timeout=None):
+            calls["url"] = url
+            calls["params"] = params
+            calls["timeout"] = timeout
+            return response
+
+        monkeypatch.setattr("kubently.modules.executor.prometheus.requests.get", fake_get)
+        return calls
+
+    return install
+
+
+# Availability
+
+
+def test_unconfigured_runner_reports_unavailable_without_network(monkeypatch):
+    monkeypatch.delenv("PROMETHEUS_URL", raising=False)
+
+    def no_network(*a, **k):
+        raise AssertionError("must not touch the network when unconfigured")
+
+    monkeypatch.setattr("kubently.modules.executor.prometheus.requests.get", no_network)
+
+    runner = PrometheusRunner()
+    assert runner.available is False
+    result = runner.run({"query_type": "instant", "query": "up"})
+    assert result["success"] is False
+    assert result["status"] == "UNAVAILABLE"
+    assert "not configured" in result["error"]
+
+
+# Path allowlist / request building
+
+
+def test_instant_query_hits_only_the_query_path(capture_get):
+    calls = capture_get(FakeResponse(prom_success([])))
+    runner = PrometheusRunner(base_url="http://prom:9090")
+    result = runner.run({"query_type": "instant", "query": "up", "time": "1700000000"})
+    assert result["success"] is True
+    assert calls["url"] == "http://prom:9090/api/v1/query"
+    assert calls["params"] == {"query": "up", "time": "1700000000"}
+
+
+def test_range_query_hits_only_the_query_range_path(capture_get):
+    calls = capture_get(FakeResponse(prom_success([], "matrix")))
+    runner = PrometheusRunner(base_url="http://prom:9090/")  # trailing slash normalized
+    result = runner.run(
+        {
+            "query_type": "range",
+            "query": "rate(x[5m])",
+            "start": "1700000000",
+            "end": "1700003600",
+            "step": "60s",
+        }
+    )
+    assert result["success"] is True
+    assert calls["url"] == "http://prom:9090/api/v1/query_range"
+    assert calls["params"]["step"] == "60s"
+
+
+def test_unknown_query_type_is_rejected_without_network(monkeypatch):
+    monkeypatch.setattr(
+        "kubently.modules.executor.prometheus.requests.get",
+        lambda *a, **k: pytest.fail("must not reach the network"),
+    )
+    runner = PrometheusRunner(base_url="http://prom:9090")
+    result = runner.run({"query_type": "admin", "query": "up"})
+    assert result["success"] is False
+    assert "Unsupported query_type" in result["error"]
+
+
+def test_range_query_requires_start_end_step():
+    runner = PrometheusRunner(base_url="http://prom:9090")
+    result = runner.run({"query_type": "range", "query": "up", "start": "1700000000"})
+    assert result["success"] is False
+    assert "end" in result["error"] and "step" in result["error"]
+
+
+def test_allowlist_is_exactly_two_read_paths():
+    assert ALLOWED_QUERY_PATHS == {
+        "instant": "/api/v1/query",
+        "range": "/api/v1/query_range",
+    }
+
+
+# Error surfacing
+
+
+def test_promql_error_is_surfaced(capture_get):
+    capture_get(
+        FakeResponse(
+            {"status": "error", "errorType": "bad_data", "error": "parse error at char 3"},
+            status_code=400,
+        )
+    )
+    runner = PrometheusRunner(base_url="http://prom:9090")
+    result = runner.run({"query_type": "instant", "query": "up{"})
+    assert result["success"] is False
+    assert "bad_data" in result["error"]
+    assert "parse error" in result["error"]
+
+
+# Result capping
+
+
+def _series(name, n_values=0):
+    metric = {"__name__": "m", "pod": name}
+    if n_values:
+        return {"metric": metric, "values": [[i, str(i)] for i in range(n_values)]}
+    return {"metric": metric, "value": [0, "1"]}
+
+
+def test_series_cap_truncates_and_notes(capture_get):
+    capture_get(FakeResponse(prom_success([_series(f"p{i}") for i in range(10)])))
+    runner = PrometheusRunner(base_url="http://prom:9090", max_series=3)
+    result = runner.run({"query_type": "instant", "query": "up"})
+    payload = json.loads(result["output"])
+    assert len(payload["result"]) == 3
+    assert any("3 of 10 series" in n for n in payload["kubently_truncation"])
+
+
+def test_sample_cap_downsamples_keeping_endpoints(capture_get):
+    series = [_series("p0", n_values=100), _series("p1", n_values=100)]
+    capture_get(FakeResponse(prom_success(series, "matrix")))
+    runner = PrometheusRunner(base_url="http://prom:9090", max_samples=20)
+    result = runner.run(
+        {"query_type": "range", "query": "m", "start": "0", "end": "1", "step": "1s"}
+    )
+    payload = json.loads(result["output"])
+    for s in payload["result"]:
+        assert len(s["values"]) <= 11  # 20 // 2 series, +1 for endpoint inclusion
+        assert s["values"][0][0] == 0  # first sample kept
+        assert s["values"][-1][0] == 99  # last sample kept
+    assert any("downsampled" in n for n in payload["kubently_truncation"])
+
+
+def test_small_results_pass_through_untruncated(capture_get):
+    capture_get(FakeResponse(prom_success([_series("p0", n_values=5)], "matrix")))
+    runner = PrometheusRunner(base_url="http://prom:9090")
+    result = runner.run(
+        {"query_type": "range", "query": "m", "start": "0", "end": "1", "step": "1s"}
+    )
+    payload = json.loads(result["output"])
+    assert len(payload["result"][0]["values"]) == 5
+    assert "kubently_truncation" not in payload
+
+
+def test_char_cap_is_final_backstop(capture_get):
+    capture_get(FakeResponse(prom_success([_series(f"pod-{i}" * 10) for i in range(40)])))
+    runner = PrometheusRunner(base_url="http://prom:9090", max_series=50, max_output_chars=500)
+    result = runner.run({"query_type": "instant", "query": "up"})
+    assert len(result["output"]) < 700
+    assert "truncated at 500 chars" in result["output"]
+
+
+def test_thin_samples_even_spacing():
+    values = list(range(100))
+    thinned = _thin_samples(values, 10)
+    assert thinned[0] == 0 and thinned[-1] == 99
+    assert len(thinned) <= 11
+    assert _thin_samples([1, 2], 10) == [1, 2]
+    assert _thin_samples(values, 1) == [99]
+
+
+# Executor dispatch
+
+
+@pytest.fixture
+def executor(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_API_URL", "http://localhost:8080")
+    monkeypatch.setenv("CLUSTER_ID", "test-cluster")
+    monkeypatch.setenv("KUBENTLY_TOKEN", "test-token")
+    monkeypatch.setenv("KUBENTLY_WHITELIST_CONFIG", "/nonexistent/whitelist.yaml")
+    monkeypatch.delenv("PROMETHEUS_URL", raising=False)
+    return SSEKubentlyExecutor()
+
+
+def test_dispatch_default_tool_is_kubectl(executor, monkeypatch):
+    monkeypatch.setattr(executor, "_run_kubectl", lambda args: {"success": True, "output": "ok"})
+    result = executor._run_tool({"args": ["get", "pods"]})
+    assert result["output"] == "ok"
+
+
+def test_dispatch_routes_prometheus_tool(executor):
+    # No PROMETHEUS_URL set -> the runner answers "unavailable", proving the
+    # envelope reached the prometheus runner and not kubectl.
+    result = executor._run_tool({"tool": "prometheus", "request": {"query": "up"}})
+    assert result["status"] == "UNAVAILABLE"
+
+
+def test_dispatch_rejects_unknown_tool(executor):
+    result = executor._run_tool({"tool": "curl", "request": {}})
+    assert result["success"] is False
+    assert result["status"] == "BLOCKED"

--- a/tests/test_prometheus_models.py
+++ b/tests/test_prometheus_models.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Validation tests for PrometheusQueryRequest.
+
+The API is the first validation layer for metric queries (the executor's path
+allowlist is the second): malformed range parameters must be rejected here so
+they never reach an executor, and only the two known query types exist.
+"""
+
+import os
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.api.models import PrometheusQueryRequest, PrometheusQueryType
+
+
+def test_minimal_instant_query():
+    req = PrometheusQueryRequest(cluster_id="prod", query="up")
+    assert req.query_type == PrometheusQueryType.INSTANT
+    assert req.timeout_seconds == 30
+
+
+def test_range_query_requires_start_end_step():
+    with pytest.raises(ValidationError, match="start, end, step"):
+        PrometheusQueryRequest(cluster_id="prod", query="up", query_type="range")
+
+    # Partially specified is still an error
+    with pytest.raises(ValidationError, match="end, step"):
+        PrometheusQueryRequest(
+            cluster_id="prod", query="up", query_type="range", start="1700000000"
+        )
+
+
+def test_valid_range_query():
+    req = PrometheusQueryRequest(
+        cluster_id="prod",
+        query="rate(kube_pod_container_status_restarts_total[5m])",
+        query_type="range",
+        start="2026-08-16T10:00:00Z",
+        end="1700003600",
+        step="60s",
+    )
+    assert req.query_type == PrometheusQueryType.RANGE
+
+
+def test_unknown_query_type_rejected():
+    with pytest.raises(ValidationError):
+        PrometheusQueryRequest(cluster_id="prod", query="up", query_type="admin")
+
+
+def test_empty_and_oversized_query_rejected():
+    with pytest.raises(ValidationError):
+        PrometheusQueryRequest(cluster_id="prod", query="")
+    with pytest.raises(ValidationError):
+        PrometheusQueryRequest(cluster_id="prod", query="x" * 4001)
+
+
+@pytest.mark.parametrize("bad_time", ["yesterday", "16/08/2026", "now()", "1700000000; rm"])
+def test_malformed_timestamps_rejected(bad_time):
+    with pytest.raises(ValidationError, match="Invalid timestamp"):
+        PrometheusQueryRequest(cluster_id="prod", query="up", time=bad_time)
+
+
+@pytest.mark.parametrize("good_time", ["1700000000", "1700000000.5", "2026-08-16T10:00:00Z",
+                                       "2026-08-16T10:00:00+02:00", "2026-08-16T10:00:00"])
+def test_valid_timestamps_accepted(good_time):
+    req = PrometheusQueryRequest(cluster_id="prod", query="up", time=good_time)
+    assert req.time == good_time
+
+
+@pytest.mark.parametrize("bad_step", ["fast", "60ss", "-30s", "1 m"])
+def test_malformed_step_rejected(bad_step):
+    with pytest.raises(ValidationError, match="duration"):
+        PrometheusQueryRequest(
+            cluster_id="prod", query="up", query_type="range",
+            start="0", end="1", step=bad_step,
+        )
+
+
+@pytest.mark.parametrize("good_step", ["30s", "5m", "1h", "15", "500ms"])
+def test_valid_step_accepted(good_step):
+    req = PrometheusQueryRequest(
+        cluster_id="prod", query="up", query_type="range",
+        start="0", end="1", step=good_step,
+    )
+    assert req.step == good_step
+
+
+def test_timeout_bounds():
+    with pytest.raises(ValidationError):
+        PrometheusQueryRequest(cluster_id="prod", query="up", timeout_seconds=0)
+    with pytest.raises(ValidationError):
+        PrometheusQueryRequest(cluster_id="prod", query="up", timeout_seconds=61)

--- a/tests/test_prometheus_tool.py
+++ b/tests/test_prometheus_tool.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Tests for the agent-side Prometheus tool plumbing.
+
+The availability contract is the point: PROMETHEUS_URL unset means the tool is
+not registered AND the prompt says nothing about metrics — the model must never
+be told about a tool it cannot call. Both switches flip on the same env var, so
+these tests guard that they cannot drift apart.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.a2a.protocol_bindings.a2a_server.prometheus import (
+    METRICS_PROMPT_SECTION,
+    build_prometheus_payload,
+    metrics_guidance,
+    prometheus_tool_enabled,
+)
+from kubently.modules.config import get_prompt
+
+REPO = os.path.join(os.path.dirname(__file__), "..")
+ROOT_PROMPT = os.path.join(REPO, "prompts", "system.prompt.yaml")
+CHART_PROMPT = os.path.join(
+    REPO, "deployment", "helm", "kubently", "prompts", "system.prompt.yaml"
+)
+
+
+# Availability gating
+
+
+def test_disabled_when_env_unset_or_blank(monkeypatch):
+    monkeypatch.delenv("PROMETHEUS_URL", raising=False)
+    assert prometheus_tool_enabled() is False
+    assert metrics_guidance() == ""
+
+    monkeypatch.setenv("PROMETHEUS_URL", "   ")
+    assert prometheus_tool_enabled() is False
+    assert metrics_guidance() == ""
+
+
+def test_enabled_when_env_set(monkeypatch):
+    monkeypatch.setenv("PROMETHEUS_URL", "http://prom:9090")
+    assert prometheus_tool_enabled() is True
+    assert metrics_guidance() == METRICS_PROMPT_SECTION
+
+
+# Payload building
+
+
+def test_build_instant_payload():
+    payload = build_prometheus_payload("up", time="1700000000")
+    assert payload["query"] == "up"
+    assert payload["query_type"] == "instant"
+    assert payload["time"] == "1700000000"
+    assert payload["start"] is None
+
+
+def test_build_range_payload():
+    payload = build_prometheus_payload(
+        "rate(x[5m])", query_type="range", start="0", end="1", step="60s"
+    )
+    assert payload["query_type"] == "range"
+    assert (payload["start"], payload["end"], payload["step"]) == ("0", "1", "60s")
+
+
+# Prompt injection: the shipped prompt must carry the {{metrics_guidance}}
+# hook, and get_prompt must render it in when enabled / to nothing when not.
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_prompt_files_declare_the_metrics_variable():
+    for path in (ROOT_PROMPT, CHART_PROMPT):
+        content = _read(path)
+        assert "{{metrics_guidance}}" in content, f"{path} lost the metrics hook"
+        assert "metrics_guidance" in content
+
+
+def test_prompt_renders_metrics_section_when_enabled(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_A2A_PROMPT_FILE", ROOT_PROMPT)
+    monkeypatch.setenv("PROMETHEUS_URL", "http://prom:9090")
+    prompt = get_prompt(role="a2a", variables={"metrics_guidance": metrics_guidance()})
+    assert "## Metrics (Prometheus)" in prompt
+    assert "query_prometheus" in prompt
+    assert "{{metrics_guidance}}" not in prompt
+
+
+def test_prompt_never_mentions_metrics_when_disabled(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_A2A_PROMPT_FILE", ROOT_PROMPT)
+    monkeypatch.delenv("PROMETHEUS_URL", raising=False)
+    prompt = get_prompt(role="a2a", variables={"metrics_guidance": metrics_guidance()})
+    assert "query_prometheus" not in prompt
+    assert "Prometheus" not in prompt
+    assert "{{metrics_guidance}}" not in prompt
+
+
+def test_prompt_default_keeps_placeholder_out_even_without_variables(monkeypatch):
+    """Older callers that don't pass variables still get a clean prompt: the
+    declared default ('') must swallow the placeholder."""
+    monkeypatch.setenv("KUBENTLY_A2A_PROMPT_FILE", ROOT_PROMPT)
+    prompt = get_prompt(role="a2a")
+    assert "{{metrics_guidance}}" not in prompt
+    assert "query_prometheus" not in prompt
+
+
+def test_guidance_covers_the_required_topics():
+    """Track C1a asks for specific guidance: when to reach for metrics and how
+    to write efficient, size-bounded PromQL."""
+    text = METRICS_PROMPT_SECTION.lower()
+    for topic in ("latency", "saturation", "oom", "restart", "topk", "rate(", "filter"):
+        assert topic in text, f"metrics guidance lost its '{topic}' coverage"


### PR DESCRIPTION
Track C1a (Roadmap Phase 3): first non-kubectl evidence source for the diagnostic agent.

- New Prometheus tool: instant + range PromQL queries via the Prometheus HTTP API, read-only GETs only, unregistered/unavailable when no Prometheus URL is configured.
- Queries route through the existing outbound-only executor channel (API → Redis queue → executor SSE → results) since the control plane can't reach an in-cluster Prometheus — sets the routing pattern the log-search and change-correlation toolsets will follow.
- Result-size guards: series/sample caps with explicit truncation notes to the model; timeout handling in the executor runner.
- System-prompt guidance (externalized YAML) on when to reach for metrics and writing bounded PromQL.
- Config via env + Helm values; docs (README toolset list, ENVIRONMENT_VARIABLES.md, CHANGELOG).
- 454 test lines across executor/models/tool; verified locally: 67 passed, 1 skipped (incl. checkpointer regression suite). Branch is a clean merge on top of current main (includes PR #66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX)_