### PR TITLE
Log-search toolset: multi-pod structured search + optional Loki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [Unreleased] - 2026-08-17
+
+### Added
+- **Log search toolset (Track C1b)** — the agent gets a `search_pod_logs`
+  tool: given a namespace and label selector (or one pod), it searches recent
+  logs across every matching pod/container for a substring or regex, with
+  time bounds (`since`/`since_time`), previous-container support for crash
+  investigations, and optional context lines around each match. The search
+  executes ON the cluster's executor — pods are resolved and logs fetched
+  through the same whitelist-enforced kubectl runner as ordinary commands
+  (composed in `--flag=value` form so values can't become flags), filtered
+  locally, so raw logs never transit Redis, the API, or the model's context
+- **Loki support when configured** — an optional `query_loki` tool (LogQL
+  range queries) for aggregated/historical log search, including logs from
+  restarted or deleted pods. Same pattern as the Prometheus toolset: a single
+  Helm value (`loki.url`) wires the executor env and switches the agent tool
+  on; the executor only ever GETs `/loki/api/v1/query_range` against its own
+  locally configured `LOKI_URL` (the control plane never supplies a URL);
+  when unset the tool is not registered and the system prompt's Loki guidance
+  (injected via a `{{loki_guidance}}` prompt variable) is omitted. Optional
+  `loki.tenantId` sets the `X-Scope-OrgID` header for multi-tenant Loki
+- **Log results are capped before they leave the executor** — pods scanned
+  (`LOG_SEARCH_MAX_PODS`, 20), matches per container (50), total matches
+  (200), per-line and total characters, an executor-side time budget, and a
+  clamped Loki line `limit` (`LOKI_MAX_LINES`, 500) — with every cap that
+  fires announced in the output the model reads, plus the shared `cap_output`
+  context guard on the agent side
+- **System-prompt log-search guidance** (externalized YAML, v4) — when to
+  search logs (errors after a deploy, correlating restarts via
+  previous-container logs, tracing upstream failures), narrowing
+  (namespace + selector + time bound) before searching, and preferring Loki
+  over pod-log search when it is configured
+- New API endpoints `/debug/logs/search` and `/debug/loki` publish `tool`
+  command envelopes over the existing outbound channel (API -> Redis pub/sub
+  -> executor SSE -> result POST) via a shared helper that also binds the
+  command id to the target cluster before publishing, so only the asked
+  executor can submit the result
+
 ## [Unreleased] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ helm install kubently deployment/helm -f deployment/helm/test-values.yaml
 - **Test Automation**: Comprehensive testing framework with 20+ Kubernetes scenarios
 - **CLI Tools**: Modern Node.js CLI for interactive debugging
 
+### Agent Toolset
+
+The diagnostic agent investigates with a small set of read-only tools:
+
+- **`list_clusters`** — enumerate registered clusters
+- **`execute_kubectl`** — read-only kubectl against one cluster (whitelist-enforced on the executor)
+- **`execute_kubectl_multi`** — one read-only kubectl command fanned out across many clusters
+- **`search_pod_logs`** — structured log search across every pod/container matching a label selector (substring or regex, time bounds, previous-container support). Logs are filtered on the cluster's executor so only matching lines — capped, with explicit truncation notes — come back
+- **`query_loki`** *(optional)* — LogQL range queries against a cluster's Loki for aggregated/historical log search, including logs from pods that have restarted or been deleted. Enabled by setting `loki.url` in Helm values (unset by default); queries execute on each cluster's executor through the same outbound channel as kubectl commands
+
 ## Documentation
 
 ### Getting Started

--- a/deployment/helm/kubently/prompts/system.prompt.yaml
+++ b/deployment/helm/kubently/prompts/system.prompt.yaml
@@ -1,10 +1,16 @@
-version: 3
+version: 4
 name: kubently_thorough_investigation
 role: system
 metadata:
   owner: kubently
   description: System prompt for thorough Kubernetes debugging with enhanced investigation patterns
-variables: []
+variables:
+  # Injected by the agent ONLY when the query_loki tool is registered
+  # (LOKI_URL set); defaults to empty so unconfigured deployments never
+  # reference a Loki tool the model cannot call.
+  - name: loki_guidance
+    required: false
+    default: ""
 content: |-
   # Kubently System Prompt
 
@@ -339,6 +345,7 @@ content: |-
 
   - execute_kubectl: Run kubectl commands for investigation and fixes
   - execute_kubectl_multi: Run one read-only kubectl command across many clusters in parallel (fleet queries)
+  - search_pod_logs: Search logs across all pods matching a selector (filtered on the cluster, only matching lines return)
   - list_clusters: Get available Kubernetes clusters
   - write_todos: Manage debugging workflow tasks to track systematic investigation progress
 
@@ -359,6 +366,23 @@ content: |-
   - Fleet results are a triage view: per-cluster output is truncated. Drill into a specific cluster with execute_kubectl when you need detail.
   - Keep fleet commands filtered and token-efficient (e.g. `-o wide`, `-o custom-columns`, `-l <selector>`); never dump unfiltered resources from every cluster. Do NOT use `--field-selector status.phase!=Running` for fleet health sweeps — CrashLoopBackOff pods have `phase=Running`, so a whole cluster can look healthy while pods crash on a loop.
   - For single-cluster questions keep using execute_kubectl.
+
+  ## Log Search
+
+  Use search_pod_logs to grep across MANY pods/containers in one call instead of dumping full logs pod-by-pod. Reach for it when:
+  - Errors appear after a deploy: search the workload's pods for `error|exception|panic` (use_regex=True) since the rollout time.
+  - Correlating restarts: set previous=True to read the pre-restart logs of every restarted replica at once — the crash reason is usually in the previous container, not the current one.
+  - Tracing an upstream failure: search the CALLING service's pods for the failing dependency's name, "timeout", or "connection refused" to see who is affected and how.
+  - Finding which replica is the outlier: the per-container sections show at a glance which pods log the error and which don't.
+
+  NARROW BEFORE SEARCHING:
+  - Identify the namespace and a label selector first (`get pods -n <ns> --show-labels`); never search without a selector or with an unbounded time window.
+  - Keep the default since="1h" (or tighter around the incident); use since_time for an exact deploy timestamp.
+  - Start with a specific query (the actual error text) before falling back to broad regexes.
+  - Results are capped at every level and truncation is always noted — when a cap fires, narrow the query/selector/window rather than re-running the same search.
+  - For ONE known pod where you just want recent context (not a search), plain `logs <pod> --tail=50` via execute_kubectl is still the cheaper call.
+
+  {{loki_guidance}}
 
   # Code References
 

--- a/deployment/helm/kubently/templates/api-deployment.yaml
+++ b/deployment/helm/kubently/templates/api-deployment.yaml
@@ -184,6 +184,14 @@ spec:
         - name: SLACK_WEBHOOK_URL
           value: {{ .Values.api.env.SLACK_WEBHOOK_URL | quote }}
         {{- end }}
+        {{- /* Presence of LOKI_URL switches on the agent's query_loki tool +
+               prompt guidance. The API never dials this URL itself — queries
+               run on each cluster's executor. Parenthesized lookup is
+               nil-safe for old values files. */}}
+        {{- if (.Values.loki).url }}
+        - name: LOKI_URL
+          value: {{ .Values.loki.url | quote }}
+        {{- end }}
         - name: KUBENTLY_A2A_PROMPT_FILE
           value: "/etc/kubently/prompts/system.prompt.yaml"
         - name: KUBENTLY_FLEET_REPORT_PROMPT_FILE

--- a/deployment/helm/kubently/templates/executor-deployment.yaml
+++ b/deployment/helm/kubently/templates/executor-deployment.yaml
@@ -81,6 +81,16 @@ spec:
         - name: KUBENTLY_WHITELIST_DB
           value: "/var/lib/kubently/whitelist.db"
         {{- end }}
+        {{- /* Loki log search: URL the executor queries (read-only).
+               Parenthesized lookup is nil-safe for old values files. */}}
+        {{- if (.Values.loki).url }}
+        - name: LOKI_URL
+          value: {{ .Values.loki.url | quote }}
+        {{- if .Values.loki.tenantId }}
+        - name: LOKI_TENANT_ID
+          value: {{ .Values.loki.tenantId | quote }}
+        {{- end }}
+        {{- end }}
         {{- /* Capability reporting configuration (optional feature) */}}
         {{- if .Values.executor.capabilities }}
         {{- if .Values.executor.capabilities.enabled }}

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -90,6 +90,31 @@ fleetReport:
   query: ""
 
 # ============================================================================
+# Loki Log Search (optional)
+# ============================================================================
+# Gives the diagnostic agent a read-only LogQL tool (query_loki) for searching
+# aggregated logs — including logs from pods that have restarted, been
+# rescheduled or deleted, which plain kubectl-based search cannot reach.
+#
+# The URL must be reachable FROM THE EXECUTOR POD — queries are executed by the
+# executor inside the monitored cluster (same outbound channel as kubectl
+# commands), never by the central API. Example for the loki-stack chart:
+#   url: "http://loki.monitoring.svc.cluster.local:3100"
+#
+# Leave empty (default) to disable: the agent does not register the tool, the
+# system prompt never mentions Loki, and the executor rejects Loki queries
+# with a clear "not configured" error. The selector-based search_pod_logs
+# tool is always available and needs no configuration.
+#
+# Split deployments (central API + remote executors): set loki.url on BOTH
+# installs. On an executor install it is the URL the executor queries; on the
+# API install it only enables the tool (the control plane never dials it).
+loki:
+  url: ""
+  # Optional X-Scope-OrgID header for multi-tenant Loki (executor-side only).
+  tenantId: ""
+
+# ============================================================================
 # Executor Configuration
 # ============================================================================
 # The executor runs IN the cluster being monitored and executes kubectl

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -48,6 +48,16 @@
 | `KUBENTLY_MAX_FLEET_CLUSTERS` | `10` | No | Max clusters per `execute_kubectl_multi` fan-out call (each cluster adds up to ~4KB to the agent context) |
 | `A2A_SERVER_DEBUG` | `false` | No | Enable A2A debug logging |
 
+### Loki Log Search (optional)
+
+When `LOKI_URL` is set on the API server, the agent registers the read-only `query_loki` tool (LogQL range queries) and injects Loki guidance into the system prompt. When unset (default), the tool does not exist and the prompt never mentions Loki. The selector-based `search_pod_logs` tool is always registered and needs no configuration.
+
+The API never dials this URL itself — queries execute on each cluster's executor against the executor's own `LOKI_URL` (see Executor Configuration below). On the API side the variable only switches the tool on.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `LOKI_URL` | - | No | Presence enables the `query_loki` agent tool. Set via Helm `loki.url` |
+
 ### Conversation Memory (A2A Checkpointing)
 
 The A2A agent persists multi-turn conversation state through a LangGraph
@@ -109,6 +119,32 @@ diagnoses are unaffected.
 | `WHITELIST_PATH` | `/etc/kubently/whitelist.yaml` | No | Path to whitelist configuration |
 | `REFRESH_INTERVAL` | `30` | No | Whitelist refresh interval in seconds |
 | `TIMEOUT_SECONDS` | `30` | No | Command execution timeout |
+
+### Log Search (search_pod_logs)
+
+The executor performs selector-based log searches locally: pods are resolved and logs fetched through the same whitelist-enforced kubectl runner as ordinary commands, filtered on the executor, and only matching lines come back. All caps announce themselves in the tool output when they fire.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `LOG_SEARCH_MAX_PODS` | `20` | No | Max pods scanned per search (excess noted) |
+| `LOG_SEARCH_MAX_MATCHES_PER_CONTAINER` | `50` | No | Max matching lines shown per container |
+| `LOG_SEARCH_MAX_TOTAL_MATCHES` | `200` | No | Max matching lines shown per search |
+| `LOG_SEARCH_MAX_LINE_CHARS` | `500` | No | Individual lines truncated beyond this |
+| `LOG_SEARCH_MAX_OUTPUT_CHARS` | `20000` | No | Hard cap on assembled result size |
+| `LOG_SEARCH_TIME_BUDGET` | `50` | No | Seconds of kubectl fetching before the search stops early (with a note) |
+
+### Loki Log Search (optional)
+
+The executor performs Loki queries locally (read-only GETs against `/loki/api/v1/query_range` only). The base URL comes exclusively from this local configuration — the control plane never supplies one. When unset (default), Loki queries are answered with a clear "not configured" error.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `LOKI_URL` | - | No | Loki base URL reachable from the executor pod, e.g. `http://loki.monitoring.svc.cluster.local:3100`. Set via Helm `loki.url` |
+| `LOKI_TENANT_ID` | - | No | Optional `X-Scope-OrgID` header for multi-tenant Loki. Set via Helm `loki.tenantId` |
+| `LOKI_TIMEOUT` | `30` | No | Query timeout in seconds |
+| `LOKI_MAX_LINES` | `500` | No | Max log lines per query (the request `limit` is clamped to this) |
+| `LOKI_MAX_LINE_CHARS` | `500` | No | Individual lines truncated beyond this |
+| `LOKI_MAX_OUTPUT_CHARS` | `20000` | No | Hard cap on serialized result size |
 
 ## Deployment-Specific Variables
 

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -33,6 +33,8 @@ from kubently.modules.api import (
     CreateSessionRequest,
     ExecuteCommandRequest,
     ExecutionStatus,
+    LogSearchRequest,
+    LokiQueryRequest,
     SessionResponse,
     SessionStatus,
 )
@@ -738,6 +740,161 @@ async def execute_command(
         error=result.get("error"),
         execution_time_ms=result.get("execution_time_ms"),
         executed_at=result.get("executed_at"),
+    )
+
+
+async def _run_executor_tool(
+    cluster_id: str,
+    tool: str,
+    tool_request: dict,
+    timeout: int,
+    correlation_id: Optional[str],
+    timeout_error: str,
+) -> CommandResponse:
+    """Publish a non-kubectl tool envelope to a cluster's executor and await
+    the result.
+
+    Shares the /debug/execute flow: validate the cluster (fail fast with the
+    list of valid clusters instead of queueing a command nothing will pick
+    up), mark it active for fast polling, bind the command id to the cluster
+    so only the asked executor can answer, publish, wait.
+    """
+    token_key = f"executor:token:{cluster_id}"
+    if not await redis_client.exists(token_key):
+        valid_clusters = sorted(
+            (k.decode() if isinstance(k, bytes) else k).replace("executor:token:", "")
+            for k in await redis_client.keys("executor:token:*")
+        )
+        error_msg = f"Cluster '{cluster_id}' not found."
+        if valid_clusters:
+            error_msg += f" Available clusters: {', '.join(valid_clusters)}"
+        else:
+            error_msg += " No clusters are currently registered."
+        raise HTTPException(404, error_msg)
+
+    cluster_active_key = f"cluster:active:{cluster_id}"
+    await redis_client.setex(cluster_active_key, 60, "1")
+
+    command = {
+        "id": str(uuid.uuid4()),
+        "tool": tool,
+        "request": tool_request,
+        "timeout": timeout,
+        "correlation_id": correlation_id,
+    }
+
+    await queue_module.bind_command(command["id"], cluster_id, ttl=max(120, timeout * 2))
+
+    channel = f"executor-commands:{cluster_id}"
+    await redis_client.publish(channel, json.dumps(command))
+    logger.info(f"Published {tool} command {command['id']} to channel {channel}")
+
+    result = await queue_module.wait_for_result(command["id"], timeout=timeout)
+
+    if not result:
+        return CommandResponse(
+            command_id=command["id"],
+            session_id=None,
+            cluster_id=cluster_id,
+            status=ExecutionStatus.TIMEOUT,
+            correlation_id=correlation_id,
+            error=timeout_error,
+        )
+
+    return CommandResponse(
+        command_id=command["id"],
+        session_id=None,
+        cluster_id=cluster_id,
+        status=ExecutionStatus.SUCCESS if result.get("success") else ExecutionStatus.FAILURE,
+        correlation_id=correlation_id,
+        output=result.get("output"),
+        error=result.get("error"),
+        execution_time_ms=result.get("execution_time_ms"),
+        executed_at=result.get("executed_at"),
+    )
+
+
+@app.post("/debug/logs/search", response_model=CommandResponse)
+async def search_logs(
+    request: LogSearchRequest,
+    auth_info: Tuple[bool, Optional[str]] = Depends(verify_api_key),
+    x_correlation_id: Optional[str] = Header(None, description="Correlation ID for A2A tracking"),
+):
+    """
+    Search logs across the pods matching a selector on one cluster.
+
+    The search rides the same outbound channel as kubectl commands (Redis
+    pub/sub -> executor SSE -> result POST): the executor inside the target
+    cluster resolves pods, fetches logs through its whitelist-enforced kubectl
+    runner, filters locally and returns only matching lines (capped). Raw logs
+    never transit this API.
+
+    Returns:
+        200: Search result (or executor-side error)
+        404: Cluster not found
+        401: Unauthorized
+    """
+    if not redis_client or not queue_module:
+        raise HTTPException(503, "Service not initialized")
+
+    return await _run_executor_tool(
+        cluster_id=request.cluster_id,
+        tool="log_search",
+        tool_request={
+            "namespace": request.namespace,
+            "selector": request.selector,
+            "pod_name": request.pod_name,
+            "container": request.container,
+            "query": request.query,
+            "use_regex": request.use_regex,
+            "case_sensitive": request.case_sensitive,
+            "since": request.since,
+            "since_time": request.since_time,
+            "tail_lines": request.tail_lines,
+            "previous": request.previous,
+            "context_lines": request.context_lines,
+        },
+        timeout=request.timeout_seconds or 60,
+        correlation_id=x_correlation_id or request.correlation_id,
+        timeout_error="Log search timeout (no executor picked it up in time)",
+    )
+
+
+@app.post("/debug/loki", response_model=CommandResponse)
+async def execute_loki_query(
+    request: LokiQueryRequest,
+    auth_info: Tuple[bool, Optional[str]] = Depends(verify_api_key),
+    x_correlation_id: Optional[str] = Header(None, description="Correlation ID for A2A tracking"),
+):
+    """
+    Run a read-only LogQL range query on a cluster's Loki.
+
+    The query rides the same outbound channel as kubectl commands: the
+    executor inside the target cluster performs the HTTP GET against its
+    locally configured LOKI_URL. This API never contacts Loki directly and
+    never forwards a URL — only the validated query parameters.
+
+    Returns:
+        200: Query result (or executor-side error, e.g. Loki not configured)
+        404: Cluster not found
+        401: Unauthorized
+    """
+    if not redis_client or not queue_module:
+        raise HTTPException(503, "Service not initialized")
+
+    return await _run_executor_tool(
+        cluster_id=request.cluster_id,
+        tool="loki",
+        tool_request={
+            "query": request.query,
+            "start": request.start,
+            "end": request.end,
+            "limit": request.limit,
+            "direction": request.direction.value,
+        },
+        timeout=request.timeout_seconds or 30,
+        correlation_id=x_correlation_id or request.correlation_id,
+        timeout_error="Loki query timeout (no executor picked it up in time)",
     )
 
 

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -303,9 +303,16 @@ class KubentlyAgent:
             )
 
         # Load system prompt from configuration
+        # Load system prompt from configuration. Loki guidance is injected
+        # only when the query_loki tool is registered, so the prompt never
+        # references a tool the model cannot call.
         from kubently.modules.config import get_prompt
 
-        self.system_prompt = get_prompt(role="a2a")
+        from .logsearch import loki_guidance
+
+        self.system_prompt = get_prompt(
+            role="a2a", variables={"loki_guidance": loki_guidance()}
+        )
 
         # Initialize tools for kubectl operations
         await self._initialize_tools()
@@ -639,10 +646,228 @@ class KubentlyAgent:
                 await interceptor.record_tool_result(tool_call_id, None, error_msg)
                 return error_msg
 
+        from kubently.modules.a2a.protocol_bindings.a2a_server.logsearch import (
+            build_log_search_payload,
+            build_loki_payload,
+            loki_tool_enabled,
+        )
+
+        async def _post_tool_request(
+            endpoint: str, payload: dict, tool_call_id, error_label: str, timeout: float = 75.0
+        ) -> str:
+            """POST a tool payload to the API, normalize errors, cap and record
+            the result. Shared by search_pod_logs and query_loki."""
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                try:
+                    response = await client.post(
+                        f"{api_url}{endpoint}",
+                        headers={"X-Api-Key": api_key()},
+                        json=payload,
+                    )
+                    if response.status_code != 200:
+                        error_msg = cap_output(
+                            f"Error: HTTP {response.status_code}: {response.text}"
+                        )
+                        await interceptor.record_tool_result(tool_call_id, None, error_msg)
+                        return error_msg
+
+                    result = response.json()
+                    exec_status, exec_error = result.get("status"), result.get("error")
+                    if exec_error or (exec_status and exec_status != "success"):
+                        error_msg = cap_output(
+                            f"Error: {exec_error or f'{error_label} status: {exec_status}'}"
+                        )
+                        await interceptor.record_tool_result(tool_call_id, None, error_msg)
+                        return error_msg
+
+                    # The executor already caps matches/lines; this is the
+                    # context-budget backstop shared with kubectl results.
+                    output = cap_output(result.get("output") or "")
+                    await interceptor.record_tool_result(tool_call_id, output)
+                    return output
+                except Exception as e:
+                    error_msg = f"Error running {error_label}: {e!s}"
+                    await interceptor.record_tool_result(tool_call_id, None, error_msg)
+                    return error_msg
+
+        @tool
+        async def search_pod_logs(
+            cluster_id: str,
+            namespace: str,
+            query: str,
+            selector: str | None = None,
+            pod_name: str | None = None,
+            container: str | None = None,
+            use_regex: bool = False,
+            case_sensitive: bool = False,
+            since: str | None = "1h",
+            since_time: str | None = None,
+            tail_lines: int = 2000,
+            previous: bool = False,
+            context_lines: int = 0,
+        ) -> str:
+            """Search logs across ALL pods matching a selector in one call.
+
+            Use this instead of dumping logs pod-by-pod when you need to find
+            WHICH pods/containers logged something: errors after a deploy,
+            correlating messages across replicas, tracing an upstream failure
+            through a workload. Logs are filtered on the cluster's executor,
+            so only matching lines (already capped) come back — far cheaper
+            than kubectl logs on each pod.
+
+            NARROW FIRST: identify the namespace and a label selector (e.g.
+            via "get pods -n <ns> --show-labels"), and keep a time bound
+            (since defaults to "1h"). Provide exactly one of `selector` or
+            `pod_name`.
+
+            Query matching:
+            - Default: case-insensitive substring
+            - use_regex=True for alternatives, e.g. "error|exception|timed? ?out"
+            - context_lines=2-3 to capture stack traces around each match
+
+            For crash investigations set previous=True to search the
+            pre-restart logs of restarted containers.
+
+            Results are capped (pods scanned, matches per container, total
+            matches, output size) and every truncation is noted in the output.
+            When a cap fires, narrow the query/selector/time window instead of
+            retrying the same search.
+
+            Args:
+                cluster_id: Target cluster (same IDs as execute_kubectl)
+                namespace: Namespace to search in
+                query: Substring or regex to search for
+                selector: Label selector (e.g. "app=api"); or use pod_name
+                pod_name: Single pod name; or use selector
+                container: Restrict to one container name
+                use_regex: Treat query as a regular expression
+                case_sensitive: Match case-sensitively
+                since: Relative time window like "30m", "1h" (default "1h")
+                since_time: Absolute RFC3339 lower bound (overrides since)
+                tail_lines: Max lines fetched per container (default 2000)
+                previous: Search previous (pre-restart) container logs
+                context_lines: Lines of context around each match (0-10)
+
+            Returns:
+                Per-container sections of matching lines with a summary
+                header, no-match list, and explicit truncation notes.
+            """
+            debug_print(
+                f"search_pod_logs called: cluster_id={cluster_id}, namespace={namespace}, "
+                f"selector={selector}, pod_name={pod_name}, query={query}"
+            )
+            tool_call_id = await interceptor.record_tool_call(
+                tool_name="search_pod_logs",
+                args={
+                    "cluster_id": cluster_id,
+                    "namespace": namespace,
+                    "query": query,
+                    "selector": selector,
+                    "pod_name": pod_name,
+                    "container": container,
+                    "use_regex": use_regex,
+                    "case_sensitive": case_sensitive,
+                    "since": since,
+                    "since_time": since_time,
+                    "tail_lines": tail_lines,
+                    "previous": previous,
+                    "context_lines": context_lines,
+                },
+                thread_id=getattr(self, "_current_thread_id", None),
+            )
+            payload = build_log_search_payload(
+                namespace=namespace,
+                query=query,
+                selector=selector,
+                pod_name=pod_name,
+                container=container,
+                use_regex=use_regex,
+                case_sensitive=case_sensitive,
+                since=since,
+                since_time=since_time,
+                tail_lines=tail_lines,
+                previous=previous,
+                context_lines=context_lines,
+            )
+            payload["cluster_id"] = cluster_id
+            return await _post_tool_request(
+                "/debug/logs/search", payload, tool_call_id, "log search"
+            )
+
         # Note: planning/todo tracking is now provided natively by deepagents
         # (write_todos via TodoListMiddleware), so the previous hand-rolled
         # todo_write tool + TodoManager were removed.
-        self.tools = [list_clusters, execute_kubectl, execute_kubectl_multi]
+        self.tools = [list_clusters, execute_kubectl, execute_kubectl_multi, search_pod_logs]
+
+        if loki_tool_enabled():
+
+            @tool
+            async def query_loki(
+                cluster_id: str,
+                query: str,
+                start: str | None = None,
+                end: str | None = None,
+                limit: int = 100,
+                direction: str = "backward",
+            ) -> str:
+                """Run a read-only LogQL range query against a cluster's Loki.
+
+                PREFER this over search_pod_logs when logs must survive pod
+                restarts/deletions, when searching across many workloads at
+                once, or when the window is further back than pods' current
+                logs reach. The query executes inside the target cluster (via
+                its executor), so use the in-cluster view of Loki.
+
+                Write BOUNDED LogQL — results are line-capped with a note when
+                truncated:
+                - Always start from a label selector: {namespace="x", app="api"}
+                - Add line filters: |= "error" (substring), |~ "regex", != / !~ to exclude
+                - Keep ranges short; Loki defaults to the last hour when
+                  start/end are omitted
+                - Count first when volume is unknown:
+                  sum by (pod) (count_over_time({namespace="x"} |= "error" [1h]))
+
+                Args:
+                    cluster_id: Target cluster (same IDs as execute_kubectl)
+                    query: LogQL expression
+                    start: Range start (RFC3339 or unix seconds; default -1h)
+                    end: Range end (RFC3339 or unix seconds; default now)
+                    limit: Max log lines returned (default 100)
+                    direction: "backward" (newest first, default) or "forward"
+
+                Returns:
+                    Per-stream sections of timestamped log lines (or compact
+                    JSON for metric-style queries), with truncation notes, or
+                    an error message (e.g. Loki not configured on that cluster
+                    — use search_pod_logs there instead).
+                """
+                debug_print(
+                    f"query_loki called: cluster_id={cluster_id}, query={query}, "
+                    f"start={start}, end={end}, limit={limit}"
+                )
+                tool_call_id = await interceptor.record_tool_call(
+                    tool_name="query_loki",
+                    args={
+                        "cluster_id": cluster_id,
+                        "query": query,
+                        "start": start,
+                        "end": end,
+                        "limit": limit,
+                        "direction": direction,
+                    },
+                    thread_id=getattr(self, "_current_thread_id", None),
+                )
+                payload = build_loki_payload(
+                    query, start=start, end=end, limit=limit, direction=direction
+                )
+                payload["cluster_id"] = cluster_id
+                return await _post_tool_request(
+                    "/debug/loki", payload, tool_call_id, "Loki query", timeout=45.0
+                )
+
+            self.tools.append(query_loki)
+            logger.info("Loki log search tool registered (LOKI_URL is set)")
+
         logger.info(f"Initialized {len(self.tools)} tools")
 
     async def run(

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/logsearch.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/logsearch.py
@@ -1,0 +1,112 @@
+"""Agent-side plumbing for the log-search toolset.
+
+Deliberately import-light (stdlib only) so unit tests can import it without
+pulling the langchain/a2a stack that agent.py requires.
+
+Two tools with different availability contracts:
+
+- search_pod_logs is ALWAYS registered: it only needs the executor's kubectl
+  runner, which every cluster has. Its guidance lives directly in the
+  externalized system prompt YAML.
+- query_loki is registered ONLY when LOKI_URL is set in the A2A server's
+  environment, and the matching guidance is injected into the system prompt
+  through the {{loki_guidance}} prompt variable at the same time. When unset,
+  neither exists, so the model is never told about a tool it cannot call.
+
+Note the A2A server never dials LOKI_URL itself — queries execute on the
+target cluster's executor against the executor's own locally configured URL.
+On the control plane the variable only switches the tool on.
+"""
+
+import os
+
+LOKI_URL_ENV = "LOKI_URL"
+
+
+def loki_tool_enabled() -> bool:
+    """Whether the query_loki tool should be registered."""
+    return bool(os.getenv(LOKI_URL_ENV, "").strip())
+
+
+def build_log_search_payload(
+    namespace: str,
+    query: str,
+    selector: str | None = None,
+    pod_name: str | None = None,
+    container: str | None = None,
+    use_regex: bool = False,
+    case_sensitive: bool = False,
+    since: str | None = "1h",
+    since_time: str | None = None,
+    tail_lines: int = 2000,
+    previous: bool = False,
+    context_lines: int = 0,
+    timeout_seconds: int = 60,
+) -> dict:
+    """Build the /debug/logs/search request body (minus cluster_id)."""
+    return {
+        "namespace": namespace,
+        "query": query,
+        "selector": selector,
+        "pod_name": pod_name,
+        "container": container,
+        "use_regex": use_regex,
+        "case_sensitive": case_sensitive,
+        "since": since,
+        "since_time": since_time,
+        "tail_lines": tail_lines,
+        "previous": previous,
+        "context_lines": context_lines,
+        "timeout_seconds": timeout_seconds,
+    }
+
+
+def build_loki_payload(
+    query: str,
+    start: str | None = None,
+    end: str | None = None,
+    limit: int = 100,
+    direction: str = "backward",
+    timeout_seconds: int = 30,
+) -> dict:
+    """Build the /debug/loki request body (minus cluster_id)."""
+    return {
+        "query": query,
+        "start": start,
+        "end": end,
+        "limit": limit,
+        "direction": direction,
+        "timeout_seconds": timeout_seconds,
+    }
+
+
+# Injected into the system prompt (via the {{loki_guidance}} variable) only
+# when the tool is registered, so an unconfigured deployment's prompt never
+# references Loki.
+LOKI_PROMPT_SECTION = """\
+### Loki (preferred when available)
+
+You also have a query_loki tool (LogQL range queries). PREFER Loki over
+search_pod_logs when the question spans history or many workloads: Loki keeps
+logs from pods that have restarted, been rescheduled or deleted, and searches a
+whole namespace in one query instead of pod-by-pod fetches. Fall back to
+search_pod_logs for the freshest lines or when a Loki query errors.
+
+Write BOUNDED LogQL — results are line-capped with a note when truncated:
+- Always start from a label selector: `{namespace="payments", app="api"}`
+- Add line filters to narrow: `{namespace="x"} |= "error"` (substring),
+  `|~ "timeout|refused"` (regex), `!=` / `!~` to exclude noise
+- Keep time ranges short (default is the last hour; pass start/end RFC3339 to widen)
+- Default direction is backward (newest first) — right for incident triage
+- Count before dumping when volume is unknown:
+  `sum by (pod) (count_over_time({namespace="x"} |= "error" [1h]))`, then fetch
+  lines only for the offenders
+
+If query_loki reports Loki is not configured for a cluster, use search_pod_logs
+on that cluster instead — do not retry Loki there.
+"""
+
+
+def loki_guidance() -> str:
+    """The prompt section to inject — empty when the tool is not registered."""
+    return LOKI_PROMPT_SECTION if loki_tool_enabled() else ""

--- a/kubently/modules/api/__init__.py
+++ b/kubently/modules/api/__init__.py
@@ -15,6 +15,9 @@ from .models import (
     CreateSessionRequest,
     ExecuteCommandRequest,
     ExecutionStatus,
+    LogSearchRequest,
+    LokiQueryDirection,
+    LokiQueryRequest,
     SessionResponse,
     SessionStatus,
 )
@@ -22,6 +25,9 @@ from .models import (
 __all__ = [
     "CreateSessionRequest",
     "ExecuteCommandRequest",
+    "LogSearchRequest",
+    "LokiQueryRequest",
+    "LokiQueryDirection",
     "SessionResponse",
     "CommandResponse",
     "CommandResult",

--- a/kubently/modules/api/models.py
+++ b/kubently/modules/api/models.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Enums
 
@@ -174,6 +174,133 @@ class ExecuteCommandRequest(BaseModel):
             # If we get here, it's not a recognized safe flag
             raise ValueError(f"Unrecognized or unsafe flag in extra_args: {arg}")
         
+        return v
+
+
+# Log search / Loki request models. Values flow to the executor as data (the
+# executor composes argv itself in --flag=value form), but they are still
+# validated here so malformed requests fail fast with a readable error.
+
+_DNS_NAME_PATTERN = re.compile(r"^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$")
+# kubectl --since durations: 30s, 5m, 2h (optionally combined, e.g. 1h30m)
+_KUBECTL_DURATION_PATTERN = re.compile(r"^(\d+h)?(\d+m)?(\d+s)?$")
+# RFC3339 or unix epoch (seconds or nanoseconds, optionally fractional)
+_TIME_PATTERN = re.compile(
+    r"^\d+(\.\d+)?$|^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$"
+)
+
+
+class LogSearchRequest(BaseModel):
+    """Request to search logs across the pods matching a selector.
+
+    The search executes on the cluster's executor: pods are resolved and logs
+    fetched through the executor's whitelist-enforced kubectl runner, filtered
+    locally, and only matching lines (capped) come back.
+    """
+
+    cluster_id: str = Field(..., description="Target cluster identifier")
+    namespace: str = Field(..., max_length=253, description="Namespace to search in")
+    selector: Optional[str] = Field(
+        None, max_length=500, description="Label selector (e.g. 'app=api'); or use pod_name"
+    )
+    pod_name: Optional[str] = Field(
+        None, max_length=253, description="Single pod to search; or use selector"
+    )
+    container: Optional[str] = Field(
+        None, max_length=253, description="Restrict to one container name"
+    )
+    query: str = Field(..., min_length=1, max_length=512, description="Substring or regex")
+    use_regex: bool = Field(default=False, description="Treat query as a regex")
+    case_sensitive: bool = Field(default=False, description="Case-sensitive matching")
+    since: Optional[str] = Field(
+        None, max_length=32, description="Relative window, kubectl duration (e.g. '1h', '30m')"
+    )
+    since_time: Optional[str] = Field(
+        None, max_length=64, description="Absolute lower bound (RFC3339)"
+    )
+    tail_lines: int = Field(
+        default=2000, ge=1, le=10000, description="Max log lines fetched per container"
+    )
+    previous: bool = Field(
+        default=False, description="Search the previous (pre-restart) container logs"
+    )
+    context_lines: int = Field(
+        default=0, ge=0, le=10, description="Context lines kept around each match"
+    )
+    timeout_seconds: Optional[int] = Field(default=60, description="Search timeout", ge=1, le=120)
+    correlation_id: Optional[str] = Field(
+        None, description="Correlation ID for A2A request tracking"
+    )
+
+    @field_validator("namespace", "pod_name", "container")
+    @classmethod
+    def validate_dns_name(cls, v):
+        if v is not None and not _DNS_NAME_PATTERN.match(v):
+            raise ValueError(f"Invalid Kubernetes name '{v}'")
+        return v
+
+    @field_validator("since")
+    @classmethod
+    def validate_since(cls, v):
+        if v is not None and (not v or not _KUBECTL_DURATION_PATTERN.match(v)):
+            raise ValueError(f"Invalid duration '{v}': use kubectl form like '30s', '5m', '1h'")
+        return v
+
+    @field_validator("since_time")
+    @classmethod
+    def validate_since_time(cls, v):
+        if v is not None and not _TIME_PATTERN.match(v):
+            raise ValueError(f"Invalid timestamp '{v}': use RFC3339 (2026-08-16T12:00:00Z)")
+        return v
+
+    @model_validator(mode="after")
+    def validate_target(self):
+        if bool(self.selector) == bool(self.pod_name):
+            raise ValueError("Provide exactly one of 'selector' or 'pod_name'")
+        return self
+
+
+class LokiQueryDirection(str, Enum):
+    """Order of returned log lines."""
+
+    BACKWARD = "backward"  # newest first (default)
+    FORWARD = "forward"
+
+
+class LokiQueryRequest(BaseModel):
+    """Request to run a read-only LogQL range query on a cluster's Loki.
+
+    The query executes on the cluster's executor against its locally
+    configured LOKI_URL — this API never dials Loki itself and never forwards
+    a URL, only the validated query parameters.
+    """
+
+    cluster_id: str = Field(..., description="Target cluster identifier")
+    query: str = Field(..., min_length=1, max_length=2000, description="LogQL expression")
+    start: Optional[str] = Field(
+        None, max_length=64, description="Range start (RFC3339 or unix); Loki defaults to -1h"
+    )
+    end: Optional[str] = Field(
+        None, max_length=64, description="Range end (RFC3339 or unix); Loki defaults to now"
+    )
+    limit: int = Field(
+        default=100, ge=1, le=1000, description="Max log lines (executor clamps further)"
+    )
+    direction: LokiQueryDirection = Field(
+        default=LokiQueryDirection.BACKWARD, description="backward (newest first) or forward"
+    )
+    timeout_seconds: Optional[int] = Field(default=30, description="Query timeout", ge=1, le=60)
+    correlation_id: Optional[str] = Field(
+        None, description="Correlation ID for A2A request tracking"
+    )
+
+    @field_validator("start", "end")
+    @classmethod
+    def validate_timestamp(cls, v):
+        if v is not None and not _TIME_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid timestamp '{v}': use RFC3339 (2026-08-16T12:00:00Z) or unix seconds"
+            )
         return v
 
 
@@ -466,6 +593,9 @@ __all__ = [
     # Request models
     "CreateSessionRequest",
     "ExecuteCommandRequest",
+    "LogSearchRequest",
+    "LokiQueryRequest",
+    "LokiQueryDirection",
     # Response models
     "SessionResponse",
     "CommandResponse",

--- a/kubently/modules/executor/logsearch.py
+++ b/kubently/modules/executor/logsearch.py
@@ -1,0 +1,380 @@
+"""Structured multi-pod log search for the Kubently executor.
+
+`kubectl logs` reads one container at a time and ships everything it prints.
+When the question is "which pods logged X since the deploy?", that means
+either N round trips or flooding the channel with unfiltered logs. This
+runner answers the question where the data lives: it resolves pods from a
+selector, fetches each container's recent logs, filters them locally, and
+returns only the matching lines (with optional context) — so raw logs never
+transit Redis, the API, or the model's context.
+
+Security model:
+
+- Every kubectl invocation goes through the SAME runner the executor uses for
+  ordinary commands (injected as `kubectl_runner`), so the dynamic whitelist
+  and read-only enforcement apply unchanged. Only `get pods` and `logs` are
+  ever composed here.
+- User-supplied values (namespace, selector, container) are passed in
+  `--flag=value` form and the pod name is validated as a DNS name, so a value
+  can never be parsed as an extra kubectl flag.
+- No network access of its own; no shell — argv lists only.
+
+Results are capped at several levels (pods scanned, matches per container,
+total matches, line length, total characters) and every cap that fires is
+announced in the output, so the model always knows when it is looking at a
+partial result.
+
+Deliberately import-light (stdlib only) to match sse_executor.py.
+"""
+
+import json
+import os
+import re
+import time
+
+DEFAULT_MAX_PODS = 20
+DEFAULT_MAX_MATCHES_PER_CONTAINER = 50
+DEFAULT_MAX_TOTAL_MATCHES = 200
+DEFAULT_MAX_LINE_CHARS = 500
+DEFAULT_MAX_OUTPUT_CHARS = 20000
+DEFAULT_TAIL_LINES = 2000
+MAX_TAIL_LINES = 10000
+MAX_QUERY_CHARS = 512
+DEFAULT_TIME_BUDGET_SECONDS = 50
+
+_DNS_NAME = re.compile(r"^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$")
+
+
+def build_matcher(query: str, use_regex: bool = False, case_sensitive: bool = False):
+    """Return a `line -> bool` predicate for the query.
+
+    Raises ValueError for an empty/oversized query or an invalid regex, with a
+    message meant for the model to read and correct.
+    """
+    if not query or not isinstance(query, str):
+        raise ValueError("Missing log search 'query' string.")
+    if len(query) > MAX_QUERY_CHARS:
+        raise ValueError(f"Query too long ({len(query)} chars, max {MAX_QUERY_CHARS}).")
+    if use_regex:
+        try:
+            pattern = re.compile(query, 0 if case_sensitive else re.IGNORECASE)
+        except re.error as e:
+            raise ValueError(f"Invalid regex '{query}': {e}") from e
+        return lambda line: pattern.search(line) is not None
+    if case_sensitive:
+        return lambda line: query in line
+    needle = query.lower()
+    return lambda line: needle in line.lower()
+
+
+def filter_lines(
+    lines: list,
+    matcher,
+    context_lines: int = 0,
+    max_matches: int | None = None,
+    max_line_chars: int = DEFAULT_MAX_LINE_CHARS,
+) -> tuple[list, int, bool]:
+    """Filter lines through `matcher`, keeping `context_lines` around each match.
+
+    Returns (output_lines, total_match_count, capped). `total_match_count` is
+    the number of matches in the input regardless of the cap, so callers can
+    report "showing N of M". Context blocks are merged when they overlap and
+    gaps are marked with "..." so line adjacency is never misrepresented.
+    """
+    match_indices = [i for i, line in enumerate(lines) if matcher(line)]
+    total = len(match_indices)
+    capped = max_matches is not None and total > max_matches
+    if capped:
+        match_indices = match_indices[:max_matches]
+
+    if not match_indices:
+        return [], total, capped
+
+    keep: set[int] = set()
+    for i in match_indices:
+        keep.update(range(max(0, i - context_lines), min(len(lines), i + context_lines + 1)))
+
+    output: list[str] = []
+    previous = None
+    for i in sorted(keep):
+        if previous is not None and i > previous + 1:
+            output.append("...")
+        line = lines[i]
+        if len(line) > max_line_chars:
+            line = line[:max_line_chars] + " [line truncated]"
+        output.append(line)
+        previous = i
+    return output, total, capped
+
+
+def _positive_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+class LogSearchRunner:
+    """Searches logs across the pods matching a selector, using the executor's
+    own (whitelist-enforced) kubectl runner for every fetch."""
+
+    def __init__(
+        self,
+        kubectl_runner,
+        max_pods: int | None = None,
+        max_matches_per_container: int | None = None,
+        max_total_matches: int | None = None,
+        max_line_chars: int | None = None,
+        max_output_chars: int | None = None,
+        time_budget_seconds: int | None = None,
+    ):
+        self._kubectl = kubectl_runner
+        self.max_pods = max_pods or _positive_env("LOG_SEARCH_MAX_PODS", DEFAULT_MAX_PODS)
+        self.max_matches_per_container = max_matches_per_container or _positive_env(
+            "LOG_SEARCH_MAX_MATCHES_PER_CONTAINER", DEFAULT_MAX_MATCHES_PER_CONTAINER
+        )
+        self.max_total_matches = max_total_matches or _positive_env(
+            "LOG_SEARCH_MAX_TOTAL_MATCHES", DEFAULT_MAX_TOTAL_MATCHES
+        )
+        self.max_line_chars = max_line_chars or _positive_env(
+            "LOG_SEARCH_MAX_LINE_CHARS", DEFAULT_MAX_LINE_CHARS
+        )
+        self.max_output_chars = max_output_chars or _positive_env(
+            "LOG_SEARCH_MAX_OUTPUT_CHARS", DEFAULT_MAX_OUTPUT_CHARS
+        )
+        self.time_budget_seconds = time_budget_seconds or _positive_env(
+            "LOG_SEARCH_TIME_BUDGET", DEFAULT_TIME_BUDGET_SECONDS
+        )
+
+    def run(self, request: dict) -> dict:
+        """Run one search request and return the executor result shape:
+        {"success", "output", "error", "status", "return_code"}."""
+        started = time.monotonic()
+
+        namespace = request.get("namespace")
+        if not namespace or not _DNS_NAME.match(str(namespace)):
+            return self._error(f"Invalid or missing namespace: {namespace!r}")
+
+        selector = request.get("selector")
+        pod_name = request.get("pod_name")
+        if bool(selector) == bool(pod_name):
+            return self._error("Provide exactly one of 'selector' or 'pod_name'.")
+        if pod_name and not _DNS_NAME.match(str(pod_name)):
+            return self._error(f"Invalid pod name: {pod_name!r}")
+
+        try:
+            matcher = build_matcher(
+                request.get("query"),
+                use_regex=bool(request.get("use_regex")),
+                case_sensitive=bool(request.get("case_sensitive")),
+            )
+        except ValueError as e:
+            return self._error(str(e))
+
+        targets, notes, error = self._resolve_targets(
+            namespace, selector, pod_name, request.get("container")
+        )
+        if error:
+            return self._error(error)
+        if not targets:
+            where = f"selector '{selector}'" if selector else f"pod '{pod_name}'"
+            return self._success(
+                f"No pods (or matching containers) found for {where} in namespace "
+                f"'{namespace}'. Check the selector with: get pods -n {namespace} --show-labels"
+            )
+
+        tail = min(int(request.get("tail_lines") or DEFAULT_TAIL_LINES), MAX_TAIL_LINES)
+        sections: list[str] = []
+        no_match: list[str] = []
+        errors: list[str] = []
+        total_shown = 0
+        total_matches = 0
+        containers_searched = 0
+
+        for pod, container in targets:
+            if total_shown >= self.max_total_matches:
+                notes.append(
+                    f"total match cap ({self.max_total_matches}) reached — "
+                    f"{len(targets) - containers_searched} container(s) not searched; "
+                    "narrow the query, selector or time window"
+                )
+                break
+            if time.monotonic() - started > self.time_budget_seconds:
+                notes.append(
+                    f"time budget ({self.time_budget_seconds}s) exhausted — "
+                    f"{len(targets) - containers_searched} container(s) not searched; "
+                    "narrow the selector or lower tail_lines"
+                )
+                break
+
+            containers_searched += 1
+            name = f"{pod}/{container}"
+            result = self._kubectl(self._logs_args(request, namespace, pod, container, tail))
+            if not result.get("success"):
+                detail = (result.get("error") or result.get("output") or "").strip()
+                if request.get("previous") and "previous terminated container" in detail:
+                    no_match.append(f"{name} (no previous container)")
+                else:
+                    errors.append(f"{name}: {detail.splitlines()[0] if detail else 'unknown error'}")
+                continue
+
+            lines = (result.get("stdout") or result.get("output") or "").splitlines()
+            kept, matches, capped = filter_lines(
+                lines,
+                matcher,
+                context_lines=min(int(request.get("context_lines") or 0), 10),
+                max_matches=min(
+                    self.max_matches_per_container, self.max_total_matches - total_shown
+                ),
+                max_line_chars=self.max_line_chars,
+            )
+            total_matches += matches
+            if not matches:
+                no_match.append(name)
+                continue
+            shown = min(matches, self.max_matches_per_container,
+                        self.max_total_matches - total_shown)
+            total_shown += shown
+            section = [f"=== {name} ==="] + kept
+            if capped:
+                section.append(
+                    f"[showing {shown} of {matches} matches in this container — "
+                    "narrow the query or time window]"
+                )
+            sections.append("\n".join(section))
+
+        output = self._assemble(
+            request, namespace, selector, pod_name, targets, containers_searched,
+            total_matches, total_shown, sections, no_match, errors, notes, tail,
+        )
+        return self._success(output)
+
+    # -- kubectl composition ------------------------------------------------
+
+    def _resolve_targets(
+        self, namespace: str, selector: str | None, pod_name: str | None, container: str | None
+    ) -> tuple[list, list, str | None]:
+        """Return ([(pod, container), ...], notes, error) for the search scope."""
+        args = ["get", "pods", f"--namespace={namespace}", "-o", "json"]
+        if selector:
+            args.append(f"--selector={selector}")
+        else:
+            args.insert(2, pod_name)
+        result = self._kubectl(args)
+        if not result.get("success"):
+            detail = (result.get("error") or result.get("output") or "").strip()
+            return [], [], f"Could not list pods: {detail.splitlines()[0] if detail else 'unknown error'}"
+
+        try:
+            payload = json.loads(result.get("stdout") or result.get("output") or "")
+        except ValueError:
+            return [], [], "Could not parse pod list (kubectl returned non-JSON)."
+
+        items = payload.get("items") if payload.get("kind") == "PodList" else [payload]
+        items = items or []
+
+        notes: list[str] = []
+        if len(items) > self.max_pods:
+            notes.append(
+                f"selector matched {len(items)} pods; searching the first {self.max_pods} — "
+                "narrow the selector to cover the rest"
+            )
+            items = items[: self.max_pods]
+
+        targets: list[tuple[str, str]] = []
+        for item in items:
+            pod = (item.get("metadata") or {}).get("name")
+            if not pod:
+                continue
+            spec = item.get("spec") or {}
+            containers = [c.get("name") for c in (spec.get("containers") or []) if c.get("name")]
+            containers += [
+                c.get("name") for c in (spec.get("initContainers") or []) if c.get("name")
+            ]
+            for c in containers:
+                if container and c != container:
+                    continue
+                targets.append((pod, c))
+        return targets, notes, None
+
+    @staticmethod
+    def _logs_args(request: dict, namespace: str, pod: str, container: str, tail: int) -> list:
+        args = [
+            "logs",
+            pod,
+            f"--namespace={namespace}",
+            f"--container={container}",
+            f"--tail={tail}",
+            "--timestamps",
+        ]
+        if request.get("since_time"):
+            args.append(f"--since-time={request['since_time']}")
+        elif request.get("since"):
+            args.append(f"--since={request['since']}")
+        if request.get("previous"):
+            args.append("--previous")
+        return args
+
+    # -- output assembly ----------------------------------------------------
+
+    def _assemble(
+        self, request, namespace, selector, pod_name, targets, containers_searched,
+        total_matches, total_shown, sections, no_match, errors, notes, tail,
+    ) -> str:
+        mode = "regex" if request.get("use_regex") else "substring"
+        scope = f"selector '{selector}'" if selector else f"pod '{pod_name}'"
+        window = (
+            f"since {request['since_time']}" if request.get("since_time")
+            else f"last {request['since']}" if request.get("since")
+            else f"tail {tail} lines/container"
+        )
+        which = "previous (pre-restart) logs" if request.get("previous") else "current logs"
+        header = (
+            f"Searched {containers_searched} of {len(targets)} container(s) for {scope} in "
+            f"namespace '{namespace}' ({mode} \"{request.get('query')}\", {window}, {which}): "
+            f"{total_matches} matching line(s)"
+        )
+        header += f", {total_shown} shown." if total_shown < total_matches else "."
+
+        parts = [header]
+        parts.extend(sections)
+        if no_match:
+            parts.append("No matches: " + ", ".join(no_match))
+        if errors:
+            parts.append("Errors:\n" + "\n".join(f"  {e}" for e in errors))
+        for note in notes:
+            parts.append(f"[{note}]")
+        if not sections and not errors:
+            parts.append(
+                "Hint: try a broader query, use_regex for alternatives (e.g. "
+                "'error|exception|fail'), a longer since window, or previous=true "
+                "for restarted containers."
+            )
+
+        output = "\n\n".join(parts)
+        if len(output) > self.max_output_chars:
+            output = output[: self.max_output_chars] + (
+                f"\n[truncated at {self.max_output_chars} chars — narrow the query, "
+                "selector or time window]"
+            )
+        return output
+
+    @staticmethod
+    def _success(output: str) -> dict:
+        return {
+            "success": True,
+            "output": output,
+            "error": None,
+            "status": "SUCCESS",
+            "return_code": 0,
+        }
+
+    @staticmethod
+    def _error(message: str, status: str = "FAILED") -> dict:
+        return {
+            "success": False,
+            "output": None,
+            "error": message,
+            "status": status,
+            "return_code": -1,
+        }

--- a/kubently/modules/executor/loki.py
+++ b/kubently/modules/executor/loki.py
@@ -1,0 +1,233 @@
+"""Read-only Loki (LogQL) query runner for the Kubently executor.
+
+Loki queries ride the same outbound channel as kubectl commands: API -> Redis
+pub/sub -> executor SSE -> result POST. This module is the executor-side
+terminus of that path, mirroring the Prometheus runner's security model:
+
+- The base URL comes ONLY from local executor configuration (LOKI_URL). The
+  control plane never supplies a URL, so a compromised API key cannot turn the
+  executor into an SSRF proxy.
+- Exactly one fixed, read-only HTTP API path is reachable:
+  /loki/api/v1/query_range. GET only. Nothing else is constructible from a
+  request.
+- When LOKI_URL is unset the runner reports "unavailable" without making any
+  network call.
+
+Results are capped (line count via the clamped `limit` parameter, per-line
+characters, total output characters) before they leave the executor, and every
+truncation is announced in the output the model reads.
+
+Deliberately import-light (stdlib + requests) to match sse_executor.py.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import requests
+
+logger = logging.getLogger("kubently-loki")
+
+QUERY_RANGE_PATH = "/loki/api/v1/query_range"
+
+DEFAULT_TIMEOUT_SECONDS = 30
+DEFAULT_LIMIT = 100
+DEFAULT_MAX_LINES = 500
+DEFAULT_MAX_LINE_CHARS = 500
+DEFAULT_MAX_OUTPUT_CHARS = 20000
+
+UNAVAILABLE_MESSAGE = (
+    "Loki is not configured on this cluster's executor (LOKI_URL is unset). "
+    "Aggregated log search is unavailable here; use search_pod_logs or kubectl "
+    "logs instead."
+)
+
+
+def format_loki_timestamp(ns_timestamp: str) -> str:
+    """Render Loki's nanosecond-epoch string as RFC3339 (falls back to raw)."""
+    try:
+        seconds = int(ns_timestamp) / 1_000_000_000
+        return (
+            datetime.fromtimestamp(seconds, tz=timezone.utc)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
+    except (ValueError, TypeError, OSError, OverflowError):
+        return str(ns_timestamp)
+
+
+def format_streams(
+    result: list,
+    max_lines: int,
+    max_line_chars: int,
+) -> tuple[str, list]:
+    """Flatten Loki streams into per-stream sections of timestamped lines.
+
+    Lines within each stream keep Loki's returned order; caps are applied
+    across all streams with a note when they fire. Returns (text, notes).
+    """
+    notes = []
+    total_lines = sum(len(s.get("values") or []) for s in result)
+    shown = 0
+    sections = []
+    for stream in result:
+        if shown >= max_lines:
+            break
+        labels = stream.get("stream") or {}
+        label_str = ", ".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
+        lines = []
+        for ts, line in stream.get("values") or []:
+            if shown >= max_lines:
+                break
+            if len(line) > max_line_chars:
+                line = line[:max_line_chars] + " [line truncated]"
+            lines.append(f"{format_loki_timestamp(ts)} {line}")
+            shown += 1
+        if lines:
+            sections.append(f"=== {{{label_str}}} ===\n" + "\n".join(lines))
+    if shown < total_lines:
+        notes.append(
+            f"showing {shown} of {total_lines} log lines — narrow the LogQL "
+            "selector, add a line filter (|= / |~), or shrink the time range"
+        )
+    return "\n\n".join(sections), notes
+
+
+class LokiRunner:
+    """Executes validated LogQL range queries against a locally configured Loki
+    and returns results in the executor's standard result shape."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        tenant_id: str | None = None,
+        timeout: int | None = None,
+        max_lines: int | None = None,
+        max_line_chars: int | None = None,
+        max_output_chars: int | None = None,
+    ):
+        self.base_url = (
+            base_url if base_url is not None else os.environ.get("LOKI_URL", "")
+        ).strip().rstrip("/")
+        self.tenant_id = (
+            tenant_id if tenant_id is not None else os.environ.get("LOKI_TENANT_ID", "")
+        ).strip()
+        self.timeout = timeout or int(
+            os.environ.get("LOKI_TIMEOUT", str(DEFAULT_TIMEOUT_SECONDS))
+        )
+        self.max_lines = max_lines or int(
+            os.environ.get("LOKI_MAX_LINES", str(DEFAULT_MAX_LINES))
+        )
+        self.max_line_chars = max_line_chars or int(
+            os.environ.get("LOKI_MAX_LINE_CHARS", str(DEFAULT_MAX_LINE_CHARS))
+        )
+        self.max_output_chars = max_output_chars or int(
+            os.environ.get("LOKI_MAX_OUTPUT_CHARS", str(DEFAULT_MAX_OUTPUT_CHARS))
+        )
+
+    @property
+    def available(self) -> bool:
+        return bool(self.base_url)
+
+    def run(self, request: dict) -> dict:
+        """Run one LogQL range query and return the executor result shape:
+        {"success", "output", "error", "status", "return_code"}."""
+        if not self.available:
+            return self._error(UNAVAILABLE_MESSAGE, status="UNAVAILABLE")
+
+        query = request.get("query")
+        if not query or not isinstance(query, str):
+            return self._error("Missing LogQL 'query' string.")
+
+        limit = min(int(request.get("limit") or DEFAULT_LIMIT), self.max_lines)
+        direction = request.get("direction") or "backward"
+        if direction not in ("backward", "forward"):
+            return self._error(
+                f"Invalid direction '{direction}': use 'backward' (newest first) "
+                "or 'forward'."
+            )
+
+        params = {"query": query, "limit": limit, "direction": direction}
+        # Loki defaults to the last hour when start/end are omitted.
+        for key in ("start", "end"):
+            if request.get(key):
+                params[key] = str(request[key])
+
+        headers = {}
+        if self.tenant_id:
+            headers["X-Scope-OrgID"] = self.tenant_id
+
+        try:
+            response = requests.get(
+                f"{self.base_url}{QUERY_RANGE_PATH}",
+                params=params,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except requests.exceptions.Timeout:
+            return self._error(
+                f"Loki query timed out after {self.timeout}s. Narrow the query "
+                "(shorter range, tighter label selector, lower limit).",
+                status="TIMEOUT",
+            )
+        except requests.exceptions.RequestException as e:
+            return self._error(f"Could not reach Loki at {self.base_url}: {e}")
+
+        try:
+            body = response.json()
+        except ValueError:
+            return self._error(
+                f"Loki returned non-JSON (HTTP {response.status_code}): "
+                f"{response.text[:200]}"
+            )
+
+        if response.status_code != 200 or body.get("status") != "success":
+            detail = body.get("error") or body.get("message") or f"HTTP {response.status_code}"
+            return self._error(f"Loki query failed: {detail}")
+
+        output = self._format_capped(body.get("data") or {})
+        return {
+            "success": True,
+            "output": output,
+            "error": None,
+            "status": "SUCCESS",
+            "return_code": 0,
+        }
+
+    def _format_capped(self, data: dict) -> str:
+        result_type = data.get("resultType")
+        result = data.get("result") or []
+
+        if result_type == "streams":
+            text, notes = format_streams(result, self.max_lines, self.max_line_chars)
+            if not text:
+                text = (
+                    "No log lines matched. Widen the time range, loosen the label "
+                    "selector, or drop/adjust line filters."
+                )
+            for note in notes:
+                text += f"\n[{note}]"
+        else:
+            # Metric-style LogQL (rate/count_over_time/...) returns matrix or
+            # vector data; pass it through compactly.
+            text = json.dumps(
+                {"resultType": result_type, "result": result}, separators=(",", ":")
+            )
+
+        if len(text) > self.max_output_chars:
+            text = text[: self.max_output_chars] + (
+                f"\n[truncated at {self.max_output_chars} chars — narrow the query "
+                "or lower the limit]"
+            )
+        return text
+
+    @staticmethod
+    def _error(message: str, status: str = "FAILED") -> dict:
+        return {
+            "success": False,
+            "output": None,
+            "error": message,
+            "status": status,
+            "return_code": -1,
+        }

--- a/kubently/modules/executor/sse_executor.py
+++ b/kubently/modules/executor/sse_executor.py
@@ -37,6 +37,9 @@ try:
 except ImportError:
     WHITELIST_AVAILABLE = False
 
+from kubently.modules.executor.logsearch import LogSearchRunner
+from kubently.modules.executor.loki import LokiRunner
+
 # Configure logging
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO"),
@@ -90,6 +93,17 @@ class SSEKubentlyExecutor:
             logger.warning("⚠️  Using HTTP without TLS - this should only be used for local development!")
         elif self.api_url.startswith("https://"):
             logger.info("✅ Using HTTPS with TLS encryption")
+
+        # Log search runs through the same kubectl runner as ordinary commands,
+        # so the whitelist and read-only enforcement apply unchanged.
+        self._logsearch = LogSearchRunner(kubectl_runner=self._run_kubectl)
+
+        # Optional Loki query runner. Configured entirely from local env
+        # (LOKI_URL etc.) — the control plane never supplies a URL. When
+        # unset, loki commands get a clear "unavailable" error back.
+        self._loki = LokiRunner()
+        if self._loki.available:
+            logger.info(f"Loki log search enabled: {self._loki.base_url}")
 
         # Command queue for processing
         self.command_queue = Queue()
@@ -215,8 +229,9 @@ class SSEKubentlyExecutor:
 
         start_time = time.time()
 
-        # Execute kubectl command
-        result = self._run_kubectl(command.get("args", []))
+        # Dispatch on the command's tool. kubectl is the default so command
+        # envelopes from older API versions (no "tool" field) keep working.
+        result = self._run_tool(command)
 
         # Add execution metadata
         result["command_id"] = command_id
@@ -241,6 +256,33 @@ class SSEKubentlyExecutor:
 
         except Exception as e:
             logger.error(f"Failed to submit result for {command_id}: {e}")
+
+    def _run_tool(self, command: dict) -> dict:
+        """
+        Route a command envelope to its tool runner.
+
+        Each tool enforces its own allowlist locally: kubectl commands go
+        through the DynamicCommandWhitelist, log searches compose only
+        whitelist-checked `get pods` / `logs` invocations, and loki queries
+        are limited to one read-only GET path against the locally configured
+        base URL.
+        """
+        tool = command.get("tool", "kubectl")
+
+        if tool == "kubectl":
+            return self._run_kubectl(command.get("args", []))
+        if tool == "log_search":
+            return self._logsearch.run(command.get("request") or {})
+        if tool == "loki":
+            return self._loki.run(command.get("request") or {})
+
+        logger.warning(f"Rejected command with unknown tool: {tool}")
+        return {
+            "success": False,
+            "error": f"Unknown tool '{tool}'. This executor supports: kubectl, log_search, loki.",
+            "status": "BLOCKED",
+            "return_code": -1,
+        }
 
     def _run_kubectl(self, args: list[str]) -> dict:
         """

--- a/prompts/system.prompt.yaml
+++ b/prompts/system.prompt.yaml
@@ -1,10 +1,16 @@
-version: 3
+version: 4
 name: kubently_thorough_investigation
 role: system
 metadata:
   owner: kubently
   description: System prompt for thorough Kubernetes debugging with enhanced investigation patterns
-variables: []
+variables:
+  # Injected by the agent ONLY when the query_loki tool is registered
+  # (LOKI_URL set); defaults to empty so unconfigured deployments never
+  # reference a Loki tool the model cannot call.
+  - name: loki_guidance
+    required: false
+    default: ""
 content: |-
   # Kubently System Prompt
 
@@ -339,6 +345,7 @@ content: |-
 
   - execute_kubectl: Run kubectl commands for investigation and fixes
   - execute_kubectl_multi: Run one read-only kubectl command across many clusters in parallel (fleet queries)
+  - search_pod_logs: Search logs across all pods matching a selector (filtered on the cluster, only matching lines return)
   - list_clusters: Get available Kubernetes clusters
   - write_todos: Manage debugging workflow tasks to track systematic investigation progress
 
@@ -359,6 +366,23 @@ content: |-
   - Fleet results are a triage view: per-cluster output is truncated. Drill into a specific cluster with execute_kubectl when you need detail.
   - Keep fleet commands filtered and token-efficient (e.g. `-o wide`, `-o custom-columns`, `-l <selector>`); never dump unfiltered resources from every cluster. Do NOT use `--field-selector status.phase!=Running` for fleet health sweeps — CrashLoopBackOff pods have `phase=Running`, so a whole cluster can look healthy while pods crash on a loop.
   - For single-cluster questions keep using execute_kubectl.
+
+  ## Log Search
+
+  Use search_pod_logs to grep across MANY pods/containers in one call instead of dumping full logs pod-by-pod. Reach for it when:
+  - Errors appear after a deploy: search the workload's pods for `error|exception|panic` (use_regex=True) since the rollout time.
+  - Correlating restarts: set previous=True to read the pre-restart logs of every restarted replica at once — the crash reason is usually in the previous container, not the current one.
+  - Tracing an upstream failure: search the CALLING service's pods for the failing dependency's name, "timeout", or "connection refused" to see who is affected and how.
+  - Finding which replica is the outlier: the per-container sections show at a glance which pods log the error and which don't.
+
+  NARROW BEFORE SEARCHING:
+  - Identify the namespace and a label selector first (`get pods -n <ns> --show-labels`); never search without a selector or with an unbounded time window.
+  - Keep the default since="1h" (or tighter around the incident); use since_time for an exact deploy timestamp.
+  - Start with a specific query (the actual error text) before falling back to broad regexes.
+  - Results are capped at every level and truncation is always noted — when a cap fires, narrow the query/selector/window rather than re-running the same search.
+  - For ONE known pod where you just want recent context (not a search), plain `logs <pod> --tail=50` via execute_kubectl is still the cheaper call.
+
+  {{loki_guidance}}
 
   # Code References
 

--- a/tests/test_log_search_executor.py
+++ b/tests/test_log_search_executor.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""
+Tests for the executor-side multi-pod log search runner.
+
+The runner composes ONLY whitelist-checked `get pods` / `logs` invocations
+through the injected kubectl runner, filters logs locally so raw logs never
+leave the executor, caps output at every level, and announces every cap that
+fires in the output the model reads.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.executor.logsearch import (
+    LogSearchRunner,
+    build_matcher,
+    filter_lines,
+)
+from kubently.modules.executor.sse_executor import SSEKubentlyExecutor
+
+
+# -- matcher building --------------------------------------------------------
+
+
+def test_substring_matcher_is_case_insensitive_by_default():
+    m = build_matcher("Connection Refused")
+    assert m("dial tcp: CONNECTION REFUSED")
+    assert m("connection refused by peer")
+    assert not m("connection accepted")
+
+
+def test_substring_matcher_case_sensitive():
+    m = build_matcher("Error", case_sensitive=True)
+    assert m("Error: boom")
+    assert not m("error: boom")
+
+
+def test_regex_matcher_alternation():
+    m = build_matcher("error|exception|timed? ?out", use_regex=True)
+    assert m("java.lang.NullPointerException")
+    assert m("request timed out")
+    assert m("TIMEOUT waiting for upstream")
+    assert not m("all good")
+
+
+def test_invalid_regex_raises_readable_error():
+    with pytest.raises(ValueError, match="Invalid regex"):
+        build_matcher("([unclosed", use_regex=True)
+
+
+def test_empty_and_oversized_queries_rejected():
+    with pytest.raises(ValueError):
+        build_matcher("")
+    with pytest.raises(ValueError, match="too long"):
+        build_matcher("x" * 1000)
+
+
+# -- line filtering / caps ---------------------------------------------------
+
+
+def test_filter_reports_total_matches_beyond_cap():
+    lines = [f"error {i}" for i in range(20)]
+    kept, total, capped = filter_lines(lines, build_matcher("error"), max_matches=5)
+    assert total == 20
+    assert capped is True
+    assert len(kept) == 5
+
+
+def test_filter_context_merges_overlaps_and_marks_gaps():
+    lines = ["a", "b", "ERROR one", "c", "ERROR two", "d", "e", "f", "g", "ERROR three"]
+    kept, total, capped = filter_lines(lines, build_matcher("error"), context_lines=1)
+    assert total == 3
+    assert capped is False
+    # First two matches' context windows overlap (b..d contiguous); the third
+    # is separated by a "..." gap marker.
+    assert kept == ["b", "ERROR one", "c", "ERROR two", "d", "...", "g", "ERROR three"]
+
+
+def test_filter_truncates_long_lines():
+    lines = ["error " + "x" * 1000]
+    kept, _, _ = filter_lines(lines, build_matcher("error"), max_line_chars=50)
+    assert len(kept) == 1
+    assert kept[0].endswith("[line truncated]")
+    assert len(kept[0]) < 100
+
+
+def test_filter_no_matches():
+    kept, total, capped = filter_lines(["a", "b"], build_matcher("zzz"))
+    assert (kept, total, capped) == ([], 0, False)
+
+
+# -- runner end-to-end with a fake kubectl -----------------------------------
+
+
+def pod_list(*pods):
+    items = []
+    for name, containers in pods:
+        items.append(
+            {
+                "metadata": {"name": name},
+                "spec": {"containers": [{"name": c} for c in containers]},
+            }
+        )
+    return {"kind": "PodList", "items": items}
+
+
+class FakeKubectl:
+    """Records every argv list and returns canned pod-list/logs responses."""
+
+    def __init__(self, pods, logs_by_target=None, logs_error=None):
+        self.pods = pods
+        self.logs_by_target = logs_by_target or {}
+        self.logs_error = logs_error
+        self.calls = []
+
+    def __call__(self, args):
+        self.calls.append(args)
+        if args[0] == "get":
+            return {"success": True, "stdout": json.dumps(self.pods), "output": ""}
+        assert args[0] == "logs", f"unexpected kubectl verb: {args[0]}"
+        pod = args[1]
+        container = next(a.split("=", 1)[1] for a in args if a.startswith("--container="))
+        if self.logs_error:
+            return {"success": False, "error": self.logs_error, "output": None}
+        text = self.logs_by_target.get((pod, container), "")
+        return {"success": True, "stdout": text, "output": text}
+
+
+def run_search(kubectl, request=None, **runner_kwargs):
+    runner = LogSearchRunner(kubectl_runner=kubectl, **runner_kwargs)
+    base = {"namespace": "payments", "selector": "app=api", "query": "error"}
+    base.update(request or {})
+    return runner.run(base)
+
+
+def test_search_finds_matches_across_pods_and_containers():
+    kubectl = FakeKubectl(
+        pod_list(("api-1", ["app", "sidecar"]), ("api-2", ["app"])),
+        logs_by_target={
+            ("api-1", "app"): "ok\nerror: db down\nok",
+            ("api-1", "sidecar"): "all fine",
+            ("api-2", "app"): "ERROR: db down again",
+        },
+    )
+    result = run_search(kubectl)
+    assert result["success"] is True
+    out = result["output"]
+    assert "=== api-1/app ===" in out
+    assert "error: db down" in out
+    assert "=== api-2/app ===" in out
+    assert "2 matching line(s)" in out
+    assert "No matches: api-1/sidecar" in out
+
+
+def test_search_composes_only_get_and_logs_with_flag_equals_form():
+    kubectl = FakeKubectl(pod_list(("api-1", ["app"])), logs_by_target={})
+    run_search(
+        kubectl,
+        {"since": "30m", "previous": True, "tail_lines": 100, "container": "app"},
+    )
+    verbs = {c[0] for c in kubectl.calls}
+    assert verbs == {"get", "logs"}
+    logs_call = next(c for c in kubectl.calls if c[0] == "logs")
+    assert "--namespace=payments" in logs_call
+    assert "--container=app" in logs_call
+    assert "--tail=100" in logs_call
+    assert "--since=30m" in logs_call
+    assert "--previous" in logs_call
+    assert "--timestamps" in logs_call
+    get_call = next(c for c in kubectl.calls if c[0] == "get")
+    assert "--selector=app=api" in get_call
+
+
+def test_since_time_takes_precedence_over_since():
+    kubectl = FakeKubectl(pod_list(("api-1", ["app"])))
+    run_search(kubectl, {"since": "1h", "since_time": "2026-08-17T00:00:00Z"})
+    logs_call = next(c for c in kubectl.calls if c[0] == "logs")
+    assert "--since-time=2026-08-17T00:00:00Z" in logs_call
+    assert not any(a.startswith("--since=") for a in logs_call)
+
+
+def test_pod_name_mode_fetches_single_pod():
+    single = {"kind": "Pod", "metadata": {"name": "api-1"},
+              "spec": {"containers": [{"name": "app"}]}}
+    kubectl = FakeKubectl(single, logs_by_target={("api-1", "app"): "an error here"})
+    result = run_search(kubectl, {"selector": None, "pod_name": "api-1"})
+    assert result["success"] is True
+    assert "api-1/app" in result["output"]
+    get_call = next(c for c in kubectl.calls if c[0] == "get")
+    assert get_call[2] == "api-1"
+
+
+def test_requires_exactly_one_of_selector_and_pod_name():
+    kubectl = FakeKubectl(pod_list())
+    both = run_search(kubectl, {"pod_name": "api-1"})
+    neither = run_search(kubectl, {"selector": None})
+    assert both["success"] is False and "exactly one" in both["error"]
+    assert neither["success"] is False and "exactly one" in neither["error"]
+    assert kubectl.calls == []  # rejected before any kubectl call
+
+
+def test_invalid_namespace_and_pod_name_rejected_before_kubectl():
+    kubectl = FakeKubectl(pod_list())
+    bad_ns = run_search(kubectl, {"namespace": "-oops"})
+    assert bad_ns["success"] is False and "namespace" in bad_ns["error"]
+    bad_pod = run_search(kubectl, {"selector": None, "pod_name": "--previous"})
+    assert bad_pod["success"] is False and "pod name" in bad_pod["error"]
+    assert kubectl.calls == []
+
+
+def test_invalid_regex_surfaces_as_error():
+    kubectl = FakeKubectl(pod_list(("api-1", ["app"])))
+    result = run_search(kubectl, {"query": "([", "use_regex": True})
+    assert result["success"] is False
+    assert "Invalid regex" in result["error"]
+
+
+def test_no_pods_matched_is_success_with_hint():
+    kubectl = FakeKubectl(pod_list())
+    result = run_search(kubectl)
+    assert result["success"] is True
+    assert "No pods" in result["output"]
+    assert "--show-labels" in result["output"]
+
+
+def test_pod_cap_limits_scan_and_notes():
+    pods = pod_list(*[(f"api-{i}", ["app"]) for i in range(6)])
+    kubectl = FakeKubectl(pods, logs_by_target={(f"api-{i}", "app"): "no hits" for i in range(6)})
+    result = run_search(kubectl, max_pods=3)
+    assert "matched 6 pods" in result["output"]
+    assert "first 3" in result["output"]
+    assert len([c for c in kubectl.calls if c[0] == "logs"]) == 3
+
+
+def test_per_container_match_cap_notes_shown_vs_total():
+    logs = "\n".join(f"error {i}" for i in range(30))
+    kubectl = FakeKubectl(pod_list(("api-1", ["app"])), logs_by_target={("api-1", "app"): logs})
+    result = run_search(kubectl, max_matches_per_container=5)
+    assert "showing 5 of 30 matches" in result["output"]
+
+
+def test_total_match_cap_stops_scanning_and_notes():
+    logs = "\n".join(f"error {i}" for i in range(10))
+    pods = pod_list(("api-1", ["app"]), ("api-2", ["app"]), ("api-3", ["app"]))
+    kubectl = FakeKubectl(pods, logs_by_target={(f"api-{i}", "app"): logs for i in (1, 2, 3)})
+    result = run_search(kubectl, max_total_matches=10)
+    out = result["output"]
+    assert "total match cap (10) reached" in out
+    # third container never fetched
+    assert len([c for c in kubectl.calls if c[0] == "logs"]) < 3
+
+
+def test_output_char_cap_is_final_backstop():
+    logs = "\n".join(f"error {'x' * 80} {i}" for i in range(50))
+    kubectl = FakeKubectl(pod_list(("api-1", ["app"])), logs_by_target={("api-1", "app"): logs})
+    result = run_search(kubectl, max_output_chars=800)
+    assert len(result["output"]) < 1000
+    assert "truncated at 800 chars" in result["output"]
+
+
+def test_previous_without_prior_container_is_not_fatal():
+    kubectl = FakeKubectl(
+        pod_list(("api-1", ["app"])),
+        logs_error='previous terminated container "app" in pod "api-1" not found',
+    )
+    result = run_search(kubectl, {"previous": True})
+    assert result["success"] is True
+    assert "no previous container" in result["output"]
+
+
+def test_kubectl_error_reported_per_container_not_fatal():
+    kubectl = FakeKubectl(pod_list(("api-1", ["app"])), logs_error="Blocked by whitelist: nope")
+    result = run_search(kubectl)
+    assert result["success"] is True
+    assert "Errors:" in result["output"]
+    assert "Blocked by whitelist" in result["output"]
+
+
+def test_zero_matches_gives_hint():
+    kubectl = FakeKubectl(pod_list(("api-1", ["app"])), logs_by_target={("api-1", "app"): "quiet"})
+    result = run_search(kubectl)
+    assert "0 matching line(s)" in result["output"]
+    assert "previous=true" in result["output"]
+
+
+# -- executor dispatch -------------------------------------------------------
+
+
+@pytest.fixture
+def executor(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_API_URL", "http://localhost:8080")
+    monkeypatch.setenv("CLUSTER_ID", "test-cluster")
+    monkeypatch.setenv("KUBENTLY_TOKEN", "test-token")
+    monkeypatch.setenv("KUBENTLY_WHITELIST_CONFIG", "/nonexistent/whitelist.yaml")
+    monkeypatch.delenv("LOKI_URL", raising=False)
+    return SSEKubentlyExecutor()
+
+
+def test_dispatch_default_tool_is_kubectl(executor, monkeypatch):
+    monkeypatch.setattr(executor, "_run_kubectl", lambda args: {"success": True, "output": "ok"})
+    result = executor._run_tool({"args": ["get", "pods"]})
+    assert result["output"] == "ok"
+
+
+def test_dispatch_routes_log_search_through_kubectl_runner(executor, monkeypatch):
+    monkeypatch.setattr(
+        executor,
+        "_run_kubectl",
+        lambda args: {"success": True, "stdout": json.dumps(pod_list()), "output": ""},
+    )
+    # Re-wire the runner's injected kubectl to the patched method
+    executor._logsearch._kubectl = executor._run_kubectl
+    result = executor._run_tool(
+        {
+            "tool": "log_search",
+            "request": {"namespace": "default", "selector": "app=x", "query": "error"},
+        }
+    )
+    assert result["success"] is True
+    assert "No pods" in result["output"]
+
+
+def test_dispatch_routes_loki_tool(executor):
+    # No LOKI_URL set -> the runner answers "unavailable", proving the
+    # envelope reached the loki runner and not kubectl.
+    result = executor._run_tool({"tool": "loki", "request": {"query": "{app=\"x\"}"}})
+    assert result["status"] == "UNAVAILABLE"
+
+
+def test_dispatch_rejects_unknown_tool(executor):
+    result = executor._run_tool({"tool": "curl", "request": {}})
+    assert result["success"] is False
+    assert result["status"] == "BLOCKED"

--- a/tests/test_log_search_models.py
+++ b/tests/test_log_search_models.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Validation tests for the log-search and Loki API request models.
+
+These models are the API-side gate for values that end up as kubectl argv
+entries (in --flag=value form) or Loki query parameters on the executor.
+"""
+
+import os
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.api.models import LogSearchRequest, LokiQueryRequest
+
+
+def make_search(**overrides):
+    base = {
+        "cluster_id": "kind",
+        "namespace": "payments",
+        "selector": "app=api",
+        "query": "error",
+    }
+    base.update(overrides)
+    return LogSearchRequest(**base)
+
+
+# LogSearchRequest
+
+
+def test_minimal_selector_request_valid_with_defaults():
+    req = make_search()
+    assert req.use_regex is False
+    assert req.tail_lines == 2000
+    assert req.previous is False
+    assert req.timeout_seconds == 60
+
+
+def test_pod_name_mode_valid():
+    req = make_search(selector=None, pod_name="api-7f9b5")
+    assert req.pod_name == "api-7f9b5"
+
+
+def test_selector_and_pod_name_mutually_exclusive():
+    with pytest.raises(ValidationError, match="exactly one"):
+        make_search(pod_name="api-1")
+    with pytest.raises(ValidationError, match="exactly one"):
+        make_search(selector=None)
+
+
+@pytest.mark.parametrize("field", ["namespace", "pod_name", "container"])
+def test_names_must_be_dns_safe(field):
+    """A leading dash could otherwise be parsed as a kubectl flag."""
+    overrides = {field: "--previous"}
+    if field == "pod_name":
+        overrides["selector"] = None
+    with pytest.raises(ValidationError, match="Invalid Kubernetes name"):
+        make_search(**overrides)
+
+
+@pytest.mark.parametrize("since", ["1h", "30m", "45s", "1h30m"])
+def test_valid_since_durations(since):
+    assert make_search(since=since).since == since
+
+
+@pytest.mark.parametrize("since", ["1 hour", "-1h", "1d", "90"])
+def test_invalid_since_durations(since):
+    with pytest.raises(ValidationError, match="Invalid duration"):
+        make_search(since=since)
+
+
+def test_since_time_accepts_rfc3339_rejects_garbage():
+    assert make_search(since_time="2026-08-17T00:00:00Z").since_time
+    with pytest.raises(ValidationError, match="Invalid timestamp"):
+        make_search(since_time="yesterday")
+
+
+def test_query_and_tail_bounds():
+    with pytest.raises(ValidationError):
+        make_search(query="")
+    with pytest.raises(ValidationError):
+        make_search(query="x" * 600)
+    with pytest.raises(ValidationError):
+        make_search(tail_lines=100000)
+    with pytest.raises(ValidationError):
+        make_search(context_lines=50)
+
+
+# LokiQueryRequest
+
+
+def make_loki(**overrides):
+    base = {"cluster_id": "kind", "query": '{app="api"} |= "error"'}
+    base.update(overrides)
+    return LokiQueryRequest(**base)
+
+
+def test_minimal_loki_request_defaults():
+    req = make_loki()
+    assert req.limit == 100
+    assert req.direction.value == "backward"
+    assert req.start is None and req.end is None
+
+
+def test_loki_timestamps_validated():
+    assert make_loki(start="1700000000", end="2026-08-17T00:00:00Z")
+    with pytest.raises(ValidationError, match="Invalid timestamp"):
+        make_loki(start="last tuesday")
+
+
+def test_loki_limit_and_direction_bounds():
+    with pytest.raises(ValidationError):
+        make_loki(limit=0)
+    with pytest.raises(ValidationError):
+        make_loki(limit=100000)
+    with pytest.raises(ValidationError):
+        make_loki(direction="sideways")
+
+
+def test_loki_query_size_bounds():
+    with pytest.raises(ValidationError):
+        make_loki(query="")
+    with pytest.raises(ValidationError):
+        make_loki(query="x" * 3000)

--- a/tests/test_log_search_tool.py
+++ b/tests/test_log_search_tool.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Tests for the agent-side log-search tool plumbing.
+
+Two availability contracts are the point here:
+- search_pod_logs is always available (kubectl is all it needs), so its
+  guidance lives statically in the externalized prompt YAML.
+- query_loki exists ONLY when LOKI_URL is set, and the prompt's Loki guidance
+  is injected through the {{loki_guidance}} variable on the same switch — the
+  model must never be told about a tool it cannot call.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.a2a.protocol_bindings.a2a_server.logsearch import (
+    LOKI_PROMPT_SECTION,
+    build_log_search_payload,
+    build_loki_payload,
+    loki_guidance,
+    loki_tool_enabled,
+)
+from kubently.modules.config import get_prompt
+
+REPO = os.path.join(os.path.dirname(__file__), "..")
+ROOT_PROMPT = os.path.join(REPO, "prompts", "system.prompt.yaml")
+CHART_PROMPT = os.path.join(
+    REPO, "deployment", "helm", "kubently", "prompts", "system.prompt.yaml"
+)
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+# Availability gating (Loki)
+
+
+def test_loki_disabled_when_env_unset_or_blank(monkeypatch):
+    monkeypatch.delenv("LOKI_URL", raising=False)
+    assert loki_tool_enabled() is False
+    assert loki_guidance() == ""
+
+    monkeypatch.setenv("LOKI_URL", "   ")
+    assert loki_tool_enabled() is False
+    assert loki_guidance() == ""
+
+
+def test_loki_enabled_when_env_set(monkeypatch):
+    monkeypatch.setenv("LOKI_URL", "http://loki:3100")
+    assert loki_tool_enabled() is True
+    assert loki_guidance() == LOKI_PROMPT_SECTION
+
+
+# Payload building
+
+
+def test_build_log_search_payload_defaults():
+    payload = build_log_search_payload("payments", "error", selector="app=api")
+    assert payload["namespace"] == "payments"
+    assert payload["selector"] == "app=api"
+    assert payload["pod_name"] is None
+    assert payload["since"] == "1h"  # bounded by default
+    assert payload["previous"] is False
+
+
+def test_build_log_search_payload_previous_and_regex():
+    payload = build_log_search_payload(
+        "payments",
+        "error|panic",
+        pod_name="api-1",
+        use_regex=True,
+        previous=True,
+        context_lines=3,
+        since=None,
+        since_time="2026-08-17T00:00:00Z",
+    )
+    assert payload["use_regex"] is True
+    assert payload["previous"] is True
+    assert payload["context_lines"] == 3
+    assert payload["since"] is None
+    assert payload["since_time"] == "2026-08-17T00:00:00Z"
+
+
+def test_build_loki_payload():
+    payload = build_loki_payload('{app="x"} |= "error"', start="1700000000", limit=50)
+    assert payload["query"] == '{app="x"} |= "error"'
+    assert payload["start"] == "1700000000"
+    assert payload["limit"] == 50
+    assert payload["direction"] == "backward"
+
+
+# Prompt: static log-search guidance + Loki injection hook
+
+
+def test_prompt_files_carry_log_search_guidance_and_loki_hook():
+    for path in (ROOT_PROMPT, CHART_PROMPT):
+        content = _read(path)
+        assert "search_pod_logs" in content, f"{path} lost the log-search guidance"
+        assert "{{loki_guidance}}" in content, f"{path} lost the loki hook"
+
+
+def test_prompt_copies_are_identical():
+    assert _read(ROOT_PROMPT) == _read(CHART_PROMPT)
+
+
+def test_prompt_renders_loki_section_when_enabled(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_A2A_PROMPT_FILE", ROOT_PROMPT)
+    monkeypatch.setenv("LOKI_URL", "http://loki:3100")
+    prompt = get_prompt(role="a2a", variables={"loki_guidance": loki_guidance()})
+    assert "query_loki" in prompt
+    assert "LogQL" in prompt
+    assert "{{loki_guidance}}" not in prompt
+
+
+def test_prompt_never_mentions_loki_when_disabled(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_A2A_PROMPT_FILE", ROOT_PROMPT)
+    monkeypatch.delenv("LOKI_URL", raising=False)
+    prompt = get_prompt(role="a2a", variables={"loki_guidance": loki_guidance()})
+    assert "query_loki" not in prompt
+    assert "Loki" not in prompt
+    assert "{{loki_guidance}}" not in prompt
+    # the always-available tool keeps its guidance either way
+    assert "search_pod_logs" in prompt
+
+
+def test_prompt_default_keeps_placeholder_out_even_without_variables(monkeypatch):
+    """Older callers that don't pass variables still get a clean prompt: the
+    declared default ('') must swallow the placeholder."""
+    monkeypatch.setenv("KUBENTLY_A2A_PROMPT_FILE", ROOT_PROMPT)
+    prompt = get_prompt(role="a2a")
+    assert "{{loki_guidance}}" not in prompt
+    assert "query_loki" not in prompt
+
+
+def test_guidance_covers_the_required_topics():
+    """Track C1b asks for specific guidance: when to search logs (errors after
+    a deploy, correlating restarts, upstream failures), narrowing first, and
+    preferring Loki when present."""
+    prompt_text = _read(ROOT_PROMPT).lower()
+    for topic in ("deploy", "restart", "upstream", "selector", "narrow"):
+        assert topic in prompt_text, f"log-search guidance lost its '{topic}' coverage"
+
+    loki_text = LOKI_PROMPT_SECTION.lower()
+    for topic in ("prefer", "restarted", "label selector", "count_over_time"):
+        assert topic in loki_text, f"loki guidance lost its '{topic}' coverage"

--- a/tests/test_loki_executor.py
+++ b/tests/test_loki_executor.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Tests for the executor-side Loki query runner.
+
+Same security contract as the Prometheus runner: only ever GET the single
+whitelisted query_range path against the LOCALLY configured base URL (never
+one supplied by the control plane), report cleanly when unconfigured, and cap
+results before they leave the executor.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.executor.loki import (
+    QUERY_RANGE_PATH,
+    LokiRunner,
+    format_loki_timestamp,
+    format_streams,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+def loki_streams(*streams):
+    return {
+        "status": "success",
+        "data": {"resultType": "streams", "result": list(streams)},
+    }
+
+
+def stream(labels, *lines, start_ns=1700000000_000000000):
+    return {
+        "stream": labels,
+        "values": [[str(start_ns + i), line] for i, line in enumerate(lines)],
+    }
+
+
+@pytest.fixture
+def capture_get(monkeypatch):
+    """Capture requests.get calls and return a canned response."""
+    calls = {}
+
+    def install(response):
+        def fake_get(url, params=None, headers=None, timeout=None):
+            calls["url"] = url
+            calls["params"] = params
+            calls["headers"] = headers
+            calls["timeout"] = timeout
+            return response
+
+        monkeypatch.setattr("kubently.modules.executor.loki.requests.get", fake_get)
+        return calls
+
+    return install
+
+
+# Availability
+
+
+def test_unconfigured_runner_reports_unavailable_without_network(monkeypatch):
+    monkeypatch.delenv("LOKI_URL", raising=False)
+
+    def no_network(*a, **k):
+        raise AssertionError("must not touch the network when unconfigured")
+
+    monkeypatch.setattr("kubently.modules.executor.loki.requests.get", no_network)
+
+    runner = LokiRunner()
+    assert runner.available is False
+    result = runner.run({"query": '{app="x"}'})
+    assert result["success"] is False
+    assert result["status"] == "UNAVAILABLE"
+    assert "not configured" in result["error"]
+    assert "search_pod_logs" in result["error"]  # points the model at the fallback
+
+
+# Path allowlist / request building
+
+
+def test_query_hits_only_the_query_range_path(capture_get):
+    calls = capture_get(FakeResponse(loki_streams()))
+    runner = LokiRunner(base_url="http://loki:3100/")  # trailing slash normalized
+    result = runner.run(
+        {"query": '{app="x"} |= "error"', "start": "1700000000", "end": "1700003600"}
+    )
+    assert result["success"] is True
+    assert calls["url"] == "http://loki:3100" + QUERY_RANGE_PATH
+    assert calls["params"]["query"] == '{app="x"} |= "error"'
+    assert calls["params"]["start"] == "1700000000"
+    assert calls["params"]["direction"] == "backward"
+
+
+def test_start_end_omitted_lets_loki_default_the_window(capture_get):
+    calls = capture_get(FakeResponse(loki_streams()))
+    LokiRunner(base_url="http://loki:3100").run({"query": '{app="x"}'})
+    assert "start" not in calls["params"] and "end" not in calls["params"]
+
+
+def test_limit_is_clamped_to_max_lines(capture_get):
+    calls = capture_get(FakeResponse(loki_streams()))
+    runner = LokiRunner(base_url="http://loki:3100", max_lines=50)
+    runner.run({"query": '{app="x"}', "limit": 5000})
+    assert calls["params"]["limit"] == 50
+
+
+def test_invalid_direction_rejected_without_network(monkeypatch):
+    monkeypatch.setattr(
+        "kubently.modules.executor.loki.requests.get",
+        lambda *a, **k: pytest.fail("must not reach the network"),
+    )
+    result = LokiRunner(base_url="http://loki:3100").run(
+        {"query": '{app="x"}', "direction": "sideways"}
+    )
+    assert result["success"] is False
+    assert "direction" in result["error"]
+
+
+def test_missing_query_rejected():
+    result = LokiRunner(base_url="http://loki:3100").run({})
+    assert result["success"] is False
+    assert "query" in result["error"]
+
+
+def test_tenant_header_sent_only_when_configured(capture_get):
+    calls = capture_get(FakeResponse(loki_streams()))
+    LokiRunner(base_url="http://loki:3100", tenant_id="team-a").run({"query": '{app="x"}'})
+    assert calls["headers"] == {"X-Scope-OrgID": "team-a"}
+
+    calls = capture_get(FakeResponse(loki_streams()))
+    LokiRunner(base_url="http://loki:3100", tenant_id="").run({"query": '{app="x"}'})
+    assert calls["headers"] == {}
+
+
+# Error surfacing
+
+
+def test_logql_error_is_surfaced(capture_get):
+    capture_get(FakeResponse({"status": "error", "error": "parse error at line 1"}, 400))
+    result = LokiRunner(base_url="http://loki:3100").run({"query": "{bad"})
+    assert result["success"] is False
+    assert "parse error" in result["error"]
+
+
+# Result formatting / capping
+
+
+def test_streams_formatted_with_labels_and_rfc3339_timestamps(capture_get):
+    capture_get(
+        FakeResponse(
+            loki_streams(
+                stream({"pod": "api-1", "namespace": "x"}, "error: db down"),
+            )
+        )
+    )
+    result = LokiRunner(base_url="http://loki:3100").run({"query": '{app="x"}'})
+    out = result["output"]
+    assert '=== {namespace="x", pod="api-1"} ===' in out
+    assert "error: db down" in out
+    assert "2023-11-14T" in out  # 1700000000s rendered as RFC3339
+
+
+def test_line_cap_across_streams_notes_truncation(capture_get):
+    capture_get(
+        FakeResponse(
+            loki_streams(
+                stream({"pod": "a"}, *[f"err {i}" for i in range(8)]),
+                stream({"pod": "b"}, *[f"err {i}" for i in range(8)]),
+            )
+        )
+    )
+    runner = LokiRunner(base_url="http://loki:3100", max_lines=10)
+    out = runner.run({"query": '{app="x"}'})["output"]
+    assert "showing 10 of 16 log lines" in out
+
+
+def test_long_lines_truncated():
+    text, _ = format_streams(
+        [stream({"pod": "a"}, "e" * 1000)], max_lines=10, max_line_chars=50
+    )
+    assert "[line truncated]" in text
+
+
+def test_empty_result_gives_hint(capture_get):
+    capture_get(FakeResponse(loki_streams()))
+    out = LokiRunner(base_url="http://loki:3100").run({"query": '{app="x"}'})["output"]
+    assert "No log lines matched" in out
+
+
+def test_metric_style_result_passes_through_as_json(capture_get):
+    capture_get(
+        FakeResponse(
+            {
+                "status": "success",
+                "data": {
+                    "resultType": "matrix",
+                    "result": [{"metric": {"pod": "a"}, "values": [[1700000000, "3"]]}],
+                },
+            }
+        )
+    )
+    out = LokiRunner(base_url="http://loki:3100").run(
+        {"query": 'sum by (pod) (count_over_time({app="x"} |= "error" [1h]))'}
+    )["output"]
+    payload = json.loads(out)
+    assert payload["resultType"] == "matrix"
+
+
+def test_char_cap_is_final_backstop(capture_get):
+    capture_get(
+        FakeResponse(
+            loki_streams(stream({"pod": "a"}, *[f"line {i} " + "x" * 100 for i in range(50)]))
+        )
+    )
+    runner = LokiRunner(base_url="http://loki:3100", max_output_chars=500)
+    out = runner.run({"query": '{app="x"}'})["output"]
+    assert len(out) < 700
+    assert "truncated at 500 chars" in out
+
+
+def test_timestamp_formatter_falls_back_on_garbage():
+    assert format_loki_timestamp("not-a-number") == "not-a-number"
+    assert format_loki_timestamp("1700000000000000000").startswith("2023-11-14T")


### PR DESCRIPTION
Track C1b (Roadmap Phase 3): log evidence beyond plain `kubectl logs`.

- `search_pod_logs`: substring/regex search across pods/containers matching a selector+namespace, with time bounds, previous-container support, per-pod and total output caps, and explicit truncation notes to the model.
- `query_loki`: LogQL range queries when a Loki URL is configured (env/Helm values), routed read-only through the executor channel following the Prometheus toolset's pattern; tool absent when unconfigured.
- System-prompt guidance on when to search logs, narrowing before searching, and preferring Loki when present.
- Branch merged current main and aligned with the C1a toolset registration as landed.
- Verified locally: 102 passed, 1 skipped across the new log-search/Loki suites plus Prometheus + checkpointer regression files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX)_