### PR TITLE
Operator runbook ingestion: matched, capped, cited in the RCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 ## [Unreleased] - 2026-08-17
 
 ### Added
+- **Operator runbook ingestion (Track P6a)** — feed org-specific knowledge
+  into investigations. Hand-written markdown runbooks with lightweight YAML
+  frontmatter (`name` + `match` criteria: alert-name globs,
+  namespace/workload selectors, free-text topic tags) load from
+  `KUBENTLY_RUNBOOKS_DIR` (Helm: `runbooks` values map → ConfigMap mounted at
+  `/etc/kubently/runbooks`, default off). When an investigation — chat
+  question, Alertmanager alert, or A2A call — matches a runbook, the best
+  match(es) are injected as operator context ("follow it where applicable,
+  note deviations") with the RCA citing the runbook by name. Scored matching
+  (alert hit > selector hit > topic hit) with a size cap
+  (`KUBENTLY_RUNBOOKS_MAX_CHARS`, default 8000 chars): one complete best
+  match beats fragments of everything; an oversized best match is truncated,
+  not dropped. Directory rescans periodically (signature-checked, like the
+  executor command whitelist), so ConfigMap edits go live without a pod
+  restart. New module `kubently/modules/runbooks/`; per-thread dedup keeps
+  multi-turn conversations from accumulating duplicate copies
 - **Cloud telemetry access via workload identity (Track D1)** — the executor
   can now query cloud logs/metrics/audit trails from inside the customer's
   account with **zero stored credentials**: the pod assumes a

--- a/README.md
+++ b/README.md
@@ -174,6 +174,57 @@ vim deployment/helm/test-values.yaml
 helm install kubently deployment/helm -f deployment/helm/test-values.yaml
 ```
 
+### Operator Runbooks
+
+Feed your organization's tribal knowledge into investigations. Runbooks are
+hand-written markdown files with lightweight frontmatter; when an
+investigation (a chat question, an Alertmanager alert, or an A2A call)
+matches a runbook's criteria, the agent receives it as "the operator's
+runbook for this situation", follows it where applicable, notes deviations,
+and cites it by name in the diagnosis.
+
+A worked example:
+
+```markdown
+---
+name: Payments CrashLoopBackOff
+match:
+  alerts: ["KubePodCrashLooping", "PaymentsPod*"]   # alert-name globs
+  namespaces: ["payments", "payments-*"]            # namespace selectors
+  workloads: ["payment-api*"]                       # matches derived pod names too
+  topics: ["crashloop", "OOMKilled", "payment service"]  # free-text tags
+---
+1. Check recent deploys first: payment-api ships through ArgoCD, and 90% of
+   crashloops here follow a bad config sync.
+2. OOMKilled almost always means the JVM heap flag drifted from the container
+   memory limit — compare `-Xmx` against `resources.limits.memory` before
+   blaming traffic.
+3. If the DB connection pool is exhausted, do NOT restart the pods; escalate
+   to #payments-oncall (restarts thundering-herd the database).
+```
+
+Deploy runbooks as Helm values (they become a ConfigMap mounted into the API
+pod; edits go live without a pod restart):
+
+```yaml
+# production-values.yaml
+runbooks:
+  payments-crashloop.md: |
+    ---
+    name: Payments CrashLoopBackOff
+    match:
+      alerts: ["KubePodCrashLooping"]
+      namespaces: ["payments"]
+    ---
+    1. Check recent deploys first ...
+```
+
+Matching is scored: an alert-name hit outranks namespace/workload selector
+hits, which outrank topic hits. The best match is injected first, and the
+total injected size is capped (`KUBENTLY_RUNBOOKS_MAX_CHARS`, default 8000
+characters) — one complete, best-matching runbook beats fragments of many.
+Outside Helm, point `KUBENTLY_RUNBOOKS_DIR` at any directory of `.md` files.
+
 ## Architecture
 
 - **API Server**: FastAPI-based REST API for cluster management and authentication

--- a/deployment/helm/kubently/templates/api-deployment.yaml
+++ b/deployment/helm/kubently/templates/api-deployment.yaml
@@ -210,10 +210,19 @@ spec:
           value: "/etc/kubently/prompts/system.prompt.yaml"
         - name: KUBENTLY_FLEET_REPORT_PROMPT_FILE
           value: "/etc/kubently/prompts/fleet_report.prompt.yaml"
+        {{- if .Values.runbooks }}
+        - name: KUBENTLY_RUNBOOKS_DIR
+          value: "/etc/kubently/runbooks"
+        {{- end }}
         volumeMounts:
         - name: prompt-config
           mountPath: /etc/kubently/prompts
           readOnly: true
+        {{- if .Values.runbooks }}
+        - name: runbooks
+          mountPath: /etc/kubently/runbooks
+          readOnly: true
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -248,4 +257,9 @@ spec:
       - name: prompt-config
         configMap:
           name: {{ include "kubently.fullname" . }}-prompt
+      {{- if .Values.runbooks }}
+      - name: runbooks
+        configMap:
+          name: {{ include "kubently.fullname" . }}-runbooks
+      {{- end }}
 {{- end }}

--- a/deployment/helm/kubently/templates/api-runbooks-configmap.yaml
+++ b/deployment/helm/kubently/templates/api-runbooks-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.api.enabled .Values.runbooks }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kubently.fullname" . }}-runbooks
+  labels:
+    {{- include "kubently.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+data:
+{{- range $filename, $content := .Values.runbooks }}
+  {{ $filename }}: |
+{{ $content | indent 4 }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -90,6 +90,34 @@ fleetReport:
   query: ""
 
 # ============================================================================
+# Operator Runbooks (optional)
+# ============================================================================
+# Hand-written markdown runbooks the agent follows during matching
+# investigations. Each entry becomes a file in a ConfigMap mounted at
+# /etc/kubently/runbooks; when an investigation's text matches a runbook's
+# criteria (alert name patterns, namespace/workload selectors, topic tags),
+# the best match(es) are injected into the agent's context and cited by name
+# in the diagnosis. ConfigMap edits go live without a pod restart (kubelet
+# volume sync + periodic reload, like the executor command whitelist).
+#
+# Leave empty (default) to disable. Example:
+#   runbooks:
+#     payments-crashloop.md: |
+#       ---
+#       name: Payments CrashLoopBackOff
+#       match:
+#         alerts: ["KubePodCrashLooping"]
+#         namespaces: ["payments"]
+#         workloads: ["payment-api*"]
+#         topics: ["crashloop", "payment"]
+#       ---
+#       1. Check recent deploys first: payment-api ships through ArgoCD.
+#       2. OOMKilled here is almost always the JVM heap flag drifting from
+#          the container memory limit - compare both before blaming traffic.
+#       3. Escalate to #payments-oncall if the DB connection pool is the cause.
+runbooks: {}
+
+# ============================================================================
 # Loki Log Search (optional)
 # ============================================================================
 # Gives the diagnostic agent a read-only LogQL tool (query_loki) for searching

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -48,6 +48,22 @@
 | `KUBENTLY_MAX_FLEET_CLUSTERS` | `10` | No | Max clusters per `execute_kubectl_multi` fan-out call (each cluster adds up to ~4KB to the agent context) |
 | `A2A_SERVER_DEBUG` | `false` | No | Enable A2A debug logging |
 
+### Operator Runbooks (optional)
+
+The agent loads hand-written markdown runbooks (YAML frontmatter with `name`
+and `match` criteria: alert-name globs, namespace/workload selectors, topic
+tags) from a directory and injects the best match(es) into investigations
+whose text matches. In Helm deployments the directory is a ConfigMap built
+from the `runbooks` values map; the store rescans it periodically (mtime +
+size signature, like the executor command whitelist), so ConfigMap edits go
+live without a pod restart.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `KUBENTLY_RUNBOOKS_DIR` | `/etc/kubently/runbooks` | No | Directory of `*.md` runbooks. Missing directory = feature off. Set automatically by Helm when `runbooks` values are provided |
+| `KUBENTLY_RUNBOOKS_RELOAD_SECONDS` | `30` | No | Minimum seconds between directory rescans |
+| `KUBENTLY_RUNBOOKS_MAX_CHARS` | `8000` | No | Cap on total injected runbook characters per investigation. Best match packs first; an oversized best match is truncated rather than dropped |
+
 ### Loki Log Search (optional)
 
 When `LOKI_URL` is set on the API server, the agent registers the read-only `query_loki` tool (LogQL range queries) and injects Loki guidance into the system prompt. When unset (default), the tool does not exist and the prompt never mentions Loki. The selector-based `search_pod_logs` tool is always registered and needs no configuration.

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -51,6 +51,24 @@ def structured_log(log_data: dict, thread_id: str = None):
 _POSTHOG_CLIENT = None  # module-level singleton, see _posthog_llm_callbacks
 
 
+def _user_message_text(messages: list[dict]) -> str:
+    """Concatenated text of the user messages in an incoming turn.
+
+    This is what runbook matching runs against; it handles the same
+    multi-part content shape the LangChain conversion below does.
+    """
+    parts = []
+    for msg in messages:
+        if msg.get("role", "user") != "user":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(p.get("text", "") for p in content if p.get("type") == "text")
+        if content:
+            parts.append(str(content))
+    return " ".join(parts)
+
+
 def _namespaced_thread_id(thread_id: str | None) -> str | None:
     """Bind a conversation thread to the authenticated caller.
 
@@ -196,6 +214,13 @@ class KubentlyAgent:
         self._memory_disabled = False
         self._initialized = False
         self.system_prompt = None
+        # Operator runbooks (kubently.modules.runbooks): matched per
+        # investigation and injected as context. None until initialize().
+        self.runbooks = None
+        # thread_id -> set of runbook names already injected into that thread,
+        # so multi-turn conversations don't accumulate duplicate copies.
+        # Best-effort (in-memory): a restart re-injects once, which is harmless.
+        self._injected_runbooks: dict[str, set] = {}
         # Investigation tracking
         self.investigation_steps = []
         self.min_investigation_steps = 4  # Minimum steps for thoroughness
@@ -327,6 +352,13 @@ class KubentlyAgent:
                 "metrics_guidance": metrics_guidance(),
             },
         )
+
+        # Operator runbooks: directory (KUBENTLY_RUNBOOKS_DIR, ConfigMap-mounted
+        # in Helm deployments) of markdown files matched per investigation and
+        # injected as context. Missing directory just means an empty store.
+        from kubently.modules.runbooks import RunbookStore
+
+        self.runbooks = RunbookStore()
 
         # Initialize tools for kubectl operations
         await self._initialize_tools()
@@ -1361,6 +1393,36 @@ class KubentlyAgent:
 
         # Store thread ID for tool call tracking
         self._current_thread_id = thread_id
+
+        # Operator runbooks: match against this turn's user text (covers chat
+        # questions, alert-derived queries and A2A calls — they all arrive
+        # here as text) and inject the best match(es) as context. Injected
+        # with role "user" for the same checkpointer reason as cluster
+        # context below, and deduped per thread so multi-turn conversations
+        # don't accumulate copies.
+        if self.runbooks is not None:
+            query_text = _user_message_text(messages)
+            matched = self.runbooks.select(query_text)
+            dedup_key = thread_id or ""
+            already = self._injected_runbooks.get(dedup_key, set())
+            fresh = [r for r in matched if r.name not in already]
+            if fresh:
+                from kubently.modules.runbooks import build_runbook_context
+
+                runbook_context = build_runbook_context(fresh, self.runbooks.max_chars)
+                if runbook_context:
+                    injected = [r.name for r in fresh if f"Runbook: {r.name} " in runbook_context]
+                    logger.info(f"Injecting runbook(s) into investigation: {injected}")
+                    structured_log(
+                        {"event": "runbooks_injected", "runbooks": injected},
+                        thread_id=thread_id,
+                    )
+                    messages = [{"role": "user", "content": runbook_context}] + messages
+                    # Cap the dedup map so long-lived processes don't grow it
+                    # unboundedly across threads.
+                    if len(self._injected_runbooks) > 1024:
+                        self._injected_runbooks.pop(next(iter(self._injected_runbooks)))
+                    self._injected_runbooks.setdefault(dedup_key, set()).update(injected)
 
         # If cluster_id is specified, inject context at the start.
         # Must be role "user", not "system": the checkpointer appends each turn's

--- a/kubently/modules/runbooks/__init__.py
+++ b/kubently/modules/runbooks/__init__.py
@@ -1,0 +1,14 @@
+"""Operator runbook ingestion.
+
+Loads hand-written markdown runbooks (with lightweight YAML frontmatter) from a
+directory — typically a ConfigMap mounted at /etc/kubently/runbooks — and
+selects the ones relevant to an investigation so the agent can follow the
+operator's documented procedure.
+
+Black box interface: RunbookStore is the only entry point. Swap the storage
+(directory, ConfigMap, object store) without touching the agent.
+"""
+
+from .store import Runbook, RunbookStore, build_runbook_context
+
+__all__ = ["Runbook", "RunbookStore", "build_runbook_context"]

--- a/kubently/modules/runbooks/store.py
+++ b/kubently/modules/runbooks/store.py
@@ -39,9 +39,8 @@ import os
 import re
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import yaml
 
@@ -102,7 +101,7 @@ def _as_str_tuple(value) -> tuple:
     return ()
 
 
-def parse_runbook(text: str, source: str) -> Optional[Runbook]:
+def parse_runbook(text: str, source: str) -> Runbook | None:
     """Parse one runbook file. Returns None (with a log line) on files that
     can't be used, so one bad file never takes down the rest of the directory.
     """
@@ -119,7 +118,7 @@ def parse_runbook(text: str, source: str) -> Optional[Runbook]:
         logger.warning("Runbook %s frontmatter is not a mapping; skipping", source)
         return None
 
-    body = text[m.end():].strip()
+    body = text[m.end() :].strip()
     if not body:
         logger.warning("Runbook %s has an empty body; skipping", source)
         return None
@@ -179,7 +178,7 @@ def _format_block(runbook: Runbook) -> str:
     return f"--- Runbook: {runbook.name} (from {runbook.source}) ---\n{runbook.body}"
 
 
-def build_runbook_context(runbooks: list, max_chars: int = DEFAULT_MAX_CHARS) -> Optional[str]:
+def build_runbook_context(runbooks: list, max_chars: int = DEFAULT_MAX_CHARS) -> str | None:
     """Build the injectable context message from ranked runbooks.
 
     Best-first packing: the top match always goes in (truncated if it alone
@@ -220,14 +219,12 @@ class RunbookStore:
 
     def __init__(
         self,
-        directory: Optional[str] = None,
-        reload_seconds: Optional[float] = None,
-        max_chars: Optional[int] = None,
+        directory: str | None = None,
+        reload_seconds: float | None = None,
+        max_chars: int | None = None,
     ):
         self.directory = Path(
-            directory
-            or os.getenv("KUBENTLY_RUNBOOKS_DIR")
-            or DEFAULT_RUNBOOKS_DIR
+            directory or os.getenv("KUBENTLY_RUNBOOKS_DIR") or DEFAULT_RUNBOOKS_DIR
         )
         self.reload_seconds = (
             reload_seconds
@@ -241,7 +238,7 @@ class RunbookStore:
         )
         self._lock = threading.Lock()
         self._runbooks: list = []
-        self._signature: Optional[tuple] = None
+        self._signature: tuple | None = None
         self._last_scan = 0.0
         self._load()
 
@@ -316,6 +313,6 @@ class RunbookStore:
         matched.sort(key=lambda sr: (-sr[0], sr[1].name))
         return [r for _, r in matched]
 
-    def build_context(self, text: str) -> Optional[str]:
+    def build_context(self, text: str) -> str | None:
         """One-call convenience: select + format, or None when nothing matches."""
         return build_runbook_context(self.select(text), self.max_chars)

--- a/kubently/modules/runbooks/store.py
+++ b/kubently/modules/runbooks/store.py
@@ -1,0 +1,321 @@
+"""Runbook loading, matching, and prompt-context building.
+
+Runbooks are markdown files with lightweight YAML frontmatter:
+
+    ---
+    name: Payments CrashLoopBackOff
+    match:
+      alerts: ["KubePodCrashLooping", "PaymentsPod*"]
+      namespaces: ["payments", "payments-*"]
+      workloads: ["payment-api*"]
+      topics: ["crashloop", "OOMKilled", "payment service down"]
+    ---
+    1. Check recent deploys of payment-api first ...
+
+Matching is scored against the investigation's query text (a chat question, an
+alert-derived query, or an A2A message — all reach the agent as text):
+
+- ``alerts``: case-insensitive glob patterns matched against text tokens.
+  Strongest signal — an alert name in the text is near-certain intent.
+- ``namespaces`` / ``workloads``: case-insensitive glob patterns matched
+  against text tokens (pod names keep their hyphens when tokenized, so
+  ``payment-api*`` matches ``payment-api-7f9d8b-x2v``).
+- ``topics``: free-text tags; a tag counts when it appears as a substring of
+  the lowercased text. Weakest signal, used for chat questions that mention
+  no alert or resource by name.
+
+Reloading follows the executor whitelist's model (mtime + content signature,
+periodic) but lazily on access instead of a watcher thread — the agent already
+runs an event loop and a second config-watcher thread per process is the thing
+sse_executor.py deliberately avoids. Kubelet syncs updated ConfigMap volumes
+in ~1 minute, so edits go live without a pod restart.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RUNBOOKS_DIR = "/etc/kubently/runbooks"
+DEFAULT_RELOAD_SECONDS = 30.0
+# ~2k tokens: enough for one detailed runbook or a few short ones without
+# crowding out kubectl output in the context window.
+DEFAULT_MAX_CHARS = 8000
+
+# Match-score weights. An alert-name hit should always outrank any pile of
+# topic hits (topics are fuzzy; alert names are exact operator intent).
+ALERT_WEIGHT = 100
+SELECTOR_WEIGHT = 40
+TOPIC_WEIGHT = 10
+
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
+# Tokens keep the characters Kubernetes names use (hyphens, dots, underscores)
+# so selector globs can match pod/workload names embedded in prose.
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
+
+TRUNCATION_NOTE = "\n\n[runbook truncated to fit the context budget]"
+
+FRAMING = (
+    "OPERATOR RUNBOOK CONTEXT: The runbook(s) below are the operator's documented "
+    "procedure for this situation. Follow the runbook where it applies; if you "
+    "deviate from it or skip steps, note the deviation and why. If a runbook "
+    "informed your diagnosis, cite it by name in your final answer / root-cause "
+    "summary (e.g. \"Per runbook 'Payments CrashLoopBackOff' ...\")."
+)
+
+
+@dataclass(frozen=True)
+class Runbook:
+    """One parsed runbook file."""
+
+    name: str
+    source: str  # filename, for citation/debugging
+    body: str
+    alerts: tuple = ()
+    namespaces: tuple = ()
+    workloads: tuple = ()
+    topics: tuple = ()
+
+    def has_match_criteria(self) -> bool:
+        return bool(self.alerts or self.namespaces or self.workloads or self.topics)
+
+
+def _as_str_tuple(value) -> tuple:
+    """Frontmatter lists are hand-written; accept a bare string or a list."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,) if value.strip() else ()
+    if isinstance(value, (list, tuple)):
+        return tuple(str(v).strip() for v in value if str(v).strip())
+    return ()
+
+
+def parse_runbook(text: str, source: str) -> Optional[Runbook]:
+    """Parse one runbook file. Returns None (with a log line) on files that
+    can't be used, so one bad file never takes down the rest of the directory.
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        logger.warning("Runbook %s has no frontmatter block; skipping", source)
+        return None
+    try:
+        meta = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError as e:
+        logger.warning("Runbook %s has invalid frontmatter YAML (%s); skipping", source, e)
+        return None
+    if not isinstance(meta, dict):
+        logger.warning("Runbook %s frontmatter is not a mapping; skipping", source)
+        return None
+
+    body = text[m.end():].strip()
+    if not body:
+        logger.warning("Runbook %s has an empty body; skipping", source)
+        return None
+
+    # Hand-written files: fall back to the filename when name is omitted.
+    name = str(meta.get("name") or Path(source).stem).strip()
+
+    match = meta.get("match") or {}
+    if not isinstance(match, dict):
+        logger.warning("Runbook %s 'match' is not a mapping; skipping", source)
+        return None
+
+    runbook = Runbook(
+        name=name,
+        source=source,
+        body=body,
+        alerts=_as_str_tuple(match.get("alerts")),
+        namespaces=_as_str_tuple(match.get("namespaces")),
+        workloads=_as_str_tuple(match.get("workloads")),
+        topics=_as_str_tuple(match.get("topics")),
+    )
+    if not runbook.has_match_criteria():
+        logger.warning(
+            "Runbook %s ('%s') has no match criteria and will never be injected",
+            source,
+            name,
+        )
+    return runbook
+
+
+def _tokens(text: str) -> set:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def _glob_hits(patterns: tuple, tokens: set) -> int:
+    hits = 0
+    for pattern in patterns:
+        p = pattern.lower()
+        if any(fnmatch.fnmatchcase(t, p) for t in tokens):
+            hits += 1
+    return hits
+
+
+def score_runbook(runbook: Runbook, text: str) -> int:
+    """Relevance of one runbook to the investigation text. 0 = no match."""
+    tokens = _tokens(text)
+    lowered = text.lower()
+    score = 0
+    score += ALERT_WEIGHT * _glob_hits(runbook.alerts, tokens)
+    score += SELECTOR_WEIGHT * _glob_hits(runbook.namespaces, tokens)
+    score += SELECTOR_WEIGHT * _glob_hits(runbook.workloads, tokens)
+    score += TOPIC_WEIGHT * sum(1 for t in runbook.topics if t.lower() in lowered)
+    return score
+
+
+def _format_block(runbook: Runbook) -> str:
+    return f"--- Runbook: {runbook.name} (from {runbook.source}) ---\n{runbook.body}"
+
+
+def build_runbook_context(runbooks: list, max_chars: int = DEFAULT_MAX_CHARS) -> Optional[str]:
+    """Build the injectable context message from ranked runbooks.
+
+    Best-first packing: the top match always goes in (truncated if it alone
+    exceeds the budget); further matches are added only if they fit whole.
+    Prefer one complete, best-matching runbook over concatenating fragments
+    of everything.
+    """
+    if not runbooks:
+        return None
+
+    parts = [FRAMING]
+    used = len(FRAMING)
+    included = 0
+    for runbook in runbooks:
+        block = _format_block(runbook)
+        cost = len(block) + 2  # joining "\n\n"
+        if included == 0 and used + cost > max_chars:
+            # Best match doesn't fit whole: truncate rather than drop.
+            keep = max_chars - used - len(TRUNCATION_NOTE) - 2
+            if keep <= 0:
+                break
+            parts.append(block[:keep] + TRUNCATION_NOTE)
+            included += 1
+            break
+        if used + cost > max_chars:
+            break
+        parts.append(block)
+        used += cost
+        included += 1
+
+    if included == 0:
+        return None
+    return "\n\n".join(parts)
+
+
+class RunbookStore:
+    """Directory-backed runbook store with periodic, signature-checked reload."""
+
+    def __init__(
+        self,
+        directory: Optional[str] = None,
+        reload_seconds: Optional[float] = None,
+        max_chars: Optional[int] = None,
+    ):
+        self.directory = Path(
+            directory
+            or os.getenv("KUBENTLY_RUNBOOKS_DIR")
+            or DEFAULT_RUNBOOKS_DIR
+        )
+        self.reload_seconds = (
+            reload_seconds
+            if reload_seconds is not None
+            else float(os.getenv("KUBENTLY_RUNBOOKS_RELOAD_SECONDS", DEFAULT_RELOAD_SECONDS))
+        )
+        self.max_chars = (
+            max_chars
+            if max_chars is not None
+            else int(os.getenv("KUBENTLY_RUNBOOKS_MAX_CHARS", DEFAULT_MAX_CHARS))
+        )
+        self._lock = threading.Lock()
+        self._runbooks: list = []
+        self._signature: Optional[tuple] = None
+        self._last_scan = 0.0
+        self._load()
+
+    def _files(self) -> list:
+        if not self.directory.is_dir():
+            return []
+        # ConfigMap volumes hide ..data/..timestamp symlink machinery behind
+        # regular-looking files; glob("*.md") only sees the projected keys.
+        return sorted(p for p in self.directory.glob("*.md") if p.is_file())
+
+    def _current_signature(self) -> tuple:
+        sig = []
+        for path in self._files():
+            try:
+                st = path.stat()
+                sig.append((path.name, st.st_mtime_ns, st.st_size))
+            except OSError:
+                continue
+        return tuple(sig)
+
+    def _load(self) -> None:
+        signature = self._current_signature()
+        runbooks = []
+        for path in self._files():
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError as e:
+                logger.warning("Cannot read runbook %s: %s", path, e)
+                continue
+            runbook = parse_runbook(text, path.name)
+            if runbook:
+                runbooks.append(runbook)
+        with self._lock:
+            self._runbooks = runbooks
+            self._signature = signature
+            self._last_scan = time.monotonic()
+        if runbooks:
+            logger.info(
+                "Loaded %d runbook(s) from %s: %s",
+                len(runbooks),
+                self.directory,
+                ", ".join(r.name for r in runbooks),
+            )
+
+    def _maybe_reload(self) -> None:
+        with self._lock:
+            fresh = time.monotonic() - self._last_scan < self.reload_seconds
+        if fresh:
+            return
+        signature = self._current_signature()
+        with self._lock:
+            unchanged = signature == self._signature
+            if unchanged:
+                self._last_scan = time.monotonic()
+        if not unchanged:
+            logger.info("Runbook directory %s changed; reloading", self.directory)
+            self._load()
+
+    @property
+    def runbooks(self) -> list:
+        self._maybe_reload()
+        with self._lock:
+            return list(self._runbooks)
+
+    def select(self, text: str) -> list:
+        """Runbooks relevant to the investigation text, best match first."""
+        if not text or not text.strip():
+            return []
+        scored = [(score_runbook(r, text), r) for r in self.runbooks]
+        matched = [(s, r) for s, r in scored if s > 0]
+        # Ties break on name so injection order is deterministic.
+        matched.sort(key=lambda sr: (-sr[0], sr[1].name))
+        return [r for _, r in matched]
+
+    def build_context(self, text: str) -> Optional[str]:
+        """One-call convenience: select + format, or None when nothing matches."""
+        return build_runbook_context(self.select(text), self.max_chars)

--- a/tests/test_runbooks.py
+++ b/tests/test_runbooks.py
@@ -14,8 +14,6 @@ import os
 import sys
 import textwrap
 
-import pytest
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from kubently.modules.runbooks import RunbookStore, build_runbook_context
@@ -149,20 +147,31 @@ class TestMatching:
         assert score_runbook(rb, "why is coredns slow in kube-system?") == 0
 
     def test_alert_hit_outranks_topic_pile(self):
-        by_alert = make_runbook(name="A", alerts=("KubePodCrashLooping",), namespaces=(),
-                                workloads=(), topics=())
-        by_topics = make_runbook(name="B", alerts=(), namespaces=(), workloads=(),
-                                 topics=("pod", "firing", "alert", "crash"))
+        by_alert = make_runbook(
+            name="A", alerts=("KubePodCrashLooping",), namespaces=(), workloads=(), topics=()
+        )
+        by_topics = make_runbook(
+            name="B",
+            alerts=(),
+            namespaces=(),
+            workloads=(),
+            topics=("pod", "firing", "alert", "crash"),
+        )
         text = "Alert 'KubePodCrashLooping' is firing: pod crash"
         assert score_runbook(by_alert, text) > score_runbook(by_topics, text)
 
 
 class TestStoreSelect:
     def test_select_orders_best_match_first(self, tmp_path):
-        write_runbook(tmp_path, "generic.md", "Generic crashloop",
-                      match_yaml='  topics: ["crashloop"]')
-        write_runbook(tmp_path, "specific.md", "Payments crashloop",
-                      match_yaml='  alerts: ["KubePodCrashLooping"]\n  topics: ["crashloop"]')
+        write_runbook(
+            tmp_path, "generic.md", "Generic crashloop", match_yaml='  topics: ["crashloop"]'
+        )
+        write_runbook(
+            tmp_path,
+            "specific.md",
+            "Payments crashloop",
+            match_yaml='  alerts: ["KubePodCrashLooping"]\n  topics: ["crashloop"]',
+        )
         store = RunbookStore(directory=str(tmp_path), reload_seconds=0)
         matches = store.select("Alert 'KubePodCrashLooping' is firing: crashloop in payments")
         assert [r.name for r in matches] == ["Payments crashloop", "Generic crashloop"]
@@ -293,8 +302,11 @@ def _load_user_message_text():
     (same extraction convention as test_thread_namespacing)."""
     from pathlib import Path
 
-    path = (Path(__file__).parent.parent / "kubently/modules/a2a/protocol_bindings"
-            / "a2a_server/agent.py")
+    path = (
+        Path(__file__).parent.parent
+        / "kubently/modules/a2a/protocol_bindings"
+        / "a2a_server/agent.py"
+    )
     src = path.read_text()
     start = src.index("def _user_message_text")
     end = src.index("def _namespaced_thread_id")
@@ -310,8 +322,13 @@ class TestUserMessageText:
         messages = [
             {"role": "user", "content": "Alert 'KubePodCrashLooping' firing"},
             {"role": "assistant", "content": "not this"},
-            {"role": "user", "content": [{"type": "text", "text": "in payments"},
-                                         {"type": "image", "url": "ignored"}]},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "in payments"},
+                    {"type": "image", "url": "ignored"},
+                ],
+            },
         ]
         text = _user_message_text(messages)
         assert "KubePodCrashLooping" in text

--- a/tests/test_runbooks.py
+++ b/tests/test_runbooks.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Tests for operator runbook ingestion (kubently.modules.runbooks).
+
+Covers the three behaviours that matter in production:
+1. Matching — alert name globs, namespace/workload selectors, topic tags,
+   and the ranking between them.
+2. Size capping — best match wins over concatenating everything; a single
+   oversized runbook is truncated, not dropped.
+3. Injection formatting — operator framing, citation instruction, and the
+   runbook name/source so the RCA can cite it.
+"""
+
+import os
+import sys
+import textwrap
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kubently.modules.runbooks import RunbookStore, build_runbook_context
+from kubently.modules.runbooks.store import (
+    FRAMING,
+    TRUNCATION_NOTE,
+    Runbook,
+    parse_runbook,
+    score_runbook,
+)
+
+
+def make_runbook(**overrides):
+    defaults = dict(
+        name="Payments CrashLoopBackOff",
+        source="payments-crashloop.md",
+        body="1. Check recent deploys first.\n2. Compare heap flag to memory limit.",
+        alerts=("KubePodCrashLooping",),
+        namespaces=("payments", "payments-*"),
+        workloads=("payment-api*",),
+        topics=("crashloop", "payment service"),
+    )
+    defaults.update(overrides)
+    return Runbook(**defaults)
+
+
+def write_runbook(directory, filename, name, body="Step 1. Look at events.", match_yaml=None):
+    match_yaml = match_yaml if match_yaml is not None else '  alerts: ["KubePodCrashLooping"]'
+    text = f"---\nname: {name}\nmatch:\n{match_yaml}\n---\n{body}\n"
+    path = directory / filename
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# =========================================================================
+# Frontmatter parsing
+# =========================================================================
+
+
+class TestParsing:
+    def test_parses_full_frontmatter(self):
+        text = textwrap.dedent(
+            """\
+            ---
+            name: DB failover
+            match:
+              alerts: ["PostgresDown", "Replica*Lag"]
+              namespaces: ["db"]
+              workloads: ["postgres-*"]
+              topics: ["failover", "replication lag"]
+            ---
+            # Steps
+            1. Do not restart the primary.
+            """
+        )
+        rb = parse_runbook(text, "db-failover.md")
+        assert rb.name == "DB failover"
+        assert rb.source == "db-failover.md"
+        assert rb.alerts == ("PostgresDown", "Replica*Lag")
+        assert rb.namespaces == ("db",)
+        assert rb.workloads == ("postgres-*",)
+        assert rb.topics == ("failover", "replication lag")
+        assert rb.body.startswith("# Steps")
+
+    def test_name_falls_back_to_filename(self):
+        text = "---\nmatch:\n  topics: [dns]\n---\nCheck CoreDNS."
+        rb = parse_runbook(text, "dns-issues.md")
+        assert rb.name == "dns-issues"
+
+    def test_scalar_criteria_accepted_as_single_entry(self):
+        # Hand-written YAML: `alerts: KubePodCrashLooping` (no list) must work.
+        text = "---\nname: X\nmatch:\n  alerts: KubePodCrashLooping\n---\nBody."
+        rb = parse_runbook(text, "x.md")
+        assert rb.alerts == ("KubePodCrashLooping",)
+
+    def test_no_frontmatter_is_skipped(self):
+        assert parse_runbook("Just a markdown file.", "plain.md") is None
+
+    def test_invalid_yaml_is_skipped(self):
+        assert parse_runbook("---\nname: [unclosed\n---\nBody.", "bad.md") is None
+
+    def test_empty_body_is_skipped(self):
+        assert parse_runbook("---\nname: X\nmatch:\n  topics: [a]\n---\n", "empty.md") is None
+
+    def test_non_mapping_match_is_skipped(self):
+        assert parse_runbook("---\nname: X\nmatch: [a, b]\n---\nBody.", "bad.md") is None
+
+
+# =========================================================================
+# Matching: alert patterns, selectors, tag relevance
+# =========================================================================
+
+
+class TestMatching:
+    def test_alert_name_exact_match(self):
+        rb = make_runbook()
+        text = "Alert 'KubePodCrashLooping' is firing in cluster prod"
+        assert score_runbook(rb, text) >= 100
+
+    def test_alert_name_glob_match(self):
+        rb = make_runbook(alerts=("Payments*",))
+        assert score_runbook(rb, "Alert 'PaymentsHighLatency' is firing") >= 100
+
+    def test_alert_match_is_case_insensitive(self):
+        rb = make_runbook()
+        assert score_runbook(rb, "alert kubepodcrashlooping fired") >= 100
+
+    def test_namespace_selector_match(self):
+        rb = make_runbook(alerts=(), workloads=(), topics=())
+        assert score_runbook(rb, "pods failing in namespace payments") > 0
+
+    def test_namespace_glob_selector(self):
+        rb = make_runbook(alerts=(), workloads=(), topics=())
+        assert score_runbook(rb, "pods failing in namespace payments-eu") > 0
+
+    def test_workload_glob_matches_derived_pod_name(self):
+        rb = make_runbook(alerts=(), namespaces=(), topics=())
+        assert score_runbook(rb, "why is payment-api-7f9d8b5c-x2vqp restarting?") > 0
+
+    def test_topic_tag_relevance(self):
+        rb = make_runbook(alerts=(), namespaces=(), workloads=())
+        assert score_runbook(rb, "the payment service seems down, some crashloop") > 0
+
+    def test_multiword_topic_matches_as_phrase(self):
+        rb = make_runbook(alerts=(), namespaces=(), workloads=(), topics=("connection refused",))
+        assert score_runbook(rb, "getting connection refused from the backend") > 0
+        assert score_runbook(rb, "connection was refused") == 0
+
+    def test_no_match_scores_zero(self):
+        rb = make_runbook()
+        assert score_runbook(rb, "why is coredns slow in kube-system?") == 0
+
+    def test_alert_hit_outranks_topic_pile(self):
+        by_alert = make_runbook(name="A", alerts=("KubePodCrashLooping",), namespaces=(),
+                                workloads=(), topics=())
+        by_topics = make_runbook(name="B", alerts=(), namespaces=(), workloads=(),
+                                 topics=("pod", "firing", "alert", "crash"))
+        text = "Alert 'KubePodCrashLooping' is firing: pod crash"
+        assert score_runbook(by_alert, text) > score_runbook(by_topics, text)
+
+
+class TestStoreSelect:
+    def test_select_orders_best_match_first(self, tmp_path):
+        write_runbook(tmp_path, "generic.md", "Generic crashloop",
+                      match_yaml='  topics: ["crashloop"]')
+        write_runbook(tmp_path, "specific.md", "Payments crashloop",
+                      match_yaml='  alerts: ["KubePodCrashLooping"]\n  topics: ["crashloop"]')
+        store = RunbookStore(directory=str(tmp_path), reload_seconds=0)
+        matches = store.select("Alert 'KubePodCrashLooping' is firing: crashloop in payments")
+        assert [r.name for r in matches] == ["Payments crashloop", "Generic crashloop"]
+
+    def test_select_empty_text_matches_nothing(self, tmp_path):
+        write_runbook(tmp_path, "a.md", "A")
+        store = RunbookStore(directory=str(tmp_path), reload_seconds=0)
+        assert store.select("") == []
+        assert store.select("   ") == []
+
+    def test_select_unrelated_text_matches_nothing(self, tmp_path):
+        write_runbook(tmp_path, "a.md", "A")
+        store = RunbookStore(directory=str(tmp_path), reload_seconds=0)
+        assert store.select("how many nodes does the cluster have?") == []
+
+
+# =========================================================================
+# Size capping
+# =========================================================================
+
+
+class TestSizeCapping:
+    def test_prefers_best_match_over_concatenating_everything(self):
+        best = make_runbook(name="Best", body="B" * 3000)
+        second = make_runbook(name="Second", source="second.md", body="S" * 3000)
+        context = build_runbook_context([best, second], max_chars=4000)
+        assert "Runbook: Best" in context
+        assert "Runbook: Second" not in context
+        assert len(context) <= 4000
+
+    def test_multiple_runbooks_fit_when_budget_allows(self):
+        a = make_runbook(name="A", body="a" * 100)
+        b = make_runbook(name="B", source="b.md", body="b" * 100)
+        context = build_runbook_context([a, b], max_chars=8000)
+        assert "Runbook: A" in context and "Runbook: B" in context
+
+    def test_oversized_best_match_is_truncated_not_dropped(self):
+        big = make_runbook(name="Huge", body="X" * 20000)
+        context = build_runbook_context([big], max_chars=2000)
+        assert context is not None
+        assert len(context) <= 2000
+        assert "Runbook: Huge" in context
+        assert context.endswith(TRUNCATION_NOTE)
+
+    def test_no_matches_yields_none(self):
+        assert build_runbook_context([], max_chars=8000) is None
+
+    def test_store_env_cap_is_respected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KUBENTLY_RUNBOOKS_MAX_CHARS", "1500")
+        write_runbook(tmp_path, "big.md", "Big", body="Z" * 5000)
+        store = RunbookStore(directory=str(tmp_path), reload_seconds=0)
+        context = store.build_context("Alert 'KubePodCrashLooping' firing")
+        assert context is not None and len(context) <= 1500
+
+
+# =========================================================================
+# Injection formatting
+# =========================================================================
+
+
+class TestInjectionFormatting:
+    def test_context_carries_operator_framing(self):
+        context = build_runbook_context([make_runbook()])
+        assert context.startswith(FRAMING)
+        assert "operator's documented procedure" in context
+        assert "note the deviation" in context
+
+    def test_context_instructs_citation_by_name(self):
+        context = build_runbook_context([make_runbook()])
+        assert "cite it by name" in context
+
+    def test_block_names_runbook_and_source_file(self):
+        context = build_runbook_context([make_runbook()])
+        assert "--- Runbook: Payments CrashLoopBackOff (from payments-crashloop.md) ---" in context
+        assert "Compare heap flag" in context
+
+
+# =========================================================================
+# Store loading and reload
+# =========================================================================
+
+
+class TestStoreLoading:
+    def test_missing_directory_is_empty_store(self, tmp_path):
+        store = RunbookStore(directory=str(tmp_path / "nope"), reload_seconds=0)
+        assert store.runbooks == []
+        assert store.select("Alert 'KubePodCrashLooping' firing") == []
+
+    def test_bad_file_does_not_break_good_files(self, tmp_path):
+        (tmp_path / "broken.md").write_text("no frontmatter here", encoding="utf-8")
+        write_runbook(tmp_path, "good.md", "Good")
+        store = RunbookStore(directory=str(tmp_path), reload_seconds=0)
+        assert [r.name for r in store.runbooks] == ["Good"]
+
+    def test_non_markdown_files_ignored(self, tmp_path):
+        (tmp_path / "notes.txt").write_text("---\nname: X\n---\nBody", encoding="utf-8")
+        store = RunbookStore(directory=str(tmp_path), reload_seconds=0)
+        assert store.runbooks == []
+
+    def test_reload_picks_up_new_file(self, tmp_path):
+        write_runbook(tmp_path, "a.md", "A")
+        store = RunbookStore(directory=str(tmp_path), reload_seconds=0)
+        assert len(store.runbooks) == 1
+        write_runbook(tmp_path, "b.md", "B")
+        assert sorted(r.name for r in store.runbooks) == ["A", "B"]
+
+    def test_reload_interval_throttles_rescan(self, tmp_path):
+        write_runbook(tmp_path, "a.md", "A")
+        store = RunbookStore(directory=str(tmp_path), reload_seconds=3600)
+        write_runbook(tmp_path, "b.md", "B")
+        # Within the interval the old snapshot is served.
+        assert [r.name for r in store.runbooks] == ["A"]
+
+    def test_env_var_directory(self, tmp_path, monkeypatch):
+        write_runbook(tmp_path, "a.md", "A")
+        monkeypatch.setenv("KUBENTLY_RUNBOOKS_DIR", str(tmp_path))
+        store = RunbookStore(reload_seconds=0)
+        assert [r.name for r in store.runbooks] == ["A"]
+
+
+# =========================================================================
+# Agent-side helpers
+# =========================================================================
+
+
+def _load_user_message_text():
+    """Import just the helper without pulling in the heavy a2a/langchain stack
+    (same extraction convention as test_thread_namespacing)."""
+    from pathlib import Path
+
+    path = (Path(__file__).parent.parent / "kubently/modules/a2a/protocol_bindings"
+            / "a2a_server/agent.py")
+    src = path.read_text()
+    start = src.index("def _user_message_text")
+    end = src.index("def _namespaced_thread_id")
+    ns: dict = {}
+    exec(src[start:end], ns)
+    return ns["_user_message_text"]
+
+
+class TestUserMessageText:
+    def test_extracts_plain_and_multipart_user_text(self):
+        _user_message_text = _load_user_message_text()
+
+        messages = [
+            {"role": "user", "content": "Alert 'KubePodCrashLooping' firing"},
+            {"role": "assistant", "content": "not this"},
+            {"role": "user", "content": [{"type": "text", "text": "in payments"},
+                                         {"type": "image", "url": "ignored"}]},
+        ]
+        text = _user_message_text(messages)
+        assert "KubePodCrashLooping" in text
+        assert "in payments" in text
+        assert "not this" not in text


### PR DESCRIPTION
Track P6a (Roadmap Phase 6): feed org-specific knowledge into investigations.

- Markdown runbooks with lightweight YAML frontmatter (`name` + `match`: alert-name globs, namespace/workload selectors, topic tags), loaded from `KUBENTLY_RUNBOOKS_DIR` — Helm `runbooks` values map → ConfigMap mounted at `/etc/kubently/runbooks`, default off, hot-reloaded like the executor whitelist.
- Matching: weighted scoring across alert patterns/selectors/tags; best match(es) injected as operator context ("follow it where applicable, note deviations") with an 8K total cap and dedup; the RCA cites the runbook by name when used.
- 336-line test suite for matching, capping, and injection formatting; README worked example + env var docs.
- Branch carries current main (P5 union-merged: runbooks + proactive Helm/doc sections coexist; values.yaml YAML-validated). Verified locally: 137 passed, 1 expected skip across runbooks + all P5 suites + checkpointer/Prometheus regression files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX)_