### PR TITLE
Proactive operation: deployment verification + scheduled checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 ## [Unreleased] - 2026-08-17
 
 ### Added
+- **Deployment verification (Track P5)** — new `POST /webhooks/verify-deployment`
+  (X-API-Key or Bearer auth) takes `{cluster, namespace, workload}` (workload
+  accepts `deploy/name`, `sts/name`, `ds/name` forms), watches the rollout
+  settle by polling `kubectl rollout status --watch=false` through the
+  executor channel (deadline `timeout_seconds`, default 600s), then has the
+  agent run a real post-deploy investigation — pod readiness/restarts, Warning
+  events, error logs via the log-search tools, metrics vs the pre-deploy
+  window where Prometheus is configured, and change correlation — and posts a
+  PASS/FAIL verdict **with evidence** to `SLACK_WEBHOOK_URL`. Verifications
+  always post; an agent PASS cannot overrule a rollout that never settled.
+  `dry_run: true` runs synchronously and returns the verdict without posting.
+  Optional zero-CI trigger: label a workload `kubently.io/verify=enabled` and
+  enable `verifyDeployment.watch` — the API sweeps registered clusters and
+  verifies every `.metadata.generation` change (first sighting only records a
+  baseline, so enabling the label never triggers a verification storm)
+- **Scheduled checks (Track P5)** — named, cron-scheduled agent
+  investigations. `scheduledChecks.checks` in Helm values (name + 5-field
+  cron schedule + optional target clusters + a question prompt) renders into
+  a ConfigMap (`KUBENTLY_CHECKS_FILE`, read per request — edits need no pod
+  restart) plus one CronJob per check POSTing
+  `POST /webhooks/scheduled-check {"check": name}`. Config validation is
+  all-or-nothing with pointed error messages — a misspelled check fails
+  loudly instead of silently vanishing. **Noise discipline**: a PASSing check
+  posts nothing unless `notifyOnPass` (global or per-check) opts in; FAIL —
+  or an answer whose verdict can't be parsed — always posts with the
+  evidence trail. `dry_run: true` returns the verdict plus `wouldPost`
+  synchronously, posting nothing
+- **Shared verdict contract** (`kubently/modules/webhook/verdict.py`) — both
+  proactive features ask the agent to open with `VERDICT: PASS` or
+  `VERDICT: FAIL`; the tolerant parser (case, model decoration, short
+  preambles) maps anything unreadable to *unknown*, which is treated like a
+  failure for posting purposes — an unparseable verdict never mutes a
+  notification
 - **Cloud telemetry access via workload identity (Track D1)** — the executor
   can now query cloud logs/metrics/audit trails from inside the customer's
   account with **zero stored credentials**: the pod assumes a

--- a/README.md
+++ b/README.md
@@ -129,6 +129,57 @@ To run the real scheduled path once — image, secrets, in-cluster URL and all:
 kubectl create job --from=cronjob/kubently-fleet-report fleet-report-test -n kubently
 ```
 
+### Deployment verification (did that deploy actually work?)
+
+Tell Kubently what you just deployed and it watches the rollout settle, then
+runs a real investigation — pods ready? events clean? errors in the new logs?
+metrics regressed vs the pre-deploy window (when Prometheus is configured)? —
+and posts a PASS/FAIL verdict with the evidence to Slack. Wire it into the last
+step of your CI pipeline:
+
+```bash
+curl -X POST https://<your-kubently-host>/webhooks/verify-deployment \
+  -H "X-API-Key: <your-api-key>" -H 'Content-Type: application/json' \
+  -d '{"cluster": "prod-east", "namespace": "shop",
+       "workload": "deploy/checkout-api", "context": "v1.42.0"}'
+```
+
+Add `"dry_run": true` to get the verdict back synchronously without posting.
+No CI access? Label the workload instead — `kubently.io/verify=enabled` — and
+enable `verifyDeployment.watch` in values: Kubently notices every generation
+change and verifies the rollout unprompted.
+
+### Scheduled checks (your recurring questions, on cron)
+
+The digest asks one broad question. Scheduled checks let you ask *your*
+questions on *their* schedules — each check is a named prompt with a cron
+schedule and optional target clusters, run by the agent and posted to Slack:
+
+```yaml
+scheduledChecks:
+  enabled: true
+  checks:
+    - name: cert-expiry
+      schedule: "0 8 * * 1"        # Monday mornings
+      prompt: |-
+        Check TLS secrets for certificates expiring within 21 days.
+        List each as namespace/name with days remaining.
+    - name: pvc-pressure
+      schedule: "0 */6 * * *"
+      clusters: [prod-east]
+      prompt: Find PersistentVolumeClaims above 85% usage.
+```
+
+A passing check posts **nothing** — silence means green (set `notifyOnPass:
+true` to hear about passes too). Failures always post, evidence included.
+Iterate on a check without waiting for cron:
+
+```bash
+curl -X POST https://<your-kubently-host>/webhooks/scheduled-check \
+  -H "X-API-Key: <your-api-key>" -H 'Content-Type: application/json' \
+  -d '{"check": "cert-expiry", "dry_run": true}'
+```
+
 **📖 See [QUICK_START.md](docs/QUICK_START.md) for full quick-start guide**
 
 **📚 See [GETTING_STARTED.md](docs/GETTING_STARTED.md) for production deployment**

--- a/deployment/helm/kubently/templates/api-deployment.yaml
+++ b/deployment/helm/kubently/templates/api-deployment.yaml
@@ -210,10 +210,33 @@ spec:
           value: "/etc/kubently/prompts/system.prompt.yaml"
         - name: KUBENTLY_FLEET_REPORT_PROMPT_FILE
           value: "/etc/kubently/prompts/fleet_report.prompt.yaml"
+        {{- if .Values.scheduledChecks.enabled }}
+        - name: KUBENTLY_CHECKS_FILE
+          value: "/etc/kubently/checks/checks.yaml"
+        {{- end }}
+        {{- /* Deploy watch: sweep for kubently.io/verify=enabled workloads and
+               verify on generation change. 0/absent disables the watch. */}}
+        {{- if ((.Values.verifyDeployment).watch).enabled }}
+        - name: KUBENTLY_VERIFY_WATCH_SECONDS
+          value: {{ .Values.verifyDeployment.watch.intervalSeconds | default 60 | quote }}
+        {{- with .Values.verifyDeployment.watch.clusters }}
+        - name: KUBENTLY_VERIFY_WATCH_CLUSTERS
+          value: {{ join "," . | quote }}
+        {{- end }}
+        {{- end }}
+        {{- if (.Values.verifyDeployment).timeoutSeconds }}
+        - name: KUBENTLY_VERIFY_TIMEOUT_SECONDS
+          value: {{ .Values.verifyDeployment.timeoutSeconds | quote }}
+        {{- end }}
         volumeMounts:
         - name: prompt-config
           mountPath: /etc/kubently/prompts
           readOnly: true
+        {{- if .Values.scheduledChecks.enabled }}
+        - name: checks-config
+          mountPath: /etc/kubently/checks
+          readOnly: true
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -248,4 +271,9 @@ spec:
       - name: prompt-config
         configMap:
           name: {{ include "kubently.fullname" . }}-prompt
+      {{- if .Values.scheduledChecks.enabled }}
+      - name: checks-config
+        configMap:
+          name: {{ include "kubently.fullname" . }}-checks
+      {{- end }}
 {{- end }}

--- a/deployment/helm/kubently/templates/scheduled-checks-configmap.yaml
+++ b/deployment/helm/kubently/templates/scheduled-checks-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.api.enabled .Values.scheduledChecks.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kubently.fullname" . }}-checks
+  labels:
+    {{- include "kubently.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scheduled-checks
+data:
+  checks.yaml: |
+    notifyOnPass: {{ .Values.scheduledChecks.notifyOnPass }}
+    checks:
+{{ toYaml (.Values.scheduledChecks.checks | default list) | indent 6 }}
+{{- end }}

--- a/deployment/helm/kubently/templates/scheduled-checks-cronjob.yaml
+++ b/deployment/helm/kubently/templates/scheduled-checks-cronjob.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.api.enabled .Values.scheduledChecks.enabled }}
+{{- $root := . }}
+{{- range .Values.scheduledChecks.checks }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  # Check names are validated API-side as lowercase-hyphen, max 30 chars, so
+  # "<fullname>-check-<name>" stays inside the Job-name length budget.
+  name: {{ include "kubently.fullname" $root }}-check-{{ .name }}
+  labels:
+    {{- include "kubently.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: scheduled-check
+    kubently.io/check: {{ .name | quote }}
+spec:
+  schedule: {{ .schedule | quote }}
+  suspend: {{ .suspend | default false }}
+  # A check takes minutes; never let a slow run stack on the next schedule.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # The endpoint ACKs 202 and investigates in the background, so this Job
+      # only needs to land the POST (same pattern as the fleet-report CronJob).
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            {{- include "kubently.selectorLabels" $root | nindent 12 }}
+            app.kubernetes.io/component: scheduled-check
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: trigger
+            # Reuses the API image (already pulled on the node, ships httpx)
+            # rather than adding a curl image to the deployment's pull set.
+            image: "{{ $root.Values.api.image.repository }}:{{ $root.Values.api.image.tag | default $root.Chart.AppVersion }}"
+            imagePullPolicy: {{ $root.Values.api.image.pullPolicy }}
+            env:
+            - name: API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $root.Values.api.existingSecret | default (printf "%s-api-keys" (include "kubently.fullname" $root)) }}
+                  key: keys
+            - name: KUBENTLY_API_URL
+              value: "http://{{ include "kubently.fullname" $root }}-api:{{ $root.Values.api.service.port }}"
+            - name: CHECK_NAME
+              value: {{ .name | quote }}
+            command:
+            - python
+            - -c
+            - |
+              import os, sys, httpx
+              # API_KEYS holds every configured key (comma- or newline-separated);
+              # any one of them authenticates this call.
+              key = next(k.strip() for k in os.environ["API_KEYS"].replace(",", "\n").split("\n") if k.strip())
+              key = key.split(":")[-1]  # tolerate the "service:key" form
+              r = httpx.post(
+                  f"{os.environ['KUBENTLY_API_URL']}/webhooks/scheduled-check",
+                  headers={"X-API-Key": key},
+                  json={"check": os.environ["CHECK_NAME"]},
+                  timeout=30,
+              )
+              print(r.status_code, r.text)
+              sys.exit(0 if r.status_code == 202 else 1)
+{{- end }}
+{{- end }}

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -90,6 +90,77 @@ fleetReport:
   query: ""
 
 # ============================================================================
+# Deployment Verification (proactive)
+# ============================================================================
+# POST /webhooks/verify-deployment after a deploy (from CI, ArgoCD hooks, or
+# curl) and the agent watches the rollout settle, then investigates the result
+# — pods, events, error logs, and metrics vs the pre-deploy window where
+# Prometheus is configured — and posts a PASS/FAIL verdict with evidence to the
+# Slack webhook (api.slackWebhook above). Verifications always post.
+#
+#   curl -X POST $API/webhooks/verify-deployment -H "X-API-Key: $KEY" \
+#     -H 'Content-Type: application/json' \
+#     -d '{"cluster": "prod-east", "namespace": "shop", "workload": "deploy/checkout-api"}'
+#
+# Preview without posting: add "dry_run": true (runs synchronously).
+verifyDeployment:
+  # Optional deploy watch: the API sweeps registered clusters for workloads
+  # labelled `kubently.io/verify=enabled` and fires a verification whenever a
+  # workload's .metadata.generation changes (i.e. someone deployed). No CI
+  # integration needed — label the workload and every deploy gets verified.
+  watch:
+    enabled: false
+    # How often to sweep, in seconds (min 15).
+    intervalSeconds: 60
+    # Restrict the sweep to specific cluster ids. Empty = all registered.
+    clusters: []
+  # Default settle deadline (seconds) when the trigger doesn't send
+  # timeout_seconds. Clamped per-request to [60, 1800].
+  timeoutSeconds: 600
+
+# ============================================================================
+# Scheduled Checks (proactive)
+# ============================================================================
+# Named, cron-scheduled agent investigations. Each check gets its own CronJob
+# that POSTs /webhooks/scheduled-check; the agent runs the check's prompt and
+# posts the result to the Slack webhook (api.slackWebhook above).
+#
+# Noise discipline: a PASSing check posts nothing unless notifyOnPass is true
+# (globally or per check). A FAIL — or an answer whose verdict can't be parsed
+# — always posts, with the evidence trail.
+#
+# Iterate on a check without waiting for cron (runs synchronously, posts
+# nothing):
+#   curl -X POST $API/webhooks/scheduled-check -H "X-API-Key: $KEY" \
+#     -H 'Content-Type: application/json' \
+#     -d '{"check": "cert-expiry", "dry_run": true}'
+# Or run the real scheduled path once:
+#   kubectl create job --from=cronjob/kubently-check-cert-expiry check-test -n kubently
+scheduledChecks:
+  enabled: false
+  # Global default; each check may override with its own notifyOnPass.
+  notifyOnPass: false
+  # Each check: name (lowercase-hyphen, max 30 chars — becomes the CronJob
+  # name), schedule (5-field cron, cluster timezone), prompt (the question the
+  # agent investigates), and optionally clusters (empty = all registered),
+  # notifyOnPass, suspend.
+  checks: []
+  # Example:
+  #   checks:
+  #     - name: cert-expiry
+  #       schedule: "0 8 * * 1"
+  #       clusters: [prod-east, prod-west]
+  #       prompt: |-
+  #         Check TLS secrets for certificates expiring within 21 days.
+  #         List each as namespace/name with days remaining.
+  #     - name: pvc-pressure
+  #       schedule: "0 */6 * * *"
+  #       notifyOnPass: true
+  #       prompt: |-
+  #         Find PersistentVolumeClaims above 85% usage and nodes under
+  #         disk pressure.
+
+# ============================================================================
 # Loki Log Search (optional)
 # ============================================================================
 # Gives the diagnostic agent a read-only LogQL tool (query_loki) for searching

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -97,6 +97,24 @@ The API never dials this URL itself — queries execute on each cluster's execut
 |----------|---------|----------|-------------|
 | `PROMETHEUS_URL` | - | No | Presence enables the `query_prometheus` agent tool. Set via Helm `prometheus.url` |
 
+### Proactive Operation (Slack notifications, deploy verification, scheduled checks)
+
+One Slack incoming-webhook URL powers every proactive path: Alertmanager
+diagnoses (`/webhooks/alertmanager`), the fleet health digest
+(`/webhooks/fleet-report`), deployment verifications
+(`/webhooks/verify-deployment`) and scheduled checks
+(`/webhooks/scheduled-check`). The URL is a credential — set it via the Helm
+`api.slackWebhook.existingSecret` reference rather than a values file.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `SLACK_WEBHOOK_URL` | - | For posting paths | Slack incoming-webhook URL all proactive results post to. `dry_run` calls never need it. Set via Helm `api.slackWebhook` |
+| `KUBENTLY_FLEET_REPORT_PROMPT_FILE` | `/etc/kubently/prompts/fleet_report.prompt.yaml` | No | Fleet digest query file (rendered from Helm `fleetReport.query`) |
+| `KUBENTLY_CHECKS_FILE` | `/etc/kubently/checks/checks.yaml` | No | Scheduled-checks config file (rendered from Helm `scheduledChecks.checks`, read per request — no restart on change) |
+| `KUBENTLY_VERIFY_TIMEOUT_SECONDS` | `600` | No | Default rollout settle deadline for `/webhooks/verify-deployment` when the request doesn't send `timeout_seconds` (per-request values clamp to 60–1800) |
+| `KUBENTLY_VERIFY_WATCH_SECONDS` | `0` (off) | No | Enables the deploy watch: sweep interval in seconds (min 15) for finding `kubently.io/verify=enabled` workloads whose generation changed. Set via Helm `verifyDeployment.watch` |
+| `KUBENTLY_VERIFY_WATCH_CLUSTERS` | - (all registered) | No | Comma-separated cluster ids to restrict the deploy watch sweep to |
+
 ### LLM Configuration (for A2A)
 
 | Variable | Default | Required | Description |

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -208,6 +208,27 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Failed to mount fleet report endpoint: {e}")
 
+    # Proactive mode: deployment verification -> Slack verdict. Same lazy-agent
+    # pattern; triggered by CI webhooks, curl, or the optional label-driven
+    # deploy watch (KUBENTLY_VERIFY_WATCH_SECONDS).
+    try:
+        from kubently.modules.webhook import create_verify_deployment_router
+
+        app.include_router(create_verify_deployment_router(verify_dual_auth, redis_client=redis_client))
+        logger.info("Deployment verification endpoint mounted at /webhooks/verify-deployment")
+    except Exception as e:
+        logger.warning(f"Failed to mount deployment verification endpoint: {e}")
+
+    # Proactive mode: named scheduled checks -> Slack (quiet on pass). Same
+    # lazy-agent pattern; triggered by the chart's per-check CronJobs.
+    try:
+        from kubently.modules.webhook import create_scheduled_checks_router
+
+        app.include_router(create_scheduled_checks_router(verify_dual_auth, redis_client=redis_client))
+        logger.info("Scheduled checks endpoint mounted at /webhooks/scheduled-check")
+    except Exception as e:
+        logger.warning(f"Failed to mount scheduled checks endpoint: {e}")
+
     logger.info("Kubently API started successfully")
 
     yield

--- a/kubently/modules/webhook/__init__.py
+++ b/kubently/modules/webhook/__init__.py
@@ -1,2 +1,4 @@
 from .alertmanager import create_router  # noqa: F401
 from .fleet_report import create_router as create_fleet_report_router  # noqa: F401
+from .scheduled_checks import create_router as create_scheduled_checks_router  # noqa: F401
+from .verify_deployment import create_router as create_verify_deployment_router  # noqa: F401

--- a/kubently/modules/webhook/scheduled_checks.py
+++ b/kubently/modules/webhook/scheduled_checks.py
@@ -1,0 +1,259 @@
+"""Named scheduled checks: cron-triggered agent investigations -> Slack.
+
+The chart renders `scheduledChecks.checks` (name + cron schedule + optional
+target clusters + a question prompt) into a ConfigMap mounted at
+KUBENTLY_CHECKS_FILE, plus one CronJob per check that POSTs
+`{"check": "<name>"}` here on its schedule. The agent runs the check's prompt
+as a real investigation and the result goes to SLACK_WEBHOOK_URL.
+
+Noise discipline: a check that PASSes posts nothing by default — the digest of
+"everything is still fine" belongs to the fleet report, not to N cron checks.
+`notifyOnPass` (global or per-check) opts back in. A FAIL — or an answer whose
+verdict cannot be parsed — always posts, with the agent's evidence trail.
+
+Same response contracts as fleet_report:
+  - scheduled: ACK 202, investigation runs in the background
+  - dry_run:   run synchronously, return verdict + whether it would have posted
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+
+import httpx
+import yaml
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from . import verdict as verdicts
+from .verdict import (
+    SLACK_MRKDWN_INSTRUCTIONS,
+    VERDICT_INSTRUCTIONS,
+    parse_verdict,
+    verdict_emoji,
+    verdict_label,
+)
+
+logger = logging.getLogger(__name__)
+
+# Strong refs for fire-and-forget background tasks (see fleet_report.py).
+_background: set[asyncio.Task] = set()
+
+DEFAULT_CHECKS_FILE = "/etc/kubently/checks/checks.yaml"
+
+# Check names become CronJob name suffixes and Slack headers: RFC-1123 label,
+# kept short so "<release>-check-<name>" stays under the Job-name limit.
+_NAME = re.compile(r"^[a-z0-9]([a-z0-9-]{0,28}[a-z0-9])?$")
+_CLUSTER_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+# Five whitespace-separated fields. Kubernetes' CronJob controller is the real
+# parser; this only catches "someone pasted a 6-field or empty schedule" at
+# config load instead of at silent-CronJob-never-fires time.
+_CRON = re.compile(r"^\S+\s+\S+\s+\S+\s+\S+\s+\S+$")
+
+
+@dataclass
+class Check:
+    name: str
+    schedule: str
+    prompt: str
+    clusters: list = field(default_factory=list)
+    notify_on_pass: bool = False
+    suspend: bool = False
+
+
+def validate_check(raw: dict, default_notify_on_pass: bool = False) -> Check:
+    """One config entry -> Check. Raises ValueError with a pointed message."""
+    if not isinstance(raw, dict):
+        raise ValueError(f"check entry must be a mapping, got {type(raw).__name__}")
+
+    name = str(raw.get("name") or "").strip()
+    if not name:
+        raise ValueError("check is missing 'name'")
+    if not _NAME.match(name):
+        raise ValueError(
+            f"check name {name!r} must be lowercase alphanumeric/hyphens, max 30 chars "
+            "(it becomes part of a CronJob name)"
+        )
+
+    schedule = str(raw.get("schedule") or "").strip()
+    if not schedule:
+        raise ValueError(f"check {name!r} is missing 'schedule'")
+    if not _CRON.match(schedule):
+        raise ValueError(f"check {name!r} schedule {schedule!r} is not a 5-field cron expression")
+
+    prompt = str(raw.get("prompt") or "").strip()
+    if not prompt:
+        raise ValueError(f"check {name!r} is missing 'prompt'")
+
+    clusters = raw.get("clusters") or []
+    if not isinstance(clusters, list):
+        raise ValueError(f"check {name!r} 'clusters' must be a list")
+    clusters = [str(c).strip() for c in clusters if str(c).strip()]
+    for c in clusters:
+        if not _CLUSTER_ID.match(c):
+            raise ValueError(f"check {name!r} has invalid cluster id {c!r}")
+
+    notify = raw.get("notifyOnPass", raw.get("notify_on_pass"))
+    return Check(
+        name=name,
+        schedule=schedule,
+        prompt=prompt,
+        clusters=clusters,
+        notify_on_pass=default_notify_on_pass if notify is None else bool(notify),
+        suspend=bool(raw.get("suspend", False)),
+    )
+
+
+def load_checks(path: str | None = None) -> dict[str, Check]:
+    """Load and validate the checks file. Raises ValueError on any bad entry.
+
+    All-or-nothing on purpose: a half-loaded config where the misspelled check
+    silently vanishes is how a "certificate expiry" check stops running without
+    anyone noticing. The CronJob POST for a check that failed validation gets a
+    clear error instead.
+    """
+    path = path or os.environ.get("KUBENTLY_CHECKS_FILE") or DEFAULT_CHECKS_FILE
+    if not os.path.isfile(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError("checks file must be a mapping with a 'checks' list")
+    default_notify = bool(data.get("notifyOnPass", False))
+    entries = data.get("checks") or []
+    if not isinstance(entries, list):
+        raise ValueError("'checks' must be a list")
+    checks: dict[str, Check] = {}
+    for raw in entries:
+        check = validate_check(raw, default_notify_on_pass=default_notify)
+        if check.name in checks:
+            raise ValueError(f"duplicate check name {check.name!r}")
+        checks[check.name] = check
+    return checks
+
+
+def build_query(check: Check) -> str:
+    parts = []
+    if len(check.clusters) == 1:
+        parts.append(f"Investigate cluster {check.clusters[0]} only.")
+    elif check.clusters:
+        parts.append(
+            "Investigate only these clusters: " + ", ".join(check.clusters) + "."
+        )
+    else:
+        parts.append("Investigate every registered cluster.")
+    parts.append(check.prompt)
+    parts.append(VERDICT_INSTRUCTIONS)
+    parts.append(SLACK_MRKDWN_INSTRUCTIONS)
+    return "\n\n".join(parts)
+
+
+def should_post(verdict: str, check: Check) -> bool:
+    """Noise discipline: quiet on PASS unless opted in; FAIL and UNKNOWN post."""
+    if verdict == verdicts.PASS:
+        return check.notify_on_pass
+    return True
+
+
+def format_slack_message(check: Check, verdict: str, body: str) -> dict:
+    from .fleet_report import to_slack_mrkdwn
+
+    header = f"{verdict_emoji(verdict)} *Scheduled check `{check.name}`: {verdict_label(verdict)}*"
+    return {"text": f"{header}\n\n{to_slack_mrkdwn(body)}"}
+
+
+async def _run_check(agent_factory, check: Check, prompt_override: str | None = None) -> tuple:
+    """Run the investigation. Returns (verdict, body)."""
+    from kubently.modules.mcp import tools
+
+    if prompt_override:
+        check = Check(
+            name=check.name,
+            schedule=check.schedule,
+            prompt=prompt_override,
+            clusters=check.clusters,
+            notify_on_pass=check.notify_on_pass,
+        )
+    cluster_id = check.clusters[0] if len(check.clusters) == 1 else None
+    result = await tools.ask_kubently(agent_factory(), build_query(check), cluster_id, None)
+    return parse_verdict(result["answer"])
+
+
+async def _post_slack(slack_url: str, message: dict) -> None:
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(slack_url, json=message)
+        resp.raise_for_status()
+
+
+async def _check_and_post(agent_factory, check: Check, slack_url: str) -> None:
+    try:
+        verdict, body = await _run_check(agent_factory, check)
+        if not should_post(verdict, check):
+            logger.info("Scheduled check %s passed; not posting (noise discipline)", check.name)
+            return
+        await _post_slack(slack_url, format_slack_message(check, verdict, body))
+        logger.info("Posted scheduled check %s (%s) to Slack", check.name, verdict)
+    except Exception:
+        logger.exception("Scheduled check %s failed", check.name)
+
+
+def create_router(verify_api_key, redis_client=None) -> APIRouter:
+    """Router factory. The agent (and its heavy langchain import) is only touched
+    once a check actually runs, so the API boots without the a2a stack."""
+    router = APIRouter()
+    state: dict = {"agent": None}
+
+    def _agent():
+        if state["agent"] is None:
+            from kubently.modules.a2a.protocol_bindings.a2a_server.agent import KubentlyAgent
+
+            state["agent"] = KubentlyAgent(redis_client=redis_client)
+        return state["agent"]
+
+    @router.post("/webhooks/scheduled-check")
+    async def scheduled_check(request: Request, auth=Depends(verify_api_key)):
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if not isinstance(body, dict):
+            raise HTTPException(400, "Body must be a JSON object")
+
+        name = str(body.get("check") or "").strip()
+        if not name:
+            raise HTTPException(400, "'check' is required")
+
+        try:
+            checks = load_checks()
+        except ValueError as e:
+            raise HTTPException(500, f"checks config is invalid: {e}")
+        check = checks.get(name)
+        if check is None:
+            known = ", ".join(sorted(checks)) or "(none configured)"
+            raise HTTPException(404, f"unknown check {name!r}; configured checks: {known}")
+
+        if body.get("dry_run"):
+            # Synchronous: the caller is a human iterating on a check. Never
+            # posts, so SLACK_WEBHOOK_URL is not required.
+            verdict, answer = await _run_check(_agent, check, body.get("prompt"))
+            return {
+                "dryRun": True,
+                "check": check.name,
+                "verdict": verdict,
+                "wouldPost": should_post(verdict, check),
+                "answer": answer,
+            }
+
+        slack_url = os.environ.get("SLACK_WEBHOOK_URL")
+        if not slack_url:
+            raise HTTPException(503, "SLACK_WEBHOOK_URL is not configured")
+        task = asyncio.create_task(_check_and_post(_agent, check, slack_url))
+        _background.add(task)
+        task.add_done_callback(_background.discard)
+        return JSONResponse(status_code=202, content={"accepted": True, "check": check.name})
+
+    return router

--- a/kubently/modules/webhook/scheduled_checks.py
+++ b/kubently/modules/webhook/scheduled_checks.py
@@ -119,7 +119,7 @@ def load_checks(path: str | None = None) -> dict[str, Check]:
     path = path or os.environ.get("KUBENTLY_CHECKS_FILE") or DEFAULT_CHECKS_FILE
     if not os.path.isfile(path):
         return {}
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     if not isinstance(data, dict):
         raise ValueError("checks file must be a mapping with a 'checks' list")
@@ -141,9 +141,7 @@ def build_query(check: Check) -> str:
     if len(check.clusters) == 1:
         parts.append(f"Investigate cluster {check.clusters[0]} only.")
     elif check.clusters:
-        parts.append(
-            "Investigate only these clusters: " + ", ".join(check.clusters) + "."
-        )
+        parts.append("Investigate only these clusters: " + ", ".join(check.clusters) + ".")
     else:
         parts.append("Investigate every registered cluster.")
     parts.append(check.prompt)
@@ -201,6 +199,19 @@ async def _check_and_post(agent_factory, check: Check, slack_url: str) -> None:
         logger.exception("Scheduled check %s failed", check.name)
 
 
+def _resolve_check(name: str) -> Check:
+    """Load config and find the named check, mapping failures to HTTP errors."""
+    try:
+        checks = load_checks()
+    except ValueError as e:
+        raise HTTPException(500, f"checks config is invalid: {e}") from e
+    check = checks.get(name)
+    if check is None:
+        known = ", ".join(sorted(checks)) or "(none configured)"
+        raise HTTPException(404, f"unknown check {name!r}; configured checks: {known}")
+    return check
+
+
 def create_router(verify_api_key, redis_client=None) -> APIRouter:
     """Router factory. The agent (and its heavy langchain import) is only touched
     once a check actually runs, so the API boots without the a2a stack."""
@@ -226,15 +237,7 @@ def create_router(verify_api_key, redis_client=None) -> APIRouter:
         name = str(body.get("check") or "").strip()
         if not name:
             raise HTTPException(400, "'check' is required")
-
-        try:
-            checks = load_checks()
-        except ValueError as e:
-            raise HTTPException(500, f"checks config is invalid: {e}")
-        check = checks.get(name)
-        if check is None:
-            known = ", ".join(sorted(checks)) or "(none configured)"
-            raise HTTPException(404, f"unknown check {name!r}; configured checks: {known}")
+        check = _resolve_check(name)
 
         if body.get("dry_run"):
             # Synchronous: the caller is a human iterating on a check. Never

--- a/kubently/modules/webhook/verdict.py
+++ b/kubently/modules/webhook/verdict.py
@@ -1,0 +1,74 @@
+"""Shared verdict plumbing for proactive investigations.
+
+Deployment verifications and scheduled checks both end the same way: the agent's
+free-text answer has to become a machine-readable pass/fail so the caller can
+decide whether (and how loudly) to post to Slack. The contract is a marker line
+the prompt asks for — `VERDICT: PASS` or `VERDICT: FAIL` first — and a parser
+that treats anything else as "unknown". Unknown is deliberately not pass:
+a verdict we cannot read must never suppress a notification.
+"""
+
+from __future__ import annotations
+
+import re
+
+PASS = "pass"
+FAIL = "fail"
+UNKNOWN = "unknown"
+
+# Appended to every proactive prompt. Kept in one place so the two features
+# cannot drift into different marker dialects.
+VERDICT_INSTRUCTIONS = (
+    "Begin your reply with exactly one line reading `VERDICT: PASS` or "
+    "`VERDICT: FAIL` (nothing else on that line), then a blank line, then your "
+    "findings. PASS means everything you checked is healthy. FAIL means you "
+    "found a problem or could not complete the investigation — when in doubt, "
+    "FAIL. After the verdict line, show your evidence: what you checked and "
+    "what you saw, one line per finding."
+)
+
+# Same Slack-formatting contract the alertmanager prompt uses; prompt compliance
+# is probabilistic, so to_slack_mrkdwn still normalises the answer on the way out.
+SLACK_MRKDWN_INSTRUCTIONS = (
+    "Be concise; this will be posted to Slack. Format as Slack mrkdwn, which "
+    "is NOT markdown: bold is *single asterisk* (never **double**), there are "
+    "no `#` headings, no `---` rules and no tables. Code fences take no "
+    "language hint — use ``` alone, not ```bash."
+)
+
+# The marker line, tolerantly: optional leading bullet/bold decoration, any
+# case, optional trailing punctuation. Models decorate despite instructions,
+# and a decorated marker is still a readable verdict.
+_MARKER = re.compile(
+    r"^\s*[*_`•\-]*\s*verdict\s*[:\-]\s*[*_`]*\s*(pass|fail)(?:ed)?\s*[*_`.!]*\s*$",
+    re.IGNORECASE,
+)
+
+# How many leading lines to scan for the marker. The instruction says "first
+# line", but a preamble sentence before it is a common failure mode and the
+# marker is unambiguous wherever it appears near the top.
+_SCAN_LINES = 5
+
+
+def parse_verdict(answer: str) -> tuple[str, str]:
+    """Extract (verdict, body) from an agent answer.
+
+    Returns one of PASS/FAIL/UNKNOWN plus the answer with the marker line
+    removed (verbatim answer when no marker was found). UNKNOWN is the
+    fail-safe: the caller should treat it like a failure for posting purposes.
+    """
+    lines = (answer or "").splitlines()
+    for i, line in enumerate(lines[:_SCAN_LINES]):
+        m = _MARKER.match(line)
+        if m:
+            body = "\n".join(lines[:i] + lines[i + 1 :]).strip()
+            return (PASS if m.group(1).lower() == "pass" else FAIL), body
+    return UNKNOWN, (answer or "").strip()
+
+
+def verdict_emoji(verdict: str) -> str:
+    return {PASS: ":white_check_mark:", FAIL: ":x:"}.get(verdict, ":warning:")
+
+
+def verdict_label(verdict: str) -> str:
+    return {PASS: "PASS", FAIL: "FAIL"}.get(verdict, "UNKNOWN")

--- a/kubently/modules/webhook/verify_deployment.py
+++ b/kubently/modules/webhook/verify_deployment.py
@@ -77,25 +77,12 @@ class VerifyRequest:
     query: str = ""  # extra caller instructions appended to the investigation
 
 
-def parse_request(body: dict) -> VerifyRequest:
-    """Validate the trigger payload. Raises ValueError with a caller-facing message.
+def _resolve_kind(body: dict, workload: str) -> tuple[str, str]:
+    """(kind, bare workload name) from the `kind` field and/or `kind/name` prefix.
 
-    `workload` accepts either a bare name or a `kind/name` prefix (the form
-    kubectl prints); an explicit `kind` field that contradicts the prefix is an
-    error rather than a silent pick.
+    An explicit `kind` field that contradicts the prefix is an error rather
+    than a silent pick.
     """
-    if not isinstance(body, dict):
-        raise ValueError("Body must be a JSON object")
-
-    cluster = str(body.get("cluster") or "").strip()
-    if not cluster:
-        raise ValueError("'cluster' is required")
-    if not _CLUSTER_ID.match(cluster):
-        raise ValueError(f"'cluster' is not a valid cluster id: {cluster!r}")
-
-    workload = str(body.get("workload") or "").strip()
-    if not workload:
-        raise ValueError("'workload' is required")
     prefix_kind = None
     if "/" in workload:
         prefix_kind, _, workload = workload.partition("/")
@@ -116,6 +103,28 @@ def parse_request(body: dict) -> VerifyRequest:
     kind = kind or prefix_kind or "deployment"
     if kind not in KINDS:
         raise ValueError(f"'kind' must be one of {', '.join(KINDS)}; got {kind!r}")
+    return kind, workload
+
+
+def parse_request(body: dict) -> VerifyRequest:
+    """Validate the trigger payload. Raises ValueError with a caller-facing message.
+
+    `workload` accepts either a bare name or a `kind/name` prefix (the form
+    kubectl prints).
+    """
+    if not isinstance(body, dict):
+        raise ValueError("Body must be a JSON object")
+
+    cluster = str(body.get("cluster") or "").strip()
+    if not cluster:
+        raise ValueError("'cluster' is required")
+    if not _CLUSTER_ID.match(cluster):
+        raise ValueError(f"'cluster' is not a valid cluster id: {cluster!r}")
+
+    workload = str(body.get("workload") or "").strip()
+    if not workload:
+        raise ValueError("'workload' is required")
+    kind, workload = _resolve_kind(body, workload)
 
     if not _DNS1123.match(workload):
         raise ValueError(f"'workload' is not a valid resource name: {workload!r}")
@@ -127,8 +136,8 @@ def parse_request(body: dict) -> VerifyRequest:
     raw_timeout = body.get("timeout_seconds", _default_timeout())
     try:
         timeout_seconds = int(raw_timeout)
-    except (TypeError, ValueError):
-        raise ValueError(f"'timeout_seconds' must be an integer; got {raw_timeout!r}")
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"'timeout_seconds' must be an integer; got {raw_timeout!r}") from e
     timeout_seconds = max(MIN_TIMEOUT_SECONDS, min(MAX_TIMEOUT_SECONDS, timeout_seconds))
 
     context = str(body.get("context") or "").strip()[:MAX_CONTEXT_CHARS]
@@ -497,7 +506,7 @@ def create_router(verify_api_key, redis_client=None) -> APIRouter:
         try:
             req = parse_request(body)
         except ValueError as e:
-            raise HTTPException(400, str(e))
+            raise HTTPException(400, str(e)) from e
 
         if req.dry_run:
             # Synchronous: the caller wants to read the verdict. No

--- a/kubently/modules/webhook/verify_deployment.py
+++ b/kubently/modules/webhook/verify_deployment.py
@@ -1,0 +1,532 @@
+"""Deployment verification webhook -> rollout settle-watch -> agent verdict -> Slack.
+
+A CI pipeline (or a human with curl) POSTs the workload it just deployed; the
+endpoint ACKs 202, waits for the rollout to settle by polling
+`kubectl rollout status` through the executor channel, then has the agent run a
+real post-deploy investigation (pods, events, logs, metrics vs the pre-deploy
+window where Prometheus is configured) and posts a PASS/FAIL verdict with the
+evidence to SLACK_WEBHOOK_URL. Verifications always post — a deploy is an event
+someone is actively watching, so silence is not a signal here (contrast with
+scheduled checks, which stay quiet on pass).
+
+Optionally the API can notice deploys itself: workloads labelled
+`kubently.io/verify=enabled` are polled for generation changes (see
+start_annotation_watch) and every observed change triggers the same verification.
+
+Two response contracts, chosen by the caller (same split as fleet_report):
+  - default: ACK 202, verification runs in the background (settle + investigation
+    take minutes; nobody holds a connection that long)
+  - dry_run: run synchronously, return the verdict to the caller, post nothing
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from dataclasses import dataclass
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from . import verdict as verdicts
+from .verdict import (
+    SLACK_MRKDWN_INSTRUCTIONS,
+    VERDICT_INSTRUCTIONS,
+    parse_verdict,
+    verdict_emoji,
+    verdict_label,
+)
+
+logger = logging.getLogger(__name__)
+
+# asyncio holds only weak references to tasks, so a fire-and-forget task can be
+# garbage-collected mid-flight. A verification runs for minutes; without a strong
+# ref the symptom is "the Slack message just never arrives", with nothing logged.
+_background: set[asyncio.Task] = set()
+
+KINDS = ("deployment", "statefulset", "daemonset")
+
+# Workload/namespace names go into kubectl args and the agent prompt, so they
+# are validated as DNS-1123 names rather than passed through as free text.
+_DNS1123 = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+# Cluster ids are Kubently's own (executor:token:{id}); slightly wider charset.
+_CLUSTER_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+DEFAULT_TIMEOUT_SECONDS = 600
+MIN_TIMEOUT_SECONDS = 60
+MAX_TIMEOUT_SECONDS = 1800
+MAX_CONTEXT_CHARS = 200
+
+# Label (not annotation) drives the optional deploy watch: labels are the only
+# metadata kubectl can select server-side, and the watch sweeps whole clusters.
+WATCH_LABEL = "kubently.io/verify=enabled"
+
+
+@dataclass
+class VerifyRequest:
+    cluster: str
+    workload: str
+    kind: str = "deployment"
+    namespace: str = "default"
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+    context: str = ""  # free text for the Slack header, e.g. an image tag
+    dry_run: bool = False
+    query: str = ""  # extra caller instructions appended to the investigation
+
+
+def parse_request(body: dict) -> VerifyRequest:
+    """Validate the trigger payload. Raises ValueError with a caller-facing message.
+
+    `workload` accepts either a bare name or a `kind/name` prefix (the form
+    kubectl prints); an explicit `kind` field that contradicts the prefix is an
+    error rather than a silent pick.
+    """
+    if not isinstance(body, dict):
+        raise ValueError("Body must be a JSON object")
+
+    cluster = str(body.get("cluster") or "").strip()
+    if not cluster:
+        raise ValueError("'cluster' is required")
+    if not _CLUSTER_ID.match(cluster):
+        raise ValueError(f"'cluster' is not a valid cluster id: {cluster!r}")
+
+    workload = str(body.get("workload") or "").strip()
+    if not workload:
+        raise ValueError("'workload' is required")
+    prefix_kind = None
+    if "/" in workload:
+        prefix_kind, _, workload = workload.partition("/")
+        # normalise the plural/abbreviated forms kubectl accepts
+        prefix_kind = prefix_kind.strip().lower()
+        prefix_kind = {
+            "deploy": "deployment",
+            "deployments": "deployment",
+            "sts": "statefulset",
+            "statefulsets": "statefulset",
+            "ds": "daemonset",
+            "daemonsets": "daemonset",
+        }.get(prefix_kind, prefix_kind)
+
+    kind = str(body.get("kind") or "").strip().lower()
+    if kind and prefix_kind and kind != prefix_kind:
+        raise ValueError(f"'kind' ({kind}) contradicts workload prefix ({prefix_kind})")
+    kind = kind or prefix_kind or "deployment"
+    if kind not in KINDS:
+        raise ValueError(f"'kind' must be one of {', '.join(KINDS)}; got {kind!r}")
+
+    if not _DNS1123.match(workload):
+        raise ValueError(f"'workload' is not a valid resource name: {workload!r}")
+
+    namespace = str(body.get("namespace") or "default").strip()
+    if not _DNS1123.match(namespace):
+        raise ValueError(f"'namespace' is not a valid namespace name: {namespace!r}")
+
+    raw_timeout = body.get("timeout_seconds", _default_timeout())
+    try:
+        timeout_seconds = int(raw_timeout)
+    except (TypeError, ValueError):
+        raise ValueError(f"'timeout_seconds' must be an integer; got {raw_timeout!r}")
+    timeout_seconds = max(MIN_TIMEOUT_SECONDS, min(MAX_TIMEOUT_SECONDS, timeout_seconds))
+
+    context = str(body.get("context") or "").strip()[:MAX_CONTEXT_CHARS]
+    query = str(body.get("query") or "").strip()
+
+    return VerifyRequest(
+        cluster=cluster,
+        workload=workload,
+        kind=kind,
+        namespace=namespace,
+        timeout_seconds=timeout_seconds,
+        context=context,
+        dry_run=bool(body.get("dry_run")),
+        query=query,
+    )
+
+
+def _default_timeout() -> int:
+    try:
+        return int(os.environ.get("KUBENTLY_VERIFY_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
+    except ValueError:
+        return DEFAULT_TIMEOUT_SECONDS
+
+
+# --- settle watch -----------------------------------------------------------
+#
+# `kubectl rollout status --watch=false` prints the current state and exits, so
+# the executor is never blocked holding a watch (COMMAND_TIMEOUT is 30s). The
+# API polls it until the rollout reports done, fails its progress deadline, or
+# our own deadline passes. The agent investigation runs in every case — a
+# rollout that never settled is exactly when the evidence matters — but the
+# settle outcome is put in the prompt so the verdict reflects it.
+
+SETTLE_COMPLETE = "complete"
+SETTLE_FAILED = "failed"
+SETTLE_TIMEOUT = "timeout"
+
+POLL_SECONDS = 15
+_MAX_CONSECUTIVE_ERRORS = 3
+
+DONE = "done"
+FAILED = "failed"
+PENDING = "pending"
+
+
+def classify_rollout(output: str | None, error: str | None) -> str:
+    """One `rollout status --watch=false` observation -> done/failed/pending."""
+    text = (output or "").strip()
+    if "successfully rolled out" in text or re.search(r"roll out complete", text):
+        return DONE
+    lowered = f"{text} {(error or '')}".lower()
+    if "not found" in lowered or "progress deadline" in lowered:
+        return FAILED
+    if error:
+        # Transport/executor errors are retried by the caller, which stops
+        # after a few in a row; a single blip is still "pending".
+        return PENDING
+    return PENDING
+
+
+async def _rollout_status_once(req: VerifyRequest, api_url: str, api_key: str) -> tuple:
+    """Returns (output, error) from one rollout-status observation."""
+    payload = {
+        "cluster_id": req.cluster,
+        "command_type": "rollout",
+        "args": ["status", f"{req.kind}/{req.workload}", "--watch=false"],
+        "namespace": req.namespace,
+        "timeout_seconds": 30,
+    }
+    async with httpx.AsyncClient(timeout=40.0) as client:
+        resp = await client.post(
+            f"{api_url}/debug/execute", headers={"X-Api-Key": api_key}, json=payload
+        )
+    if resp.status_code != 200:
+        return None, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    result = resp.json()
+    if result.get("error") or (result.get("status") and result["status"] != "success"):
+        return result.get("output"), result.get("error") or f"status: {result.get('status')}"
+    return result.get("output") or "", None
+
+
+async def wait_for_settle(req: VerifyRequest, poll_seconds: int = POLL_SECONDS) -> tuple[str, str]:
+    """Poll rollout status until it settles. Returns (outcome, last observation)."""
+    from kubently.modules.auth import AuthModule
+
+    api_url = os.getenv("KUBENTLY_API_URL", "http://localhost:8080")
+    api_key = AuthModule.extract_first_api_key()
+
+    deadline = asyncio.get_running_loop().time() + req.timeout_seconds
+    consecutive_errors = 0
+    last = "no rollout status observed"
+    while True:
+        try:
+            output, error = await _rollout_status_once(req, api_url, api_key)
+        except Exception as e:  # network to our own API; transient
+            output, error = None, str(e)
+        state = classify_rollout(output, error)
+        if output or error:
+            last = (output or error or "").strip()
+        if state == DONE:
+            return SETTLE_COMPLETE, last
+        if state == FAILED:
+            return SETTLE_FAILED, last
+        consecutive_errors = consecutive_errors + 1 if error else 0
+        if consecutive_errors >= _MAX_CONSECUTIVE_ERRORS:
+            return SETTLE_FAILED, f"could not observe rollout status: {last}"
+        if asyncio.get_running_loop().time() + poll_seconds > deadline:
+            return SETTLE_TIMEOUT, last
+        await asyncio.sleep(poll_seconds)
+
+
+# --- investigation ----------------------------------------------------------
+
+
+def build_query(req: VerifyRequest, settle_outcome: str, settle_detail: str) -> str:
+    """The post-deploy investigation the agent actually runs."""
+    target = f"{req.kind}/{req.workload} in namespace {req.namespace} on cluster {req.cluster}"
+    if settle_outcome == SETTLE_COMPLETE:
+        lead = f"The rollout of {target} just completed ({settle_detail})."
+    elif settle_outcome == SETTLE_TIMEOUT:
+        lead = (
+            f"The rollout of {target} did NOT settle within {req.timeout_seconds}s. "
+            f"Last observed status: {settle_detail}. Find out why it is stuck."
+        )
+    else:
+        lead = (
+            f"The rollout of {target} failed to complete. "
+            f"Last observed status: {settle_detail}. Find out what went wrong."
+        )
+    parts = [
+        lead,
+        "Verify this deployment is actually healthy — do not take the rollout "
+        "status at face value:",
+        "1. Are all its pods Ready, with no restarts or waiting states "
+        "(CrashLoopBackOff, ImagePullBackOff, CreateContainerConfigError)?",
+        "2. Any Warning events for the workload or its pods since the rollout?",
+        "3. Any errors, panics or stack traces in the new pods' logs? Use the "
+        "log search tools if available.",
+        "4. If a Prometheus tool is available, compare the workload's error "
+        "rate, latency and restart metrics for the last 15 minutes against the "
+        "30 minutes before the rollout; call out regressions.",
+        "5. If a recent-changes tool is available, confirm what changed in "
+        "this rollout and mention it in the evidence.",
+        "Skip any numbered step whose tool is not available — do not guess at "
+        "data you cannot fetch.",
+    ]
+    if req.context:
+        parts.append(f"Deploy context from the caller: {req.context}")
+    if req.query:
+        parts.append(f"Additional caller instructions: {req.query}")
+    parts.append(VERDICT_INSTRUCTIONS)
+    parts.append(SLACK_MRKDWN_INSTRUCTIONS)
+    return "\n\n".join(parts)
+
+
+def format_slack_message(req: VerifyRequest, verdict: str, body: str) -> dict:
+    from .fleet_report import to_slack_mrkdwn
+
+    header = (
+        f"{verdict_emoji(verdict)} *Deploy verification {verdict_label(verdict)}* — "
+        f"`{req.kind}/{req.workload}` in `{req.namespace}` on `{req.cluster}`"
+    )
+    if req.context:
+        header += f" ({req.context})"
+    return {"text": f"{header}\n\n{to_slack_mrkdwn(body)}"}
+
+
+async def _run_verification(agent_factory, req: VerifyRequest) -> tuple[str, str]:
+    """Settle-watch + agent investigation. Returns (verdict, body)."""
+    from kubently.modules.mcp import tools
+
+    settle_outcome, settle_detail = await wait_for_settle(req)
+    query = build_query(req, settle_outcome, settle_detail)
+    result = await tools.ask_kubently(agent_factory(), query, req.cluster, None)
+    verdict, body = parse_verdict(result["answer"])
+    # The agent's verdict cannot overrule an unsettled rollout: a PASS from
+    # "pods look fine" while the rollout is stuck would be a false all-clear.
+    if settle_outcome != SETTLE_COMPLETE and verdict == verdicts.PASS:
+        verdict = verdicts.FAIL
+        body = f"(rollout did not settle: {settle_detail})\n\n{body}"
+    return verdict, body
+
+
+async def _post_slack(slack_url: str, message: dict) -> None:
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(slack_url, json=message)
+        resp.raise_for_status()
+
+
+async def _verify_and_post(agent_factory, req: VerifyRequest, slack_url: str) -> None:
+    try:
+        verdict, body = await _run_verification(agent_factory, req)
+        await _post_slack(slack_url, format_slack_message(req, verdict, body))
+        logger.info(
+            "Posted deploy verification (%s) for %s/%s to Slack",
+            verdict,
+            req.cluster,
+            req.workload,
+        )
+    except Exception:
+        logger.exception("Deploy verification failed for %s/%s", req.cluster, req.workload)
+
+
+# --- optional deploy watch --------------------------------------------------
+#
+# Poll registered clusters for labelled workloads whose .metadata.generation
+# moved, and fire the same verification. Generation only changes on spec
+# changes (not scale-status churn), which is exactly "a deploy happened".
+# First sight of a workload records a baseline and does not verify — enabling
+# the label on an old deployment must not trigger a verification storm.
+
+_WATCH_JSONPATH = (
+    r'{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}'
+    r'{.metadata.generation}{"\n"}{end}'
+)
+
+
+def parse_watch_output(output: str) -> list[tuple[str, str, int]]:
+    """Parse the jsonpath sweep output into (namespace, name, generation)."""
+    rows = []
+    for line in (output or "").splitlines():
+        parts = line.split()
+        if len(parts) != 3:
+            continue
+        ns, name, gen = parts
+        try:
+            rows.append((ns, name, int(gen)))
+        except ValueError:
+            continue
+    return rows
+
+
+async def _sweep_cluster(cluster: str, kind: str, api_url: str, api_key: str) -> list:
+    payload = {
+        "cluster_id": cluster,
+        "command_type": "get",
+        "args": [f"{kind}s", "-A", "-l", WATCH_LABEL, "-o", f"jsonpath={_WATCH_JSONPATH}"],
+        "namespace": None,
+        "timeout_seconds": 30,
+    }
+    async with httpx.AsyncClient(timeout=40.0) as client:
+        resp = await client.post(
+            f"{api_url}/debug/execute", headers={"X-Api-Key": api_key}, json=payload
+        )
+    if resp.status_code != 200:
+        return []
+    result = resp.json()
+    if result.get("error") or (result.get("status") and result["status"] != "success"):
+        return []
+    return parse_watch_output(result.get("output") or "")
+
+
+async def _watch_clusters(redis_client) -> list[str]:
+    configured = [
+        c.strip()
+        for c in os.environ.get("KUBENTLY_VERIFY_WATCH_CLUSTERS", "").split(",")
+        if c.strip()
+    ]
+    if configured:
+        return configured
+    if redis_client is None:
+        return []
+    keys = await redis_client.keys("executor:token:*")
+    out = []
+    for key in keys:
+        raw = key.decode() if isinstance(key, bytes) else key
+        out.append(raw.replace("executor:token:", ""))
+    return sorted(out)
+
+
+async def _watch_loop(agent_factory, redis_client, interval: int, spawn) -> None:
+    """spawn(req) schedules a verification; injected so tests can observe it."""
+    from kubently.modules.auth import AuthModule
+
+    api_url = os.getenv("KUBENTLY_API_URL", "http://localhost:8080")
+    seen: dict[tuple, int] = {}
+    while True:
+        try:
+            api_key = AuthModule.extract_first_api_key()
+            for cluster in await _watch_clusters(redis_client):
+                for kind in KINDS:
+                    for ns, name, gen in await _sweep_cluster(cluster, kind, api_url, api_key):
+                        key = (cluster, kind, ns, name)
+                        prev = seen.get(key)
+                        seen[key] = gen
+                        if prev is not None and gen > prev:
+                            logger.info(
+                                "Deploy watch: %s %s/%s on %s generation %d -> %d; verifying",
+                                kind,
+                                ns,
+                                name,
+                                cluster,
+                                prev,
+                                gen,
+                            )
+                            spawn(
+                                VerifyRequest(
+                                    cluster=cluster,
+                                    workload=name,
+                                    kind=kind,
+                                    namespace=ns,
+                                    timeout_seconds=_default_timeout(),
+                                    context=f"detected via {WATCH_LABEL} label",
+                                )
+                            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Deploy watch sweep failed; retrying next interval")
+        await asyncio.sleep(interval)
+
+
+def start_annotation_watch(agent_factory, redis_client) -> asyncio.Task | None:
+    """Start the label-driven deploy watch if configured (returns the task).
+
+    Enabled by KUBENTLY_VERIFY_WATCH_SECONDS > 0. Requires SLACK_WEBHOOK_URL —
+    a watch-triggered verification has no caller to return a dry run to.
+    """
+    try:
+        interval = int(os.environ.get("KUBENTLY_VERIFY_WATCH_SECONDS", "0"))
+    except ValueError:
+        interval = 0
+    if interval <= 0:
+        return None
+    slack_url = os.environ.get("SLACK_WEBHOOK_URL")
+    if not slack_url:
+        logger.warning("Deploy watch enabled but SLACK_WEBHOOK_URL is not set; watch disabled")
+        return None
+
+    def spawn(req: VerifyRequest) -> None:
+        task = asyncio.create_task(_verify_and_post(agent_factory, req, slack_url))
+        _background.add(task)
+        task.add_done_callback(_background.discard)
+
+    task = asyncio.create_task(_watch_loop(agent_factory, redis_client, max(interval, 15), spawn))
+    _background.add(task)
+    task.add_done_callback(_background.discard)
+    logger.info("Deploy watch started (every %ds, label %s)", max(interval, 15), WATCH_LABEL)
+    return task
+
+
+# --- router -----------------------------------------------------------------
+
+
+def create_router(verify_api_key, redis_client=None) -> APIRouter:
+    """Router factory. The agent (and its heavy langchain import) is only touched
+    once a verification actually runs, so the API boots without the a2a stack."""
+    router = APIRouter()
+    state: dict = {"agent": None}
+
+    def _agent():
+        if state["agent"] is None:
+            from kubently.modules.a2a.protocol_bindings.a2a_server.agent import KubentlyAgent
+
+            state["agent"] = KubentlyAgent(redis_client=redis_client)
+        return state["agent"]
+
+    start_annotation_watch(_agent, redis_client)
+
+    @router.post("/webhooks/verify-deployment")
+    async def verify_deployment(request: Request, auth=Depends(verify_api_key)):
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        try:
+            req = parse_request(body)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+
+        if req.dry_run:
+            # Synchronous: the caller wants to read the verdict. No
+            # SLACK_WEBHOOK_URL requirement — a dry run never posts.
+            verdict, answer_body = await _run_verification(_agent, req)
+            return {
+                "dryRun": True,
+                "cluster": req.cluster,
+                "workload": f"{req.kind}/{req.workload}",
+                "namespace": req.namespace,
+                "verdict": verdict,
+                "answer": answer_body,
+            }
+
+        slack_url = os.environ.get("SLACK_WEBHOOK_URL")
+        if not slack_url:
+            raise HTTPException(503, "SLACK_WEBHOOK_URL is not configured")
+        task = asyncio.create_task(_verify_and_post(_agent, req, slack_url))
+        _background.add(task)
+        task.add_done_callback(_background.discard)
+        return JSONResponse(
+            status_code=202,
+            content={
+                "accepted": True,
+                "cluster": req.cluster,
+                "workload": f"{req.kind}/{req.workload}",
+                "namespace": req.namespace,
+                "timeoutSeconds": req.timeout_seconds,
+            },
+        )
+
+    return router

--- a/tests/test_scheduled_checks.py
+++ b/tests/test_scheduled_checks.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Unit tests for the named scheduled checks endpoint + config validation."""
+
+import asyncio
+import os
+import sys
+import textwrap
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.webhook import scheduled_checks as sc
+from kubently.modules.webhook.scheduled_checks import (
+    Check,
+    build_query,
+    create_router,
+    format_slack_message,
+    load_checks,
+    should_post,
+    validate_check,
+)
+
+GOOD = {
+    "name": "cert-expiry",
+    "schedule": "0 8 * * 1",
+    "prompt": "Check TLS secrets for certificates expiring within 21 days.",
+}
+
+
+# --- config validation ------------------------------------------------------
+
+
+def test_validate_minimal_check():
+    check = validate_check(GOOD)
+    assert check.name == "cert-expiry"
+    assert check.schedule == "0 8 * * 1"
+    assert check.clusters == []
+    assert check.notify_on_pass is False
+    assert check.suspend is False
+
+
+def test_validate_full_check():
+    check = validate_check(
+        {**GOOD, "clusters": ["prod-east", "prod-west"], "notifyOnPass": True, "suspend": True}
+    )
+    assert check.clusters == ["prod-east", "prod-west"]
+    assert check.notify_on_pass is True
+    assert check.suspend is True
+
+
+def test_validate_notify_on_pass_inherits_global_default():
+    assert validate_check(GOOD, default_notify_on_pass=True).notify_on_pass is True
+    # explicit per-check value beats the global default
+    assert (
+        validate_check({**GOOD, "notifyOnPass": False}, default_notify_on_pass=True).notify_on_pass
+        is False
+    )
+
+
+def test_validate_missing_name():
+    with pytest.raises(ValueError, match="missing 'name'"):
+        validate_check({k: v for k, v in GOOD.items() if k != "name"})
+
+
+def test_validate_bad_names():
+    for bad in ("Has-Caps", "under_score", "-leading", "x" * 40, "sp ace"):
+        with pytest.raises(ValueError, match="name"):
+            validate_check({**GOOD, "name": bad})
+
+
+def test_validate_missing_schedule():
+    with pytest.raises(ValueError, match="missing 'schedule'"):
+        validate_check({k: v for k, v in GOOD.items() if k != "schedule"})
+
+
+def test_validate_bad_cron():
+    for bad in ("hourly", "0 8 * *", "0 8 * * 1 2026"):
+        with pytest.raises(ValueError, match="cron"):
+            validate_check({**GOOD, "schedule": bad})
+
+
+def test_validate_missing_prompt():
+    with pytest.raises(ValueError, match="missing 'prompt'"):
+        validate_check({**GOOD, "prompt": "   "})
+
+
+def test_validate_bad_clusters():
+    with pytest.raises(ValueError, match="must be a list"):
+        validate_check({**GOOD, "clusters": "prod-east"})
+    with pytest.raises(ValueError, match="invalid cluster id"):
+        validate_check({**GOOD, "clusters": ["ok", "bad cluster"]})
+
+
+def test_validate_non_mapping_entry():
+    with pytest.raises(ValueError, match="mapping"):
+        validate_check(["not", "a", "dict"])
+
+
+def _write_checks(tmp_path, content):
+    path = tmp_path / "checks.yaml"
+    path.write_text(textwrap.dedent(content))
+    return str(path)
+
+
+def test_load_checks_file(tmp_path):
+    path = _write_checks(
+        tmp_path,
+        """
+        notifyOnPass: false
+        checks:
+          - name: cert-expiry
+            schedule: "0 8 * * 1"
+            prompt: Check certs.
+          - name: pvc-usage
+            schedule: "0 */6 * * *"
+            clusters: [prod-east]
+            notifyOnPass: true
+            prompt: Check PVC usage above 85%.
+        """,
+    )
+    checks = load_checks(path)
+    assert set(checks) == {"cert-expiry", "pvc-usage"}
+    assert checks["pvc-usage"].notify_on_pass is True
+    assert checks["pvc-usage"].clusters == ["prod-east"]
+
+
+def test_load_checks_missing_file_is_empty(tmp_path):
+    assert load_checks(str(tmp_path / "nope.yaml")) == {}
+
+
+def test_load_checks_duplicate_names(tmp_path):
+    path = _write_checks(
+        tmp_path,
+        """
+        checks:
+          - {name: dup, schedule: "0 8 * * 1", prompt: a}
+          - {name: dup, schedule: "0 9 * * 1", prompt: b}
+        """,
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        load_checks(path)
+
+
+def test_load_checks_rejects_any_bad_entry(tmp_path):
+    """All-or-nothing: a misspelled check must not silently vanish."""
+    path = _write_checks(
+        tmp_path,
+        """
+        checks:
+          - {name: good, schedule: "0 8 * * 1", prompt: fine}
+          - {name: bad, prompt: no schedule here}
+        """,
+    )
+    with pytest.raises(ValueError, match="'bad'"):
+        load_checks(path)
+
+
+def test_load_checks_env_var(tmp_path, monkeypatch):
+    path = _write_checks(tmp_path, 'checks:\n  - {name: x, schedule: "0 8 * * 1", prompt: p}\n')
+    monkeypatch.setenv("KUBENTLY_CHECKS_FILE", path)
+    assert set(load_checks()) == {"x"}
+
+
+# --- query + noise discipline -----------------------------------------------
+
+
+def _check(**kw):
+    defaults = dict(name="cert-expiry", schedule="0 8 * * 1", prompt="Check certs.")
+    defaults.update(kw)
+    return Check(**defaults)
+
+
+def test_build_query_targets_clusters():
+    assert "Investigate every registered cluster." in build_query(_check())
+    assert "Investigate cluster prod-east only." in build_query(_check(clusters=["prod-east"]))
+    q = build_query(_check(clusters=["a", "b"]))
+    assert "Investigate only these clusters: a, b." in q
+
+
+def test_build_query_carries_prompt_and_verdict_contract():
+    q = build_query(_check())
+    assert "Check certs." in q
+    assert "VERDICT: PASS" in q and "VERDICT: FAIL" in q
+    assert "Slack mrkdwn" in q
+
+
+def test_should_post_matrix():
+    quiet = _check()
+    loud = _check(notify_on_pass=True)
+    assert should_post("pass", quiet) is False  # the noise discipline
+    assert should_post("pass", loud) is True
+    assert should_post("fail", quiet) is True
+    assert should_post("fail", loud) is True
+    assert should_post("unknown", quiet) is True  # unreadable verdict never mutes
+
+
+def test_format_slack_message():
+    msg = format_slack_message(_check(), "fail", "**3 certs** expire in 5 days")
+    assert msg["text"].startswith(":x: *Scheduled check `cert-expiry`: FAIL*")
+    assert "**" not in msg["text"]  # mrkdwn normalised
+
+
+# --- endpoint ---------------------------------------------------------------
+
+
+def _client(monkeypatch, tmp_path, verdict="pass", body="fine", posts=None):
+    path = _write_checks(
+        tmp_path,
+        """
+        checks:
+          - name: cert-expiry
+            schedule: "0 8 * * 1"
+            prompt: Check certs.
+          - name: loud-check
+            schedule: "0 9 * * 1"
+            notifyOnPass: true
+            prompt: Check stuff loudly.
+        """,
+    )
+    monkeypatch.setenv("KUBENTLY_CHECKS_FILE", path)
+
+    async def fake_run_check(agent_factory, check, prompt_override=None):
+        return verdict, f"{body} [prompt={(prompt_override or check.prompt)[:60]}]"
+
+    async def fake_post_slack(slack_url, message):
+        if posts is not None:
+            posts.append((slack_url, message))
+
+    monkeypatch.setattr(sc, "_run_check", fake_run_check)
+    monkeypatch.setattr(sc, "_post_slack", fake_post_slack)
+
+    app = FastAPI()
+    app.include_router(create_router(lambda: True))
+    return TestClient(app)
+
+
+def test_endpoint_unknown_check_404(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    resp = client.post("/webhooks/scheduled-check", json={"check": "nope"})
+    assert resp.status_code == 404
+    assert "cert-expiry" in resp.json()["detail"]  # tells you what IS configured
+
+
+def test_endpoint_missing_check_field_400(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    assert client.post("/webhooks/scheduled-check", json={}).status_code == 400
+
+
+def test_endpoint_invalid_config_500(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    bad = tmp_path / "bad-checks.yaml"
+    bad.write_text("checks:\n  - {name: x}\n")
+    monkeypatch.setenv("KUBENTLY_CHECKS_FILE", str(bad))
+    resp = client.post("/webhooks/scheduled-check", json={"check": "x"})
+    assert resp.status_code == 500
+    assert "invalid" in resp.json()["detail"]
+
+
+def test_endpoint_pass_posts_nothing(monkeypatch, tmp_path):
+    """The noise discipline, end to end: green check -> silent channel."""
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/x")
+    posts = []
+    client = _client(monkeypatch, tmp_path, verdict="pass", posts=posts)
+    resp = client.post("/webhooks/scheduled-check", json={"check": "cert-expiry"})
+    assert resp.status_code == 202
+    assert posts == []
+
+
+def test_endpoint_pass_posts_when_opted_in(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/x")
+    posts = []
+    client = _client(monkeypatch, tmp_path, verdict="pass", posts=posts)
+    resp = client.post("/webhooks/scheduled-check", json={"check": "loud-check"})
+    assert resp.status_code == 202
+    assert len(posts) == 1
+    assert "PASS" in posts[0][1]["text"]
+
+
+def test_endpoint_fail_posts_with_evidence(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/x")
+    posts = []
+    client = _client(monkeypatch, tmp_path, verdict="fail", body="3 certs expiring", posts=posts)
+    resp = client.post("/webhooks/scheduled-check", json={"check": "cert-expiry"})
+    assert resp.status_code == 202
+    assert len(posts) == 1
+    assert "FAIL" in posts[0][1]["text"]
+    assert "3 certs expiring" in posts[0][1]["text"]
+
+
+def test_endpoint_unknown_verdict_posts(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/x")
+    posts = []
+    client = _client(monkeypatch, tmp_path, verdict="unknown", posts=posts)
+    client.post("/webhooks/scheduled-check", json={"check": "cert-expiry"})
+    assert len(posts) == 1
+
+
+def test_endpoint_requires_slack_url(monkeypatch, tmp_path):
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    client = _client(monkeypatch, tmp_path)
+    assert client.post("/webhooks/scheduled-check", json={"check": "cert-expiry"}).status_code == 503
+
+
+def test_endpoint_dry_run_reports_would_post(monkeypatch, tmp_path):
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    posts = []
+    client = _client(monkeypatch, tmp_path, verdict="pass", posts=posts)
+    resp = client.post("/webhooks/scheduled-check", json={"check": "cert-expiry", "dry_run": True})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["dryRun"] is True
+    assert data["verdict"] == "pass"
+    assert data["wouldPost"] is False  # quiet check: a pass would not have posted
+    assert posts == []
+
+
+def test_endpoint_dry_run_prompt_override(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    resp = client.post(
+        "/webhooks/scheduled-check",
+        json={"check": "cert-expiry", "dry_run": True, "prompt": "only check kube-system"},
+    )
+    assert "only check kube-system" in resp.json()["answer"]

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Unit tests for the shared proactive-verdict parsing."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.webhook.verdict import (
+    FAIL,
+    PASS,
+    UNKNOWN,
+    parse_verdict,
+    verdict_emoji,
+    verdict_label,
+)
+
+
+def test_parse_pass():
+    verdict, body = parse_verdict("VERDICT: PASS\n\nAll 3 pods Ready, no warnings.")
+    assert verdict == PASS
+    assert body == "All 3 pods Ready, no warnings."
+    assert "VERDICT" not in body
+
+
+def test_parse_fail():
+    verdict, body = parse_verdict("VERDICT: FAIL\n\n• `api-7f9` CrashLoopBackOff")
+    assert verdict == FAIL
+    assert "CrashLoopBackOff" in body
+
+
+def test_parse_is_case_insensitive():
+    assert parse_verdict("verdict: pass\nok")[0] == PASS
+    assert parse_verdict("Verdict: Fail\nbad")[0] == FAIL
+
+
+def test_parse_tolerates_model_decoration():
+    """Models bold/bullet the marker despite instructions; still a verdict."""
+    assert parse_verdict("*VERDICT: PASS*\n\nfine")[0] == PASS
+    assert parse_verdict("**VERDICT: FAIL**\n\nbad")[0] == FAIL
+    assert parse_verdict("- VERDICT: PASS")[0] == PASS
+
+
+def test_parse_tolerates_short_preamble():
+    text = "Here is my assessment.\nVERDICT: FAIL\n\npod is down"
+    verdict, body = parse_verdict(text)
+    assert verdict == FAIL
+    assert "Here is my assessment." in body
+    assert "VERDICT" not in body
+
+
+def test_missing_marker_is_unknown_not_pass():
+    """Fail-safe: an unreadable verdict must never suppress a notification."""
+    verdict, body = parse_verdict("Everything looks great, no problems at all!")
+    assert verdict == UNKNOWN
+    assert body == "Everything looks great, no problems at all!"
+
+
+def test_marker_deep_in_body_is_not_a_verdict():
+    """A verdict quoted mid-explanation (beyond the scan window) doesn't count."""
+    text = "\n".join(["line"] * 10 + ["VERDICT: PASS"])
+    assert parse_verdict(text)[0] == UNKNOWN
+
+
+def test_empty_answer_is_unknown():
+    assert parse_verdict("")[0] == UNKNOWN
+    assert parse_verdict(None)[0] == UNKNOWN
+
+
+def test_prose_containing_the_word_verdict_is_not_a_marker():
+    assert parse_verdict("The verdict: passing this to the team.")[0] == UNKNOWN
+
+
+def test_emoji_and_label():
+    assert verdict_emoji(PASS) == ":white_check_mark:"
+    assert verdict_emoji(FAIL) == ":x:"
+    assert verdict_emoji(UNKNOWN) == ":warning:"
+    assert verdict_label(PASS) == "PASS"
+    assert verdict_label(FAIL) == "FAIL"
+    assert verdict_label(UNKNOWN) == "UNKNOWN"

--- a/tests/test_verify_deployment.py
+++ b/tests/test_verify_deployment.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Unit tests for the deployment verification webhook."""
+
+import asyncio
+import os
+import sys
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.webhook import verify_deployment as vd
+from kubently.modules.webhook.verify_deployment import (
+    DONE,
+    FAILED,
+    PENDING,
+    SETTLE_COMPLETE,
+    SETTLE_FAILED,
+    SETTLE_TIMEOUT,
+    VerifyRequest,
+    build_query,
+    classify_rollout,
+    create_router,
+    format_slack_message,
+    parse_request,
+    parse_watch_output,
+)
+
+# --- trigger parsing --------------------------------------------------------
+
+
+def test_parse_minimal_request():
+    req = parse_request({"cluster": "prod-east", "workload": "checkout-api"})
+    assert req.cluster == "prod-east"
+    assert req.workload == "checkout-api"
+    assert req.kind == "deployment"
+    assert req.namespace == "default"
+    assert req.dry_run is False
+
+
+def test_parse_kind_prefix_forms():
+    assert parse_request({"cluster": "c", "workload": "deploy/api"}).kind == "deployment"
+    assert parse_request({"cluster": "c", "workload": "deployment/api"}).kind == "deployment"
+    assert parse_request({"cluster": "c", "workload": "sts/db"}).kind == "statefulset"
+    assert parse_request({"cluster": "c", "workload": "ds/agent"}).kind == "daemonset"
+    req = parse_request({"cluster": "c", "workload": "statefulsets/db"})
+    assert (req.kind, req.workload) == ("statefulset", "db")
+
+
+def test_parse_explicit_kind_field():
+    req = parse_request({"cluster": "c", "workload": "db", "kind": "statefulset"})
+    assert req.kind == "statefulset"
+
+
+def test_parse_kind_contradiction_rejected():
+    with pytest.raises(ValueError, match="contradicts"):
+        parse_request({"cluster": "c", "workload": "deploy/api", "kind": "daemonset"})
+
+
+def test_parse_agreeing_kind_and_prefix_ok():
+    req = parse_request({"cluster": "c", "workload": "deploy/api", "kind": "deployment"})
+    assert req.workload == "api"
+
+
+def test_parse_missing_cluster():
+    with pytest.raises(ValueError, match="'cluster' is required"):
+        parse_request({"workload": "api"})
+
+
+def test_parse_missing_workload():
+    with pytest.raises(ValueError, match="'workload' is required"):
+        parse_request({"cluster": "c"})
+
+
+def test_parse_bad_kind():
+    with pytest.raises(ValueError, match="'kind' must be one of"):
+        parse_request({"cluster": "c", "workload": "cronjob/x"})
+
+
+def test_parse_rejects_shell_metacharacters():
+    """Workload/namespace go into kubectl args; only DNS-1123 names pass."""
+    for bad in ("api;rm -rf /", "api pod", "API", "a/b/c", "-api"):
+        with pytest.raises(ValueError):
+            parse_request({"cluster": "c", "workload": bad})
+    with pytest.raises(ValueError, match="namespace"):
+        parse_request({"cluster": "c", "workload": "api", "namespace": "ns$(x)"})
+    with pytest.raises(ValueError, match="cluster"):
+        parse_request({"cluster": "c luster", "workload": "api"})
+
+
+def test_parse_timeout_clamped():
+    lo = parse_request({"cluster": "c", "workload": "api", "timeout_seconds": 5})
+    hi = parse_request({"cluster": "c", "workload": "api", "timeout_seconds": 999999})
+    assert lo.timeout_seconds == vd.MIN_TIMEOUT_SECONDS
+    assert hi.timeout_seconds == vd.MAX_TIMEOUT_SECONDS
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        parse_request({"cluster": "c", "workload": "api", "timeout_seconds": "soon"})
+
+
+def test_parse_context_truncated():
+    req = parse_request({"cluster": "c", "workload": "api", "context": "x" * 500})
+    assert len(req.context) == vd.MAX_CONTEXT_CHARS
+
+
+def test_parse_non_dict_body():
+    with pytest.raises(ValueError, match="JSON object"):
+        parse_request(["nope"])
+
+
+# --- rollout classification -------------------------------------------------
+
+
+def test_classify_rollout_done():
+    assert classify_rollout('deployment "api" successfully rolled out', None) == DONE
+
+
+def test_classify_rollout_pending():
+    out = 'Waiting for deployment "api" rollout to finish: 1 of 3 updated replicas are available...'
+    assert classify_rollout(out, None) == PENDING
+    assert classify_rollout("", None) == PENDING
+
+
+def test_classify_rollout_failed():
+    assert classify_rollout(None, 'deployments.apps "api" not found') == FAILED
+    assert classify_rollout('error: deployment "api" exceeded its progress deadline', None) == FAILED
+
+
+def test_classify_transport_error_is_pending():
+    """A single executor blip must not end the settle-watch."""
+    assert classify_rollout(None, "HTTP 408: timeout waiting for executor") == PENDING
+
+
+# --- settle watch -----------------------------------------------------------
+
+
+def _req(**kw):
+    defaults = dict(cluster="c", workload="api", timeout_seconds=600)
+    defaults.update(kw)
+    return VerifyRequest(**defaults)
+
+
+def _run_settle(monkeypatch, observations, timeout_seconds=600):
+    """Drive wait_for_settle over a scripted sequence of (output, error)."""
+    monkeypatch.setenv("API_KEYS", "test-service:test-key")
+    seq = iter(observations)
+
+    async def fake_status(req, api_url, api_key):
+        try:
+            return next(seq)
+        except StopIteration:
+            return "", None  # pending forever
+
+    monkeypatch.setattr(vd, "_rollout_status_once", fake_status)
+    return asyncio.run(vd.wait_for_settle(_req(timeout_seconds=timeout_seconds), poll_seconds=0))
+
+
+def test_settle_completes(monkeypatch):
+    outcome, last = _run_settle(
+        monkeypatch,
+        [
+            ("Waiting for deployment rollout: 1 of 3", None),
+            ('deployment "api" successfully rolled out', None),
+        ],
+    )
+    assert outcome == SETTLE_COMPLETE
+    assert "successfully rolled out" in last
+
+
+def test_settle_fails_on_terminal_error(monkeypatch):
+    outcome, last = _run_settle(monkeypatch, [(None, 'deployments.apps "api" not found')])
+    assert outcome == SETTLE_FAILED
+    assert "not found" in last
+
+
+def test_settle_times_out(monkeypatch):
+    outcome, _ = _run_settle(monkeypatch, [("waiting...", None)], timeout_seconds=0)
+    assert outcome == SETTLE_TIMEOUT
+
+
+def test_settle_tolerates_transient_errors_then_completes(monkeypatch):
+    outcome, _ = _run_settle(
+        monkeypatch,
+        [
+            (None, "HTTP 503: executor busy"),
+            (None, "HTTP 503: executor busy"),
+            ('deployment "api" successfully rolled out', None),
+        ],
+    )
+    assert outcome == SETTLE_COMPLETE
+
+
+def test_settle_gives_up_after_consecutive_errors(monkeypatch):
+    outcome, last = _run_settle(monkeypatch, [(None, "HTTP 503: boom")] * 5)
+    assert outcome == SETTLE_FAILED
+    assert "could not observe rollout status" in last
+
+
+# --- query + verdict interplay ----------------------------------------------
+
+
+def test_build_query_mentions_target_and_verdict_contract():
+    q = build_query(_req(namespace="payments", context="v1.2.3"), SETTLE_COMPLETE, "rolled out")
+    assert "deployment/api in namespace payments on cluster c" in q
+    assert "VERDICT: PASS" in q and "VERDICT: FAIL" in q
+    assert "v1.2.3" in q
+    assert "Prometheus" in q  # metrics regression step is in the brief
+
+
+def test_build_query_unsettled_rollout_changes_the_brief():
+    q = build_query(_req(), SETTLE_TIMEOUT, "1 of 3 available")
+    assert "did NOT settle" in q
+    assert "1 of 3 available" in q
+
+
+def test_agent_pass_cannot_overrule_unsettled_rollout(monkeypatch):
+    """PASS from 'pods look fine' while the rollout is stuck is a false all-clear."""
+
+    async def fake_settle(req, poll_seconds=vd.POLL_SECONDS):
+        return SETTLE_TIMEOUT, "stuck at 1 of 3"
+
+    async def fake_ask(agent, query, cluster_id, conversation_id):
+        return {"answer": "VERDICT: PASS\n\npods look fine", "thread_id": "t"}
+
+    monkeypatch.setattr(vd, "wait_for_settle", fake_settle)
+    from kubently.modules.mcp import tools
+
+    monkeypatch.setattr(tools, "ask_kubently", fake_ask)
+    verdict, body = asyncio.run(vd._run_verification(lambda: object(), _req()))
+    assert verdict == "fail"
+    assert "rollout did not settle" in body
+
+
+# --- verdict formatting -----------------------------------------------------
+
+
+def test_format_slack_message_pass():
+    msg = format_slack_message(_req(context="v2"), "pass", "All pods Ready.")
+    assert msg["text"].startswith(":white_check_mark: *Deploy verification PASS*")
+    assert "`deployment/api`" in msg["text"]
+    assert "(v2)" in msg["text"]
+    assert "All pods Ready." in msg["text"]
+
+
+def test_format_slack_message_fail_normalises_mrkdwn():
+    msg = format_slack_message(_req(), "fail", "**Root cause:** bad image")
+    assert msg["text"].startswith(":x: *Deploy verification FAIL*")
+    assert "**" not in msg["text"]
+
+
+def test_format_slack_message_unknown_is_warning():
+    msg = format_slack_message(_req(), "unknown", "no marker")
+    assert msg["text"].startswith(":warning: *Deploy verification UNKNOWN*")
+
+
+# --- endpoint ---------------------------------------------------------------
+
+
+def _client(monkeypatch, verdict="pass", body="ok", posts=None):
+    async def fake_run_verification(agent_factory, req):
+        return verdict, body
+
+    async def fake_verify_and_post(agent_factory, req, slack_url):
+        if posts is not None:
+            posts.append((slack_url, req))
+
+    monkeypatch.setattr(vd, "_run_verification", fake_run_verification)
+    monkeypatch.setattr(vd, "_verify_and_post", fake_verify_and_post)
+    monkeypatch.delenv("KUBENTLY_VERIFY_WATCH_SECONDS", raising=False)
+
+    app = FastAPI()
+    app.include_router(create_router(lambda: True))
+    return TestClient(app)
+
+
+def test_endpoint_acks_202_and_schedules_post(monkeypatch):
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/x")
+    posts = []
+    client = _client(monkeypatch, posts=posts)
+    resp = client.post(
+        "/webhooks/verify-deployment",
+        json={"cluster": "prod", "workload": "deploy/api", "namespace": "shop"},
+    )
+    assert resp.status_code == 202
+    assert resp.json()["workload"] == "deployment/api"
+    assert posts and posts[0][0] == "https://hooks.slack.test/x"
+    assert posts[0][1].namespace == "shop"
+
+
+def test_endpoint_requires_slack_url(monkeypatch):
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    client = _client(monkeypatch)
+    resp = client.post("/webhooks/verify-deployment", json={"cluster": "c", "workload": "api"})
+    assert resp.status_code == 503
+
+
+def test_endpoint_rejects_bad_payload(monkeypatch):
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/x")
+    client = _client(monkeypatch)
+    resp = client.post("/webhooks/verify-deployment", json={"workload": "api"})
+    assert resp.status_code == 400
+    assert "cluster" in resp.json()["detail"]
+
+
+def test_endpoint_dry_run_returns_verdict_and_posts_nothing(monkeypatch):
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    posts = []
+    client = _client(monkeypatch, verdict="fail", body="pod down", posts=posts)
+    resp = client.post(
+        "/webhooks/verify-deployment",
+        json={"cluster": "c", "workload": "api", "dry_run": True},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["dryRun"] is True
+    assert data["verdict"] == "fail"
+    assert data["answer"] == "pod down"
+    assert posts == []
+
+
+# --- deploy watch -----------------------------------------------------------
+
+
+def test_parse_watch_output():
+    out = "shop api 4\nshop worker 2\n\nbad line here extra\npayments db notanint\n"
+    assert parse_watch_output(out) == [("shop", "api", 4), ("shop", "worker", 2)]
+    assert parse_watch_output("") == []
+
+
+def test_watch_fires_only_on_generation_change(monkeypatch):
+    """First sweep records baselines (no storm on label-enable); a bumped
+    generation on a later sweep triggers exactly one verification."""
+    monkeypatch.setenv("API_KEYS", "test-service:test-key")
+    sweeps = [
+        [("shop", "api", 4)],  # baseline
+        [("shop", "api", 4)],  # unchanged
+        [("shop", "api", 5)],  # deploy happened
+    ]
+    calls = {"n": 0}
+    done = asyncio.Event()
+
+    async def fake_sweep(cluster, kind, api_url, api_key):
+        if kind != "deployment":
+            return []
+        if calls["n"] >= len(sweeps):
+            done.set()
+            return sweeps[-1]
+        result = sweeps[calls["n"]]
+        calls["n"] += 1
+        return result
+
+    async def fake_clusters(redis_client):
+        return ["prod"]
+
+    monkeypatch.setattr(vd, "_sweep_cluster", fake_sweep)
+    monkeypatch.setattr(vd, "_watch_clusters", fake_clusters)
+
+    spawned = []
+
+    async def run():
+        task = asyncio.create_task(
+            vd._watch_loop(lambda: object(), None, 0, spawned.append)
+        )
+        await asyncio.wait_for(done.wait(), timeout=5)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(run())
+    assert len(spawned) == 1
+    req = spawned[0]
+    assert (req.cluster, req.kind, req.namespace, req.workload) == (
+        "prod",
+        "deployment",
+        "shop",
+        "api",
+    )
+
+
+def test_watch_not_started_without_config(monkeypatch):
+    monkeypatch.delenv("KUBENTLY_VERIFY_WATCH_SECONDS", raising=False)
+    assert vd.start_annotation_watch(lambda: object(), None) is None
+
+
+def test_watch_not_started_without_slack(monkeypatch):
+    monkeypatch.setenv("KUBENTLY_VERIFY_WATCH_SECONDS", "60")
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    assert vd.start_annotation_watch(lambda: object(), None) is None


### PR DESCRIPTION
Track P5 (Roadmap Phase 5): Kubently stops being purely reactive.

- **Deployment verification**: `POST /webhooks/verify-deployment` (cluster/namespace/workload) watches the rollout settle, then runs a real agent investigation — pod health, events, error logs, metrics regressions when Prometheus is configured — and posts a pass/fail verdict with evidence to the configured Slack destination. Label-based trigger support alongside the webhook.
- **Scheduled checks**: named checks in Helm values/ConfigMap (schedule + target clusters + question prompt) run as per-check CronJobs reusing the fleet-report plumbing; dry-run supported.
- **Noise discipline**: passing scheduled checks post nothing by default (configurable); verifications always post; failures carry the evidence trail.
- Purely additive (~2,000 insertions, no modifications to toolsets/checkpointer/executor). Docs + Helm wiring included.
- Verified locally: 138 passed, 1 expected skip across verdict/verify/scheduled-check suites plus cloud-tools, change-correlation, and checkpointer regression files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX)_