### PR TITLE
Incident history: past diagnoses as searchable, namespace-isolated retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 ## [Unreleased] - 2026-08-17
 
 ### Added
+- **Incident history (Track P6c)** — past diagnoses become searchable
+  institutional memory ("have we seen this before?"). When an investigation
+  concludes with a root cause, a compact record (timestamp, cluster,
+  resources involved, symptom keywords, root-cause one-liner, resolution
+  when stated) is persisted to Redis under the same per-caller namespace
+  derivation the conversation checkpointer uses for thread ids — records
+  never cross tenant namespaces, and every key embeds the namespace. Core
+  Redis commands only (no RediSearch/SCAN), configurable TTL
+  (`KUBENTLY_INCIDENT_TTL_SECONDS`, default 90d) and per-namespace cap
+  (`KUBENTLY_INCIDENT_MAX_PER_NAMESPACE`, default 200, oldest evicted).
+  Retrieval: the `search_past_incidents` agent tool (v1 keyword scoring —
+  resource > cluster > symptom > root-cause-text overlap, prefix-aware for
+  hashed pod names — behind a `search()`/`best_match()` interface an
+  embedding backend could implement later), plus auto-surfacing: a new
+  investigation strongly matching a past incident
+  (`KUBENTLY_INCIDENT_SURFACE_MIN_SCORE`, default 40) gets a one-line
+  "SIMILAR PAST INCIDENT (date): <root cause>" context note framed as
+  something to verify — and cite in the RCA when it materially informs the
+  diagnosis — never to assume. Explicitly retrieval over stored summaries,
+  not a learning system. Default on; `KUBENTLY_INCIDENT_HISTORY=false`
+  disables. New module `kubently/modules/incidents/`
 - **Operator runbook ingestion (Track P6a)** — feed org-specific knowledge
   into investigations. Hand-written markdown runbooks with lightweight YAML
   frontmatter (`name` + `match` criteria: alert-name globs,

--- a/README.md
+++ b/README.md
@@ -276,6 +276,35 @@ total injected size is capped (`KUBENTLY_RUNBOOKS_MAX_CHARS`, default 8000
 characters) — one complete, best-matching runbook beats fragments of many.
 Outside Helm, point `KUBENTLY_RUNBOOKS_DIR` at any directory of `.md` files.
 
+### Incident History
+
+Past diagnoses become searchable institutional memory. Whenever an
+investigation concludes with a root cause, Kubently stores a compact record —
+date, cluster, resources involved, symptom keywords, the root-cause
+one-liner, and the resolution when one was stated — in Redis, isolated per
+authenticated caller (the same namespace boundary as conversation memory, so
+in multi-tenant deployments one tenant's incidents are never visible to
+another).
+
+The history is used two ways:
+
+- The agent's **`search_past_incidents`** tool answers "have we seen this
+  before?" — keyword search over resources, clusters, symptoms and
+  root-cause text, newest first.
+- **Auto-surface**: when a new investigation strongly matches a past incident
+  (same resources/symptoms/cluster), a one-line
+  `SIMILAR PAST INCIDENT (date): <root cause>` note is injected into
+  context — framed as something to *verify against fresh evidence*, never to
+  assume. When a past incident materially informs the diagnosis, the RCA
+  cites it ("same root cause as the 2026-07-03 incident").
+
+This is retrieval over stored summaries, not a learning system: records are
+plain data with a TTL (default 90 days, `KUBENTLY_INCIDENT_TTL_SECONDS`) and
+a per-tenant cap (default 200, `KUBENTLY_INCIDENT_MAX_PER_NAMESPACE`,
+oldest evicted). The feature is on by default; set
+`KUBENTLY_INCIDENT_HISTORY=false` (Helm: under `api.env`) to disable both
+recording and retrieval.
+
 ## Architecture
 
 - **API Server**: FastAPI-based REST API for cluster management and authentication
@@ -295,6 +324,7 @@ The diagnostic agent investigates with a small set of read-only tools:
 - **`search_pod_logs`** — structured log search across every pod/container matching a label selector (substring or regex, time bounds, previous-container support). Logs are filtered on the cluster's executor so only matching lines — capped, with explicit truncation notes — come back
 - **`query_loki`** *(optional)* — LogQL range queries against a cluster's Loki for aggregated/historical log search, including logs from pods that have restarted or been deleted. Enabled by setting `loki.url` in Helm values (unset by default); queries execute on each cluster's executor through the same outbound channel as kubectl commands
 - **`query_prometheus`** *(optional)* — instant and range PromQL queries for latency, saturation, OOM-trend and restarts-over-time evidence. Enabled by setting `prometheus.url` in Helm values (unset by default); queries execute on each cluster's executor through the same outbound channel as kubectl commands
+- **`search_past_incidents`** — keyword search over this deployment's incident history (see below). On by default when Redis is available; disable with `KUBENTLY_INCIDENT_HISTORY=false`
 
 ## Documentation
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -103,6 +103,30 @@ Whatever the backend, initialization failure degrades gracefully: the agent
 logs a warning and continues without cross-request memory, and single-request
 diagnoses are unaffected.
 
+### Incident History (institutional memory)
+
+When an investigation concludes with a root cause, the agent persists a
+compact incident record (timestamp, cluster, resources involved, symptom
+keywords, root-cause one-liner, resolution when stated) to Redis. Past
+incidents are retrievable through the `search_past_incidents` agent tool,
+and a strong match against a new investigation auto-surfaces a one-line
+"similar past incident" note (framed as context to verify, never a
+conclusion). Records are stored per authenticated caller using the same
+namespace derivation as conversation-memory thread ids, so incidents never
+cross tenant boundaries. Core Redis commands only — works on managed Redis
+without RediSearch. On by default; requires a Redis connection.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `KUBENTLY_INCIDENT_HISTORY` | `true` | No | Kill switch. `false` disables recording, the `search_past_incidents` tool, and auto-surfacing |
+| `KUBENTLY_INCIDENT_TTL_SECONDS` | `7776000` (90 days) | No | TTL for incident records. Set to `0` to disable expiry |
+| `KUBENTLY_INCIDENT_MAX_PER_NAMESPACE` | `200` | No | Per-caller-namespace record cap; oldest records are evicted beyond it |
+| `KUBENTLY_INCIDENT_SURFACE_MIN_SCORE` | `40` | No | Minimum match score before a past incident is auto-surfaced into a new investigation. Raise to surface less often; the search tool is unaffected |
+
+In Helm deployments set these under `api.env`. Recording and retrieval
+failures are logged and skipped — incident history can never break an
+investigation or a response.
+
 ### Prometheus Metrics Tool (optional)
 
 When `PROMETHEUS_URL` is set on the API server, the agent registers the read-only `query_prometheus` tool and injects metrics guidance into the system prompt. When unset (default), the tool does not exist and the prompt never mentions metrics.

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -221,6 +221,13 @@ class KubentlyAgent:
         # so multi-turn conversations don't accumulate duplicate copies.
         # Best-effort (in-memory): a restart re-injects once, which is harmless.
         self._injected_runbooks: dict[str, set] = {}
+        # Incident history (kubently.modules.incidents): past diagnoses become
+        # searchable institutional memory. None until initialize() (or when
+        # disabled / no Redis).
+        self.incidents = None
+        # thread_id -> incident ids already auto-surfaced into that thread
+        # (same dedup pattern as _injected_runbooks).
+        self._surfaced_incidents: dict[str, set] = {}
         # Investigation tracking
         self.investigation_steps = []
         self.min_investigation_steps = 4  # Minimum steps for thoroughness
@@ -359,6 +366,22 @@ class KubentlyAgent:
         from kubently.modules.runbooks import RunbookStore
 
         self.runbooks = RunbookStore()
+
+        # Incident history: retrieval over compact summaries of concluded
+        # investigations, stored in Redis per caller namespace. Default on;
+        # KUBENTLY_INCIDENT_HISTORY=false or a missing Redis client turns it
+        # off (the agent then just has no institutional memory, as before).
+        from kubently.modules.incidents import IncidentStore, incidents_enabled
+
+        if incidents_enabled() and self.redis_client is not None:
+            try:
+                self.incidents = IncidentStore(self.redis_client)
+                logger.info("Incident history enabled (search_past_incidents + auto-surface)")
+            except Exception as e:
+                logger.warning(f"Incident history unavailable: {e}")
+                self.incidents = None
+        else:
+            self.incidents = None
 
         # Initialize tools for kubectl operations
         await self._initialize_tools()
@@ -1164,6 +1187,76 @@ class KubentlyAgent:
             get_events_for_resource,
         ]
 
+        if self.incidents is not None:
+            from kubently.modules.incidents import caller_namespace, format_search_results
+
+            @tool
+            async def search_past_incidents(
+                query: str,
+                cluster_id: str | None = None,
+                limit: int = 5,
+            ) -> str:
+                """Search this deployment's history of past diagnosed incidents.
+
+                Institutional memory: every investigation that concluded with a
+                root cause left a compact record (date, cluster, resources,
+                symptom keywords, root-cause one-liner, resolution when
+                stated). Use this to answer "have we seen this before?" —
+                when current symptoms feel like a recurrence, when the user
+                asks about past issues, or before concluding a novel root
+                cause for a familiar-looking failure.
+
+                Matching is keyword-based: mention the failing resource names,
+                namespace, and symptom words (e.g. "checkout-api payments
+                CrashLoopBackOff OOMKilled") for the best results. Pass an
+                empty query to list the most recent incidents.
+
+                IMPORTANT: results are summaries of PAST states, not evidence
+                about the current cluster. Verify against fresh kubectl/log
+                evidence before relying on one. If a past incident materially
+                informs your diagnosis, cite it in your root-cause summary
+                (e.g. "same root cause as the 2026-07-03 incident").
+
+                Args:
+                    query: Free-text search (resource names, namespaces,
+                        symptoms, root-cause words). Empty = newest first.
+                    cluster_id: Optionally boost incidents from this cluster
+                    limit: Max results (default 5)
+
+                Returns:
+                    Matching incidents (best first) with date, cluster,
+                    resources, root cause and resolution, or a clear
+                    "no matching past incidents" note.
+                """
+                debug_print(
+                    f"search_past_incidents called: query={query!r}, "
+                    f"cluster_id={cluster_id}, limit={limit}"
+                )
+                tool_call_id = await interceptor.record_tool_call(
+                    tool_name="search_past_incidents",
+                    args={"query": query, "cluster_id": cluster_id, "limit": limit},
+                    thread_id=getattr(self, "_current_thread_id", None),
+                )
+                try:
+                    # Same per-caller namespace derivation as conversation
+                    # memory: a caller can only ever search their own records.
+                    results = await self.incidents.search(
+                        caller_namespace(),
+                        query=query,
+                        cluster_id=cluster_id,
+                        limit=max(1, min(int(limit), 20)),
+                    )
+                    output = cap_output(format_search_results(results))
+                    await interceptor.record_tool_result(tool_call_id, output)
+                    return output
+                except Exception as e:
+                    error_msg = f"Error searching past incidents: {e!s}"
+                    await interceptor.record_tool_result(tool_call_id, None, error_msg)
+                    return error_msg
+
+            self.tools.append(search_past_incidents)
+            logger.info("Incident history search tool registered")
+
         if loki_tool_enabled():
 
             @tool
@@ -1394,6 +1487,10 @@ class KubentlyAgent:
         # Store thread ID for tool call tracking
         self._current_thread_id = thread_id
 
+        # This turn's user text: matched against runbooks and past incidents,
+        # and kept as the "query" on any incident record this turn produces.
+        query_text = _user_message_text(messages)
+
         # Operator runbooks: match against this turn's user text (covers chat
         # questions, alert-derived queries and A2A calls — they all arrive
         # here as text) and inject the best match(es) as context. Injected
@@ -1401,7 +1498,6 @@ class KubentlyAgent:
         # context below, and deduped per thread so multi-turn conversations
         # don't accumulate copies.
         if self.runbooks is not None:
-            query_text = _user_message_text(messages)
             matched = self.runbooks.select(query_text)
             dedup_key = thread_id or ""
             already = self._injected_runbooks.get(dedup_key, set())
@@ -1423,6 +1519,42 @@ class KubentlyAgent:
                     if len(self._injected_runbooks) > 1024:
                         self._injected_runbooks.pop(next(iter(self._injected_runbooks)))
                     self._injected_runbooks.setdefault(dedup_key, set()).update(injected)
+
+        # Incident history auto-surface: when this investigation strongly
+        # matches a past diagnosed incident in the caller's namespace, inject
+        # a one-line "similar past incident" note framed as context to verify,
+        # never as a conclusion. Role "user" for the same checkpointer reason
+        # as runbooks/cluster context; deduped per thread; the thread's own
+        # records are excluded so turn 2 doesn't surface turn 1's diagnosis.
+        # Any failure here is logged and skipped — surfacing must never break
+        # an investigation.
+        if self.incidents is not None and query_text.strip():
+            try:
+                from kubently.modules.incidents import build_surface_note, caller_namespace
+
+                dedup_key = thread_id or ""
+                match = await self.incidents.best_match(
+                    caller_namespace(),
+                    query_text,
+                    cluster_id=cluster_id,
+                    exclude_thread_id=thread_id,
+                    exclude_ids=self._surfaced_incidents.get(dedup_key, set()),
+                )
+                if match:
+                    score, past = match
+                    logger.info(
+                        f"Auto-surfacing past incident {past.id} (score={score})"
+                    )
+                    structured_log(
+                        {"event": "incident_surfaced", "incident_id": past.id, "score": score},
+                        thread_id=thread_id,
+                    )
+                    messages = [{"role": "user", "content": build_surface_note(past)}] + messages
+                    if len(self._surfaced_incidents) > 1024:
+                        self._surfaced_incidents.pop(next(iter(self._surfaced_incidents)))
+                    self._surfaced_incidents.setdefault(dedup_key, set()).add(past.id)
+            except Exception as e:
+                logger.warning(f"Incident auto-surface failed (continuing without): {e}")
 
         # If cluster_id is specified, inject context at the start.
         # Must be role "user", not "system": the checkpointer appends each turn's
@@ -1525,6 +1657,39 @@ class KubentlyAgent:
 
                         # Add a note about checking raw outputs
                         response_text += "\n\nPlease review the raw command outputs above to understand the issue."
+
+                    # Incident history: if this answer states a root cause,
+                    # persist a compact record to the caller's namespace so
+                    # future investigations can find it. Extraction returning
+                    # None means no RCA was produced — nothing to record.
+                    # Best-effort: a storage failure must never break the
+                    # user-facing response.
+                    if self.incidents is not None:
+                        try:
+                            from kubently.modules.incidents import (
+                                caller_namespace,
+                                extract_incident,
+                            )
+
+                            trace = await get_tool_call_interceptor().get_tool_calls_for_thread(
+                                actual_thread_id
+                            )
+                            incident = extract_incident(
+                                response_text,
+                                user_text=query_text,
+                                tool_calls=trace,
+                                cluster_id=cluster_id,
+                                thread_id=actual_thread_id,
+                            )
+                            if incident:
+                                await self.incidents.record(caller_namespace(), incident)
+                                logger.info(f"Recorded incident {incident.id}")
+                                structured_log(
+                                    {"event": "incident_recorded", "incident_id": incident.id},
+                                    thread_id=actual_thread_id,
+                                )
+                        except Exception as e:
+                            logger.warning(f"Incident recording failed (response unaffected): {e}")
 
                     yield {
                         "type": "message",

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -1532,13 +1532,16 @@ class KubentlyAgent:
             try:
                 from kubently.modules.incidents import build_surface_note, caller_namespace
 
-                dedup_key = thread_id or ""
+                # Dedup only applies within a real conversation thread: a
+                # one-shot request (no thread) is a fresh conversation every
+                # time, so nothing to dedup against.
+                already = self._surfaced_incidents.get(thread_id, set()) if thread_id else set()
                 match = await self.incidents.best_match(
                     caller_namespace(),
                     query_text,
                     cluster_id=cluster_id,
                     exclude_thread_id=thread_id,
-                    exclude_ids=self._surfaced_incidents.get(dedup_key, set()),
+                    exclude_ids=already,
                 )
                 if match:
                     score, past = match
@@ -1550,9 +1553,10 @@ class KubentlyAgent:
                         thread_id=thread_id,
                     )
                     messages = [{"role": "user", "content": build_surface_note(past)}] + messages
-                    if len(self._surfaced_incidents) > 1024:
-                        self._surfaced_incidents.pop(next(iter(self._surfaced_incidents)))
-                    self._surfaced_incidents.setdefault(dedup_key, set()).add(past.id)
+                    if thread_id:
+                        if len(self._surfaced_incidents) > 1024:
+                            self._surfaced_incidents.pop(next(iter(self._surfaced_incidents)))
+                        self._surfaced_incidents.setdefault(thread_id, set()).add(past.id)
             except Exception as e:
                 logger.warning(f"Incident auto-surface failed (continuing without): {e}")
 

--- a/kubently/modules/incidents/__init__.py
+++ b/kubently/modules/incidents/__init__.py
@@ -1,0 +1,48 @@
+"""Incident history: past diagnoses as searchable institutional memory.
+
+When an investigation concludes with a root cause, a compact summary record
+(timestamp, cluster, resources involved, symptom keywords, root-cause
+one-liner, resolution when stated) is persisted to Redis. Later
+investigations can ask "have we seen this before?" — via the
+search_past_incidents agent tool, or via the auto-surface note injected when
+a new investigation strongly matches a past record.
+
+This is retrieval over stored summaries, deliberately NOT a learning system:
+records are plain data the agent reads and must verify against fresh
+evidence, never weights or behavioral adjustments.
+
+Records are namespaced per authenticated caller with the same derivation the
+conversation checkpointer uses for thread ids, and every Redis key embeds the
+namespace: in multi-tenant deployments one tenant's incidents are never
+visible to another. That isolation is a security boundary, not a convenience.
+
+Black box interface: IncidentStore is the storage/retrieval entry point;
+extract_incident builds records from a concluded investigation. The v1 store
+scores with keyword/resource/cluster overlap — an embedding-backed store can
+replace it behind the same search()/best_match() interface without touching
+the agent.
+"""
+
+from .records import (
+    IncidentRecord,
+    caller_namespace,
+    extract_incident,
+    incidents_enabled,
+)
+from .store import (
+    IncidentStore,
+    build_surface_note,
+    format_search_results,
+    score_incident,
+)
+
+__all__ = [
+    "IncidentRecord",
+    "IncidentStore",
+    "build_surface_note",
+    "caller_namespace",
+    "extract_incident",
+    "format_search_results",
+    "incidents_enabled",
+    "score_incident",
+]

--- a/kubently/modules/incidents/records.py
+++ b/kubently/modules/incidents/records.py
@@ -1,0 +1,326 @@
+"""Incident record shape, extraction from concluded investigations, and the
+per-caller namespace derivation shared with the conversation checkpointer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+
+ENABLED_ENV = "KUBENTLY_INCIDENT_HISTORY"
+
+# Namespace used when there is no authenticated caller (direct/local
+# invocation). Matches the checkpointer's behaviour of falling back to the
+# raw, un-prefixed thread id in single-tenant deployments.
+LOCAL_NAMESPACE = "local"
+
+# An RCA one-liner longer than this is a paragraph, not a summary.
+MAX_FIELD_CHARS = 300
+MAX_RESOURCES = 12
+MAX_SYMPTOMS = 8
+
+# Failure-mode vocabulary for symptom keywords. Substring-matched against the
+# lowercased investigation text; ordering is stable so records are
+# deterministic. Deliberately coarse — symptoms are a retrieval signal, not a
+# diagnosis.
+SYMPTOM_TERMS = (
+    "crashloopbackoff",
+    "oomkilled",
+    "oom",
+    "imagepullbackoff",
+    "errimagepull",
+    "createcontainerconfigerror",
+    "failedscheduling",
+    "unschedulable",
+    "pending",
+    "evicted",
+    "not ready",
+    "notready",
+    "connection refused",
+    "timed out",
+    "timeout",
+    "dns",
+    "forbidden",
+    "rbac",
+    "unauthorized",
+    "networkpolicy",
+    "network policy",
+    "no endpoints",
+    "0 endpoints",
+    "probe",
+    "readiness",
+    "liveness",
+    "restart",
+    "crash",
+    "502",
+    "503",
+    "5xx",
+    "quota",
+    "disk pressure",
+    "memory pressure",
+    "pvc",
+    "volume",
+    "mount",
+    "certificate",
+    "tls",
+    "selector",
+    "port mismatch",
+    "image pull",
+    "backoff",
+    "throttl",
+    "misconfigur",
+)
+
+# Same token shape as the runbook matcher: keep the characters Kubernetes
+# names use so resource names survive tokenization intact.
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
+
+# The agent's response template renders "- Root Cause: <one-liner>"; accept
+# loose variants (markdown decoration, missing bullet, en-dash) because the
+# model does not always follow the template exactly.
+_ROOT_CAUSE_RE = re.compile(
+    r"root\s*cause\s*[:\-–]\s*[*_`]*\s*(?P<cause>[^\n]+)", re.IGNORECASE
+)
+
+# "🔧 Fix:" heading (content on following lines) or inline "Fix:/Resolution:".
+_RESOLUTION_RE = re.compile(
+    r"(?:fix|resolution|remediation)\s*[:\-–]\s*[*_`]*\s*(?P<res>[^\n]*)",
+    re.IGNORECASE,
+)
+
+
+def incidents_enabled() -> bool:
+    """Feature kill-switch: default ON, KUBENTLY_INCIDENT_HISTORY=false disables."""
+    raw = os.getenv(ENABLED_ENV, "true").strip().lower()
+    return raw not in ("false", "0", "no", "off", "disabled")
+
+
+def caller_namespace() -> str:
+    """Namespace for the current caller's incident records.
+
+    Uses the same derivation as the checkpointer's thread namespacing
+    (_namespaced_thread_id in agent.py): a short hash of the authenticated
+    caller's API key. Records written and read through this namespace can
+    therefore never cross tenants — the same security boundary the
+    conversation memory relies on. Unauthenticated/local invocation gets a
+    fixed "local" namespace, preserving single-tenant behaviour.
+    """
+    try:
+        from kubently.modules.auth.context import current_api_key
+
+        key = current_api_key.get()
+    except Exception:
+        key = None
+    if not key:
+        return LOCAL_NAMESPACE
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class IncidentRecord:
+    """One concluded investigation, compressed to its retrievable essence."""
+
+    id: str
+    timestamp: str  # ISO-8601 UTC
+    root_cause: str
+    cluster_id: str | None = None
+    resources: tuple = ()
+    symptoms: tuple = ()
+    resolution: str | None = None
+    thread_id: str | None = None
+    query: str | None = None  # the user question that started the investigation
+
+    def to_json(self) -> str:
+        data = asdict(self)
+        data["resources"] = list(self.resources)
+        data["symptoms"] = list(self.symptoms)
+        return json.dumps(data, ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, raw: str) -> IncidentRecord:
+        data = json.loads(raw)
+        data["resources"] = tuple(data.get("resources") or ())
+        data["symptoms"] = tuple(data.get("symptoms") or ())
+        known = {f for f in cls.__dataclass_fields__}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+    def date(self) -> str:
+        """Human date (YYYY-MM-DD) for citations."""
+        return self.timestamp[:10]
+
+
+def _clean_line(text: str) -> str:
+    """Strip markdown decoration and bound the length of an extracted field."""
+    cleaned = text.strip().strip("*_`").strip()
+    # Drop a trailing markdown emphasis remnant like "**" mid-strip left over.
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    if len(cleaned) > MAX_FIELD_CHARS:
+        cleaned = cleaned[: MAX_FIELD_CHARS - 1].rstrip() + "…"
+    return cleaned
+
+
+def extract_root_cause(text: str) -> str | None:
+    """The root-cause one-liner from a final answer, or None when the answer
+    contains no explicit root-cause statement (= no RCA, nothing to record)."""
+    if not text:
+        return None
+    m = _ROOT_CAUSE_RE.search(text)
+    if not m:
+        return None
+    cause = _clean_line(m.group("cause"))
+    return cause or None
+
+
+def extract_resolution(text: str) -> str | None:
+    """First line of the fix/resolution section, when one is stated."""
+    if not text:
+        return None
+    for m in _RESOLUTION_RE.finditer(text):
+        inline = _clean_line(m.group("res"))
+        if inline:
+            return inline
+        # Heading form ("🔧 Fix:\n1. do the thing"): take the next non-empty line.
+        rest = text[m.end() :]
+        for line in rest.splitlines():
+            cleaned = _clean_line(line)
+            if cleaned:
+                return cleaned
+    return None
+
+
+def extract_symptoms(*texts: str) -> tuple:
+    """Symptom keywords present in the given texts, vocabulary order."""
+    lowered = " ".join(t.lower() for t in texts if t)
+    found = []
+    for term in SYMPTOM_TERMS:
+        if term in lowered and term not in found:
+            found.append(term)
+        if len(found) >= MAX_SYMPTOMS:
+            break
+    return tuple(found)
+
+
+def _flatten_text(content) -> str:
+    """Coerce an LLM message content (str or content-block list) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+        return "\n".join(parts)
+    return str(content or "")
+
+
+def extract_resources(tool_calls) -> tuple:
+    """Resources touched during the investigation, from the tool-call trace.
+
+    Best-effort: pulls namespaces and resource/pod/workload names out of the
+    recorded tool-call args (the interceptor trace every tool must feed).
+    Produces "namespace/name" strings where both are known, bare names
+    otherwise.
+    """
+    resources: list = []
+
+    def add(item: str | None) -> None:
+        if not item:
+            return
+        item = str(item).strip()
+        if not item or item in ("default", "all") or item in resources:
+            return
+        if len(resources) < MAX_RESOURCES:
+            resources.append(item)
+
+    for call in tool_calls or ():
+        args = call.get("args") or {}
+        ns = args.get("namespace")
+        if ns in ("default", "all"):
+            ns = None
+        for key in ("resource_name", "pod_name"):
+            name = args.get(key)
+            if name:
+                add(f"{ns}/{name}" if ns else str(name))
+        parsed = args.get("parsed") or {}
+        pns = parsed.get("namespace")
+        if pns in ("default", "all"):
+            pns = None
+        name = parsed.get("name")
+        if name:
+            add(f"{pns or ns}/{name}" if (pns or ns) else str(name))
+        selector = args.get("selector")
+        if selector:
+            add(f"{ns}/{selector}" if ns else str(selector))
+        if ns:
+            add(str(ns))
+    return tuple(resources)
+
+
+def extract_cluster(tool_calls, cluster_id: str | None = None) -> str | None:
+    """The investigation's cluster: explicit context wins, else the cluster
+    most tool calls targeted."""
+    if cluster_id:
+        return cluster_id
+    counts: dict = {}
+    for call in tool_calls or ():
+        args = call.get("args") or {}
+        cid = args.get("cluster_id")
+        if cid:
+            counts[str(cid)] = counts.get(str(cid), 0) + 1
+    if not counts:
+        return None
+    return max(counts, key=counts.get)
+
+
+def extract_incident(
+    final_text,
+    *,
+    user_text: str = "",
+    tool_calls=(),
+    cluster_id: str | None = None,
+    thread_id: str | None = None,
+    now: datetime | None = None,
+) -> IncidentRecord | None:
+    """Build an incident record from a concluded investigation.
+
+    Returns None when the final answer states no root cause — that is the
+    "did this investigation conclude with an RCA?" detector: chit-chat,
+    partial answers and clarifying questions produce no record.
+
+    The record id is deterministic over (thread, root cause), so a multi-turn
+    conversation that restates the same diagnosis updates one record instead
+    of piling up near-duplicates.
+    """
+    text = _flatten_text(final_text)
+    root_cause = extract_root_cause(text)
+    if not root_cause:
+        return None
+
+    ts = (now or datetime.now(UTC)).isoformat()
+    incident_id = hashlib.sha256(
+        f"{thread_id or ''}|{root_cause.lower()}".encode()
+    ).hexdigest()[:16]
+
+    query = _clean_line(user_text) if user_text else None
+    return IncidentRecord(
+        id=incident_id,
+        timestamp=ts,
+        root_cause=root_cause,
+        cluster_id=extract_cluster(tool_calls, cluster_id),
+        resources=extract_resources(tool_calls),
+        symptoms=extract_symptoms(user_text, text),
+        resolution=extract_resolution(text),
+        thread_id=thread_id,
+        query=query,
+    )
+
+
+def tokens(text: str) -> set:
+    """Tokenize search text the way the runbook matcher does (Kubernetes
+    names keep their hyphens/dots)."""
+    return set(_TOKEN_RE.findall((text or "").lower()))

--- a/kubently/modules/incidents/records.py
+++ b/kubently/modules/incidents/records.py
@@ -82,12 +82,12 @@ _TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
 # loose variants (markdown decoration, missing bullet, en-dash) because the
 # model does not always follow the template exactly.
 _ROOT_CAUSE_RE = re.compile(
-    r"root\s*cause\s*[:\-–]\s*[*_`]*\s*(?P<cause>[^\n]+)", re.IGNORECASE
+    r"root\s*cause\s*[:\-\u2013]\s*[*_`]*\s*(?P<cause>[^\n]+)", re.IGNORECASE
 )
 
 # "🔧 Fix:" heading (content on following lines) or inline "Fix:/Resolution:".
 _RESOLUTION_RE = re.compile(
-    r"(?:fix|resolution|remediation)\s*[:\-–]\s*[*_`]*\s*(?P<res>[^\n]*)",
+    r"(?:fix|resolution|remediation)\s*[:\-\u2013]\s*[*_`]*\s*(?P<res>[^\n]*)",
     re.IGNORECASE,
 )
 
@@ -218,6 +218,28 @@ def _flatten_text(content) -> str:
     return str(content or "")
 
 
+def _significant_ns(value) -> str | None:
+    """A namespace worth recording ("default"/"all" carry no signal)."""
+    if value in (None, "default", "all"):
+        return None
+    return str(value)
+
+
+def _named_resources(args: dict) -> list:
+    """(namespace, name) pairs one tool call's args point at."""
+    ns = _significant_ns(args.get("namespace"))
+    pairs = []
+    for key in ("resource_name", "pod_name", "selector"):
+        if args.get(key):
+            pairs.append((ns, str(args[key])))
+    parsed = args.get("parsed") or {}
+    if parsed.get("name"):
+        pairs.append((_significant_ns(parsed.get("namespace")) or ns, str(parsed["name"])))
+    if ns:
+        pairs.append((None, ns))
+    return pairs
+
+
 def extract_resources(tool_calls) -> tuple:
     """Resources touched during the investigation, from the tool-call trace.
 
@@ -227,37 +249,11 @@ def extract_resources(tool_calls) -> tuple:
     otherwise.
     """
     resources: list = []
-
-    def add(item: str | None) -> None:
-        if not item:
-            return
-        item = str(item).strip()
-        if not item or item in ("default", "all") or item in resources:
-            return
-        if len(resources) < MAX_RESOURCES:
-            resources.append(item)
-
     for call in tool_calls or ():
-        args = call.get("args") or {}
-        ns = args.get("namespace")
-        if ns in ("default", "all"):
-            ns = None
-        for key in ("resource_name", "pod_name"):
-            name = args.get(key)
-            if name:
-                add(f"{ns}/{name}" if ns else str(name))
-        parsed = args.get("parsed") or {}
-        pns = parsed.get("namespace")
-        if pns in ("default", "all"):
-            pns = None
-        name = parsed.get("name")
-        if name:
-            add(f"{pns or ns}/{name}" if (pns or ns) else str(name))
-        selector = args.get("selector")
-        if selector:
-            add(f"{ns}/{selector}" if ns else str(selector))
-        if ns:
-            add(str(ns))
+        for ns, name in _named_resources(call.get("args") or {}):
+            item = f"{ns}/{name}" if ns else name
+            if item not in resources and len(resources) < MAX_RESOURCES:
+                resources.append(item)
     return tuple(resources)
 
 
@@ -302,9 +298,9 @@ def extract_incident(
         return None
 
     ts = (now or datetime.now(UTC)).isoformat()
-    incident_id = hashlib.sha256(
-        f"{thread_id or ''}|{root_cause.lower()}".encode()
-    ).hexdigest()[:16]
+    incident_id = hashlib.sha256(f"{thread_id or ''}|{root_cause.lower()}".encode()).hexdigest()[
+        :16
+    ]
 
     query = _clean_line(user_text) if user_text else None
     return IncidentRecord(

--- a/kubently/modules/incidents/store.py
+++ b/kubently/modules/incidents/store.py
@@ -1,0 +1,335 @@
+"""Redis-backed incident record store with keyword retrieval.
+
+Key layout (prefix "kubently:incidents"; {ns} is the caller namespace from
+records.caller_namespace — the SAME per-caller derivation the conversation
+checkpointer uses for thread ids, so record isolation follows the identical
+security boundary):
+
+- {p}:rec:{ns}:{id}   string: JSON-serialized IncidentRecord, TTL-bound
+- {p}:idx:{ns}        zset: incident ids scored by record epoch time
+
+Every key embeds the namespace and every operation takes an explicit
+namespace, so no read or write can ever range across namespaces. Only core
+Redis commands are used (SET/ZADD/ZRANGE/MGET) — no RediSearch, no SCAN —
+matching the plain-redis checkpointer's managed-Redis discipline.
+
+Retrieval is v1 keyword scoring: cluster match > resource-name overlap >
+symptom overlap > root-cause token overlap, newest-first tiebreak. The
+search()/best_match() interface is the seam where an embedding-backed store
+would slot in later (same inputs: namespace + free text + optional cluster;
+same outputs: scored records) — swap the class, keep the agent untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from .records import IncidentRecord, tokens
+
+logger = logging.getLogger(__name__)
+
+TTL_ENV = "KUBENTLY_INCIDENT_TTL_SECONDS"
+CAP_ENV = "KUBENTLY_INCIDENT_MAX_PER_NAMESPACE"
+SURFACE_MIN_SCORE_ENV = "KUBENTLY_INCIDENT_SURFACE_MIN_SCORE"
+
+# ~90 days: long enough for "have we seen this before?" to span quarters,
+# short enough that stale cluster state ages out. 0 disables expiry.
+DEFAULT_TTL_SECONDS = 90 * 24 * 3600
+DEFAULT_MAX_PER_NAMESPACE = 200
+
+# Score weights. A resource-name hit is the strongest single retrieval signal
+# (specific object recurring), then the cluster, then coarse symptom words.
+RESOURCE_WEIGHT = 25
+CLUSTER_WEIGHT = 20
+SYMPTOM_WEIGHT = 15
+TEXT_WEIGHT = 5
+# Per-signal contribution caps so one dimension can't drown the others.
+MAX_RESOURCE_HITS = 2
+MAX_SYMPTOM_HITS = 3
+MAX_TEXT_HITS = 5
+
+# Auto-surface only on a strong match: roughly "a specific resource plus a
+# matching symptom" (25+15) or "same cluster plus symptoms". Below this the
+# note would be noise injected into every vaguely similar investigation.
+DEFAULT_SURFACE_MIN_SCORE = 40
+
+# Newest records considered per search. Bounds MGET fan-out; with the
+# per-namespace cap at its default this covers the whole namespace.
+SEARCH_SCAN_LIMIT = 500
+
+# Generic words that would otherwise inflate root-cause text overlap.
+_STOPWORDS = frozenset(
+    "the a an is are was were to of in on for with and or not no by at it its "
+    "this that pod pods container containers due caused causing because from "
+    "has have had be been being as".split()
+)
+
+
+def _s(value: Any) -> str:
+    """Normalize a Redis reply to str (client may or may not decode responses)."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return value
+
+
+def _resolve_ttl() -> int | None:
+    raw = os.getenv(TTL_ENV, "").strip()
+    if not raw:
+        return DEFAULT_TTL_SECONDS
+    ttl = int(raw)
+    return ttl if ttl > 0 else None
+
+
+def _resolve_cap() -> int:
+    raw = os.getenv(CAP_ENV, "").strip()
+    if not raw:
+        return DEFAULT_MAX_PER_NAMESPACE
+    cap = int(raw)
+    return cap if cap > 0 else DEFAULT_MAX_PER_NAMESPACE
+
+
+def surface_min_score() -> int:
+    raw = os.getenv(SURFACE_MIN_SCORE_ENV, "").strip()
+    if not raw:
+        return DEFAULT_SURFACE_MIN_SCORE
+    return int(raw)
+
+
+def score_incident(
+    record: IncidentRecord,
+    query_text: str,
+    cluster_id: str | None = None,
+) -> int:
+    """Relevance of one past incident to a new investigation. 0 = unrelated."""
+    query_tokens = tokens(query_text)
+    lowered = (query_text or "").lower()
+    score = 0
+
+    # Cluster: explicit context match, or the cluster named in the query text.
+    if record.cluster_id:
+        rc = record.cluster_id.lower()
+        if (cluster_id and rc == cluster_id.lower()) or rc in query_tokens:
+            score += CLUSTER_WEIGHT
+
+    # Resources: split "namespace/name" so either half can match. Prefix
+    # matching (min 4 chars) lets a workload name in the query match stored
+    # pod names that carry ReplicaSet/pod hash suffixes, and vice versa.
+    resource_tokens = set()
+    for res in record.resources:
+        for part in str(res).lower().split("/"):
+            if part:
+                resource_tokens.add(part)
+    resource_hits = 0
+    for rt in resource_tokens:
+        if rt in query_tokens or any(
+            len(qt) >= 4 and (rt.startswith(qt) or qt.startswith(rt))
+            for qt in query_tokens
+        ):
+            resource_hits += 1
+    score += RESOURCE_WEIGHT * min(resource_hits, MAX_RESOURCE_HITS)
+
+    # Symptoms: substring match, same as extraction.
+    symptom_hits = sum(1 for s in record.symptoms if s in lowered)
+    score += SYMPTOM_WEIGHT * min(symptom_hits, MAX_SYMPTOM_HITS)
+
+    # Root cause + original question: token overlap minus stopwords.
+    cause_tokens = (tokens(record.root_cause) | tokens(record.query or "")) - _STOPWORDS
+    score += TEXT_WEIGHT * min(
+        len(cause_tokens & (query_tokens - _STOPWORDS)), MAX_TEXT_HITS
+    )
+    return score
+
+
+class IncidentStore:
+    """Per-namespace incident persistence and retrieval on core Redis."""
+
+    def __init__(
+        self,
+        redis_client: Any,
+        *,
+        prefix: str = "kubently:incidents",
+        ttl_seconds: int | None = None,
+        max_per_namespace: int | None = None,
+    ) -> None:
+        self._redis = redis_client
+        self._prefix = prefix
+        self._ttl = ttl_seconds if ttl_seconds is not None else _resolve_ttl()
+        if self._ttl is not None and self._ttl <= 0:
+            self._ttl = None
+        self._cap = max_per_namespace if max_per_namespace else _resolve_cap()
+
+    # -- keys ----------------------------------------------------------------
+
+    def _rec_key(self, namespace: str, incident_id: str) -> str:
+        return f"{self._prefix}:rec:{namespace}:{incident_id}"
+
+    def _idx_key(self, namespace: str) -> str:
+        return f"{self._prefix}:idx:{namespace}"
+
+    # -- write ---------------------------------------------------------------
+
+    async def record(self, namespace: str, record: IncidentRecord) -> None:
+        """Persist one record; enforce the per-namespace cap (oldest evicted)."""
+        try:
+            epoch = datetime.fromisoformat(record.timestamp).timestamp()
+        except ValueError:
+            epoch = time.time()
+
+        idx_key = self._idx_key(namespace)
+        pipe = self._redis.pipeline(transaction=True)
+        if self._ttl:
+            pipe.set(self._rec_key(namespace, record.id), record.to_json(), ex=self._ttl)
+            # The index outlives any single record by design: refresh it to
+            # the newest record's TTL so it expires with its last record.
+            pipe.zadd(idx_key, {record.id: epoch})
+            pipe.expire(idx_key, self._ttl)
+        else:
+            pipe.set(self._rec_key(namespace, record.id), record.to_json())
+            pipe.zadd(idx_key, {record.id: epoch})
+        await pipe.execute()
+
+        # Cap enforcement: evict oldest beyond the namespace budget.
+        count = await self._redis.zcard(idx_key)
+        excess = count - self._cap
+        if excess > 0:
+            oldest = [_s(i) for i in await self._redis.zrange(idx_key, 0, excess - 1)]
+            if oldest:
+                pipe = self._redis.pipeline(transaction=True)
+                pipe.delete(*[self._rec_key(namespace, i) for i in oldest])
+                pipe.zrem(idx_key, *oldest)
+                await pipe.execute()
+
+    # -- read ----------------------------------------------------------------
+
+    async def load_recent(self, namespace: str, limit: int = SEARCH_SCAN_LIMIT) -> list:
+        """Newest records in one namespace. Index entries whose record has
+        TTL-expired are pruned lazily here."""
+        idx_key = self._idx_key(namespace)
+        ids = [_s(i) for i in await self._redis.zrevrange(idx_key, 0, limit - 1)]
+        if not ids:
+            return []
+        raws = await self._redis.mget([self._rec_key(namespace, i) for i in ids])
+        records: list = []
+        expired: list = []
+        for incident_id, raw in zip(ids, raws):
+            if raw is None:
+                expired.append(incident_id)
+                continue
+            try:
+                records.append(IncidentRecord.from_json(_s(raw)))
+            except Exception:
+                expired.append(incident_id)
+        if expired:
+            await self._redis.zrem(idx_key, *expired)
+        return records
+
+    async def count(self, namespace: str) -> int:
+        return await self._redis.zcard(self._idx_key(namespace))
+
+    async def search(
+        self,
+        namespace: str,
+        query: str = "",
+        cluster_id: str | None = None,
+        limit: int = 5,
+        min_score: int = 1,
+        exclude_thread_id: str | None = None,
+    ) -> list:
+        """Scored keyword search over one namespace's records.
+
+        Returns [(score, IncidentRecord)] best-first (recency breaks ties).
+        With no query text, returns the newest records (score 0) so "list
+        recent incidents" works too.
+        """
+        records = await self.load_recent(namespace)
+        if exclude_thread_id:
+            records = [r for r in records if r.thread_id != exclude_thread_id]
+        if not (query or "").strip() and not cluster_id:
+            return [(0, r) for r in records[:limit]]
+        scored = [(score_incident(r, query, cluster_id), r) for r in records]
+        matched = [(s, r) for s, r in scored if s >= min_score]
+        # load_recent is newest-first; stable sort keeps that order on ties.
+        matched.sort(key=lambda sr: -sr[0])
+        return matched[:limit]
+
+    async def best_match(
+        self,
+        namespace: str,
+        query: str,
+        cluster_id: str | None = None,
+        exclude_thread_id: str | None = None,
+        exclude_ids=(),
+    ):
+        """The strongest past-incident match, or None below the surface
+        threshold. This is the auto-surface gate: weak matches stay silent."""
+        results = await self.search(
+            namespace,
+            query,
+            cluster_id=cluster_id,
+            limit=len(exclude_ids) + 1 if exclude_ids else 1,
+            min_score=surface_min_score(),
+            exclude_thread_id=exclude_thread_id,
+        )
+        for score, record in results:
+            if record.id not in exclude_ids:
+                return score, record
+        return None
+
+
+# -- presentation ------------------------------------------------------------
+
+RESULTS_FRAMING = (
+    "Past incidents are summaries of previous diagnoses in this deployment — "
+    "context, not evidence. Verify against the current cluster state before "
+    "relying on one; if a past incident materially informs your diagnosis, "
+    "cite it in your root-cause summary (e.g. \"same root cause as the "
+    "{date} incident\")."
+)
+
+
+def _format_record(score: int, record: IncidentRecord) -> str:
+    lines = [f"- [{record.date()}] root cause: {record.root_cause}"]
+    details = []
+    if record.cluster_id:
+        details.append(f"cluster: {record.cluster_id}")
+    if record.resources:
+        details.append(f"resources: {', '.join(record.resources[:6])}")
+    if record.symptoms:
+        details.append(f"symptoms: {', '.join(record.symptoms)}")
+    if details:
+        lines.append("  " + "; ".join(details))
+    if record.resolution:
+        lines.append(f"  resolution: {record.resolution}")
+    return "\n".join(lines)
+
+
+def format_search_results(scored: list) -> str:
+    """Tool output for search_past_incidents."""
+    if not scored:
+        return (
+            "No matching past incidents found in this deployment's incident "
+            "history. This does not mean the problem is new — history only "
+            "covers investigations that concluded here with a root cause."
+        )
+    parts = [f"Found {len(scored)} matching past incident(s), best match first:\n"]
+    parts.extend(_format_record(s, r) for s, r in scored)
+    parts.append("\n" + RESULTS_FRAMING)
+    return "\n".join(parts)
+
+
+def build_surface_note(record: IncidentRecord) -> str:
+    """The one-line context note injected when a new investigation strongly
+    matches a past incident."""
+    resolution = f" Resolution then: {record.resolution}." if record.resolution else ""
+    return (
+        f"SIMILAR PAST INCIDENT ({record.date()}): {record.root_cause}.{resolution} "
+        "This past diagnosis may or may not apply now — verify with fresh "
+        "evidence rather than assuming. If it materially informs your "
+        "diagnosis, cite it (e.g. \"same root cause as the "
+        f"{record.date()} incident\"). Use the search_past_incidents tool "
+        "for more history."
+    )

--- a/kubently/modules/incidents/store.py
+++ b/kubently/modules/incidents/store.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 
 from .records import IncidentRecord, tokens
@@ -63,9 +63,47 @@ SEARCH_SCAN_LIMIT = 500
 
 # Generic words that would otherwise inflate root-cause text overlap.
 _STOPWORDS = frozenset(
-    "the a an is are was were to of in on for with and or not no by at it its "
-    "this that pod pods container containers due caused causing because from "
-    "has have had be been being as".split()
+    {
+        "the",
+        "a",
+        "an",
+        "is",
+        "are",
+        "was",
+        "were",
+        "to",
+        "of",
+        "in",
+        "on",
+        "for",
+        "with",
+        "and",
+        "or",
+        "not",
+        "no",
+        "by",
+        "at",
+        "it",
+        "its",
+        "this",
+        "that",
+        "pod",
+        "pods",
+        "container",
+        "containers",
+        "due",
+        "caused",
+        "causing",
+        "because",
+        "from",
+        "has",
+        "have",
+        "had",
+        "be",
+        "been",
+        "being",
+        "as",
+    }
 )
 
 
@@ -126,8 +164,7 @@ def score_incident(
     resource_hits = 0
     for rt in resource_tokens:
         if rt in query_tokens or any(
-            len(qt) >= 4 and (rt.startswith(qt) or qt.startswith(rt))
-            for qt in query_tokens
+            len(qt) >= 4 and (rt.startswith(qt) or qt.startswith(rt)) for qt in query_tokens
         ):
             resource_hits += 1
     score += RESOURCE_WEIGHT * min(resource_hits, MAX_RESOURCE_HITS)
@@ -138,9 +175,7 @@ def score_incident(
 
     # Root cause + original question: token overlap minus stopwords.
     cause_tokens = (tokens(record.root_cause) | tokens(record.query or "")) - _STOPWORDS
-    score += TEXT_WEIGHT * min(
-        len(cause_tokens & (query_tokens - _STOPWORDS)), MAX_TEXT_HITS
-    )
+    score += TEXT_WEIGHT * min(len(cause_tokens & (query_tokens - _STOPWORDS)), MAX_TEXT_HITS)
     return score
 
 
@@ -215,7 +250,7 @@ class IncidentStore:
         raws = await self._redis.mget([self._rec_key(namespace, i) for i in ids])
         records: list = []
         expired: list = []
-        for incident_id, raw in zip(ids, raws):
+        for incident_id, raw in zip(ids, raws, strict=False):
             if raw is None:
                 expired.append(incident_id)
                 continue
@@ -286,8 +321,8 @@ RESULTS_FRAMING = (
     "Past incidents are summaries of previous diagnoses in this deployment — "
     "context, not evidence. Verify against the current cluster state before "
     "relying on one; if a past incident materially informs your diagnosis, "
-    "cite it in your root-cause summary (e.g. \"same root cause as the "
-    "{date} incident\")."
+    'cite it in your root-cause summary (e.g. "same root cause as the '
+    '{date} incident").'
 )
 
 
@@ -329,7 +364,7 @@ def build_surface_note(record: IncidentRecord) -> str:
         f"SIMILAR PAST INCIDENT ({record.date()}): {record.root_cause}.{resolution} "
         "This past diagnosis may or may not apply now — verify with fresh "
         "evidence rather than assuming. If it materially informs your "
-        "diagnosis, cite it (e.g. \"same root cause as the "
-        f"{record.date()} incident\"). Use the search_past_incidents tool "
+        'diagnosis, cite it (e.g. "same root cause as the '
+        f'{record.date()} incident"). Use the search_past_incidents tool '
         "for more history."
     )

--- a/tests/test_incident_agent_integration.py
+++ b/tests/test_incident_agent_integration.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Incident history wired through KubentlyAgent.run().
+
+Module behaviour is covered in test_incidents.py; these tests pin the agent
+integration itself: a concluded RCA is persisted, a later similar
+investigation gets the auto-surface note (deduped per thread, never the
+thread's own record), the search_past_incidents tool is registered exactly
+when the feature is on, and the kill switch removes all of it.
+
+The LLM/graph is stubbed: run() drives a fake compiled graph that returns a
+canned final answer, so no model call and no checkpointer is involved.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+pytest.importorskip("langchain_core")
+pytest.importorskip("deepagents")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from langchain_core.messages import AIMessage  # noqa: E402
+
+from kubently.modules.a2a.protocol_bindings.a2a_server.agent import KubentlyAgent  # noqa: E402
+from kubently.modules.incidents import IncidentStore  # noqa: E402
+
+RCA_ANSWER = (
+    "📊 Summary:\n"
+    "- Root Cause: checkout-api readiness probe points at port 8081 but the "
+    "container listens on 8080, so the service has no endpoints.\n"
+    "🔧 Fix:\nAlign the probe port with the container port.\n"
+)
+
+
+class FakeGraph:
+    """Stands in for the compiled deepagents graph."""
+
+    def __init__(self, answer: str):
+        self.answer = answer
+        self.invocations = []
+
+    async def ainvoke(self, payload, config=None):
+        self.invocations.append(payload)
+        return {"messages": [AIMessage(content=self.answer)]}
+
+
+def make_agent(redis, answer=RCA_ANSWER, incidents=True) -> KubentlyAgent:
+    agent = KubentlyAgent(redis_client=redis)
+    # Short-circuit initialize(): stub everything it would build.
+    agent._initialized = True
+    agent._memory_disabled = True
+    agent.memory = None
+    agent.runbooks = None
+    agent.incidents = IncidentStore(redis) if incidents else None
+    agent.agent = FakeGraph(answer)
+    return agent
+
+
+async def drain(agent, messages, **kwargs):
+    return [item async for item in agent.run(messages, **kwargs)]
+
+
+@pytest.fixture
+def redis():
+    return fakeredis.FakeAsyncRedis(decode_responses=True)
+
+
+async def test_rca_answer_is_recorded(redis):
+    agent = make_agent(redis)
+    out = await drain(
+        agent,
+        [{"role": "user", "content": "why does checkout-api have no endpoints?"}],
+        thread_id="t1",
+        cluster_id="prod-east",
+    )
+    assert out and out[0]["type"] == "message"
+    # The concluded RCA left a record in the (unauthenticated → local) namespace.
+    records = await agent.incidents.load_recent("local")
+    assert len(records) == 1
+    rec = records[0]
+    assert "readiness probe" in rec.root_cause
+    assert rec.cluster_id == "prod-east"
+    assert rec.thread_id == "t1"
+
+
+async def test_non_rca_answer_records_nothing(redis):
+    agent = make_agent(redis, answer="All pods are healthy — nothing to fix.")
+    await drain(agent, [{"role": "user", "content": "any problems?"}], thread_id="t1")
+    assert await agent.incidents.count("local") == 0
+
+
+async def test_similar_investigation_gets_surface_note(redis):
+    # First conversation concludes with an RCA.
+    first = make_agent(redis)
+    await drain(
+        first,
+        [{"role": "user", "content": "checkout-api has no endpoints"}],
+        thread_id="t1",
+        cluster_id="prod-east",
+    )
+    # A NEW conversation with matching symptoms gets the note injected.
+    second = make_agent(redis)
+    await drain(
+        second,
+        [{"role": "user", "content": "checkout-api service has no endpoints again"}],
+        thread_id="t2",
+        cluster_id="prod-east",
+    )
+    sent = second.agent.invocations[0]["messages"]
+    injected = [m.content for m in sent if "SIMILAR PAST INCIDENT" in str(m.content)]
+    assert injected, "expected the auto-surface note in the model input"
+    assert "readiness probe" in injected[0]
+    assert "verify" in injected[0].lower()
+
+
+async def test_own_thread_never_surfaces_its_own_record(redis):
+    agent = make_agent(redis)
+    msgs = [{"role": "user", "content": "checkout-api has no endpoints"}]
+    await drain(agent, msgs, thread_id="t1", cluster_id="prod-east")
+    # Turn 2 of the SAME thread: its own turn-1 diagnosis must not echo back.
+    await drain(agent, msgs, thread_id="t1", cluster_id="prod-east")
+    sent = agent.agent.invocations[1]["messages"]
+    assert not any("SIMILAR PAST INCIDENT" in str(m.content) for m in sent)
+
+
+async def test_surface_note_deduped_within_thread(redis):
+    seeder = make_agent(redis)
+    await drain(
+        seeder,
+        [{"role": "user", "content": "checkout-api has no endpoints"}],
+        thread_id="t1",
+        cluster_id="prod-east",
+    )
+    other = make_agent(redis)
+    msgs = [{"role": "user", "content": "checkout-api service has no endpoints"}]
+    await drain(other, msgs, thread_id="t2", cluster_id="prod-east")
+    await drain(other, msgs, thread_id="t2", cluster_id="prod-east")
+    second_turn = other.agent.invocations[1]["messages"]
+    assert not any("SIMILAR PAST INCIDENT" in str(m.content) for m in second_turn)
+
+
+async def test_unrelated_investigation_gets_no_note(redis):
+    seeder = make_agent(redis)
+    await drain(
+        seeder,
+        [{"role": "user", "content": "checkout-api has no endpoints"}],
+        thread_id="t1",
+        cluster_id="prod-east",
+    )
+    other = make_agent(redis)
+    await drain(
+        other,
+        [{"role": "user", "content": "how many nodes does staging-eu have?"}],
+        thread_id="t2",
+    )
+    sent = other.agent.invocations[0]["messages"]
+    assert not any("SIMILAR PAST INCIDENT" in str(m.content) for m in sent)
+
+
+async def test_kill_switch_disables_everything(redis, monkeypatch):
+    monkeypatch.setenv("KUBENTLY_INCIDENT_HISTORY", "false")
+    agent = make_agent(redis, incidents=False)
+    await drain(
+        agent,
+        [{"role": "user", "content": "checkout-api has no endpoints"}],
+        thread_id="t1",
+    )
+    # Nothing recorded anywhere.
+    assert [k async for k in redis.scan_iter("kubently:incidents:*")] == []
+
+
+def test_search_tool_registration_is_gated():
+    """search_past_incidents registers exactly when the store exists; the
+    baseline toolset is otherwise untouched (additive change only)."""
+    src = Path(
+        "kubently/modules/a2a/protocol_bindings/a2a_server/agent.py"
+    ).read_text()
+    assert "async def search_past_incidents(" in src
+    assert "if self.incidents is not None:" in src
+    # Tool tracing rule from CLAUDE.md: the tool must record calls + results.
+    tool_body = src.split("async def search_past_incidents(")[1].split("self.tools.append")[0]
+    assert "record_tool_call" in tool_body
+    assert "record_tool_result" in tool_body

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Incident history (Track P6c): extraction, persistence, isolation, retrieval.
+
+The store is retrieval over compact summaries of concluded investigations —
+explicitly NOT a learning system. These tests pin the properties that matter:
+
+- extraction only fires when the answer states a root cause (that IS the
+  "investigation concluded with an RCA" detector);
+- records live in per-caller Redis namespaces derived exactly like the
+  checkpointer's thread namespacing — one tenant's incidents must NEVER be
+  visible to another (security boundary, not a convenience);
+- TTL bounds record lifetime and the per-namespace cap evicts oldest-first;
+- keyword scoring ranks by resource/cluster/symptom relevance;
+- auto-surface only triggers on a strong match, never on vague similarity.
+"""
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from kubently.modules.auth.context import current_api_key  # noqa: E402
+from kubently.modules.incidents import (  # noqa: E402
+    IncidentRecord,
+    IncidentStore,
+    build_surface_note,
+    caller_namespace,
+    extract_incident,
+    format_search_results,
+    incidents_enabled,
+    score_incident,
+)
+from kubently.modules.incidents.store import (  # noqa: E402
+    DEFAULT_SURFACE_MIN_SCORE,
+    surface_min_score,
+)
+
+RCA_ANSWER = """📊 Summary:
+- Root Cause: The payment-api deployment's JVM heap flag (-Xmx4g) exceeds the container memory limit (2Gi), so pods are OOMKilled on startup.
+- Evidence: container status shows OOMKilled, restart count 14.
+
+🔧 Fix:
+Set -Xmx to 1536m or raise the memory limit.
+
+✅ Verification:
+kubectl get pods -n payments
+"""
+
+TOOL_TRACE = [
+    {
+        "tool_name": "execute_kubectl",
+        "args": {
+            "cluster_id": "prod-east",
+            "command": "describe pod payment-api-7f9d8-x2v",
+            "namespace": "payments",
+            "parsed": {
+                "verb": "describe",
+                "resource": "pod",
+                "name": "payment-api-7f9d8-x2v",
+                "namespace": "payments",
+            },
+        },
+    },
+    {
+        "tool_name": "search_pod_logs",
+        "args": {
+            "cluster_id": "prod-east",
+            "namespace": "payments",
+            "selector": "app=payment-api",
+            "query": "OutOfMemoryError",
+        },
+    },
+]
+
+
+def make_record(**overrides) -> IncidentRecord:
+    base = dict(
+        id="abc123",
+        timestamp=datetime.now(UTC).isoformat(),
+        root_cause="JVM heap exceeds container memory limit; pods OOMKilled",
+        cluster_id="prod-east",
+        resources=("payments/payment-api-7f9d8-x2v", "payments"),
+        symptoms=("crashloopbackoff", "oomkilled"),
+        resolution="Lower -Xmx below the memory limit",
+        thread_id="thread-1",
+        query="payment-api crashlooping in payments",
+    )
+    base.update(overrides)
+    return IncidentRecord(**base)
+
+
+@pytest.fixture
+def redis():
+    return fakeredis.FakeAsyncRedis(decode_responses=True)
+
+
+@pytest.fixture
+def store(redis):
+    return IncidentStore(redis, ttl_seconds=90 * 24 * 3600, max_per_namespace=200)
+
+
+# -- extraction ---------------------------------------------------------------
+
+
+class TestExtraction:
+    def test_full_extraction_from_rca_answer(self):
+        rec = extract_incident(
+            RCA_ANSWER,
+            user_text="payment-api pods in payments are in CrashLoopBackOff",
+            tool_calls=TOOL_TRACE,
+            thread_id="t1",
+        )
+        assert rec is not None
+        assert rec.root_cause.startswith("The payment-api deployment's JVM heap flag")
+        assert rec.cluster_id == "prod-east"  # inferred from the tool trace
+        assert "payments/payment-api-7f9d8-x2v" in rec.resources
+        assert "payments" in rec.resources
+        assert "crashloopbackoff" in rec.symptoms
+        assert "oomkilled" in rec.symptoms
+        assert rec.resolution.startswith("Set -Xmx to 1536m")
+        assert rec.thread_id == "t1"
+
+    def test_no_root_cause_means_no_record(self):
+        """The root-cause line is the 'RCA produced' detector: answers without
+        one (clarifying questions, healthy-cluster reports) record nothing."""
+        for answer in (
+            "Everything looks healthy — all pods are Running.",
+            "Which cluster would you like me to look at?",
+            "",
+            None,
+        ):
+            assert extract_incident(answer, user_text="check payments") is None
+
+    def test_explicit_cluster_context_wins_over_trace(self):
+        rec = extract_incident(RCA_ANSWER, tool_calls=TOOL_TRACE, cluster_id="staging-eu")
+        assert rec.cluster_id == "staging-eu"
+
+    def test_deterministic_id_dedupes_restated_diagnosis(self):
+        """Same thread restating the same root cause updates one record
+        rather than creating near-duplicates."""
+        a = extract_incident(RCA_ANSWER, thread_id="t1")
+        b = extract_incident(RCA_ANSWER, thread_id="t1")
+        c = extract_incident(RCA_ANSWER, thread_id="t2")
+        assert a.id == b.id
+        assert a.id != c.id
+
+    def test_content_block_list_answers_are_handled(self):
+        """Anthropic answers can arrive as content-block lists, not strings."""
+        blocks = [{"type": "text", "text": RCA_ANSWER}]
+        rec = extract_incident(blocks)
+        assert rec is not None and "JVM heap" in rec.root_cause
+
+    def test_long_root_cause_is_bounded(self):
+        rec = extract_incident("Root Cause: " + "x" * 2000)
+        assert rec is not None
+        assert len(rec.root_cause) <= 300
+
+    def test_json_round_trip(self):
+        rec = make_record()
+        again = IncidentRecord.from_json(rec.to_json())
+        assert again == rec
+
+    def test_kill_switch_env(self, monkeypatch):
+        monkeypatch.delenv("KUBENTLY_INCIDENT_HISTORY", raising=False)
+        assert incidents_enabled() is True  # default ON
+        for off in ("false", "0", "off", "disabled", "FALSE"):
+            monkeypatch.setenv("KUBENTLY_INCIDENT_HISTORY", off)
+            assert incidents_enabled() is False
+        monkeypatch.setenv("KUBENTLY_INCIDENT_HISTORY", "true")
+        assert incidents_enabled() is True
+
+
+# -- namespace derivation -----------------------------------------------------
+
+
+class TestCallerNamespace:
+    def test_matches_checkpointer_thread_derivation(self):
+        """Incident namespaces MUST use the same caller derivation as the
+        checkpointer's thread namespacing — same key, same prefix, so the
+        isolation boundaries line up exactly."""
+        import hashlib
+
+        token = current_api_key.set("tenant-a-key")
+        try:
+            assert caller_namespace() == hashlib.sha256(b"tenant-a-key").hexdigest()[:16]
+        finally:
+            current_api_key.reset(token)
+
+    def test_different_callers_different_namespaces(self):
+        token = current_api_key.set("tenant-a-key")
+        a = caller_namespace()
+        current_api_key.reset(token)
+        token = current_api_key.set("tenant-b-key")
+        b = caller_namespace()
+        current_api_key.reset(token)
+        assert a != b
+
+    def test_key_not_leaked(self):
+        token = current_api_key.set("super-secret-key")
+        ns = caller_namespace()
+        current_api_key.reset(token)
+        assert "super-secret-key" not in ns
+
+    def test_unauthenticated_gets_local(self):
+        assert current_api_key.get() is None
+        assert caller_namespace() == "local"
+
+
+# -- persistence & isolation --------------------------------------------------
+
+
+class TestPersistence:
+    async def test_record_and_search_round_trip(self, store):
+        rec = make_record()
+        await store.record("ns-a", rec)
+        results = await store.search("ns-a", "payment-api oomkilled")
+        assert len(results) == 1
+        score, found = results[0]
+        assert found == rec
+        assert score > 0
+
+    async def test_namespace_isolation_is_absolute(self, store):
+        """CRITICAL: tenant A's incidents must never be visible to tenant B —
+        not via search, not via empty-query listing, not via count."""
+        secret = make_record(root_cause="tenant-a secret database credentials leaked")
+        await store.record("tenant-a", secret)
+
+        assert await store.search("tenant-b", "database credentials leaked") == []
+        assert await store.search("tenant-b", "") == []
+        assert await store.count("tenant-b") == 0
+        assert await store.best_match("tenant-b", "database credentials leaked") is None
+        # And the record IS there for its owner.
+        assert await store.count("tenant-a") == 1
+        assert len(await store.search("tenant-a", "database credentials")) == 1
+
+    async def test_all_keys_embed_the_namespace(self, store, redis):
+        """Defense in depth: every Redis key carries the namespace, so there
+        is no shared key any cross-tenant read could go through."""
+        await store.record("tenant-a", make_record())
+        keys = [k async for k in redis.scan_iter("*")]
+        assert keys, "expected keys to be written"
+        assert all(":tenant-a" in k or ":tenant-a:" in k for k in keys), keys
+
+    async def test_record_ttl_applied(self, redis):
+        store = IncidentStore(redis, ttl_seconds=3600, max_per_namespace=10)
+        rec = make_record()
+        await store.record("ns", rec)
+        ttl = await redis.ttl(f"kubently:incidents:rec:ns:{rec.id}")
+        assert 0 < ttl <= 3600
+        idx_ttl = await redis.ttl("kubently:incidents:idx:ns")
+        assert 0 < idx_ttl <= 3600
+
+    async def test_zero_ttl_disables_expiry(self, redis):
+        store = IncidentStore(redis, ttl_seconds=0, max_per_namespace=10)
+        rec = make_record()
+        await store.record("ns", rec)
+        assert await redis.ttl(f"kubently:incidents:rec:ns:{rec.id}") == -1
+
+    async def test_ttl_env_default(self, monkeypatch, redis):
+        monkeypatch.delenv("KUBENTLY_INCIDENT_TTL_SECONDS", raising=False)
+        store = IncidentStore(redis)
+        assert store._ttl == 90 * 24 * 3600
+        monkeypatch.setenv("KUBENTLY_INCIDENT_TTL_SECONDS", "3600")
+        assert IncidentStore(redis)._ttl == 3600
+        monkeypatch.setenv("KUBENTLY_INCIDENT_TTL_SECONDS", "0")
+        assert IncidentStore(redis)._ttl is None
+
+    async def test_expired_record_pruned_from_index_lazily(self, store, redis):
+        """A rec key that TTL-expired while its index entry survived must be
+        skipped and cleaned up, not returned as garbage."""
+        rec = make_record()
+        await store.record("ns", rec)
+        await redis.delete(f"kubently:incidents:rec:ns:{rec.id}")  # simulate expiry
+        assert await store.search("ns", "payment-api") == []
+        assert await redis.zcard("kubently:incidents:idx:ns") == 0
+
+    async def test_per_namespace_cap_evicts_oldest(self, redis):
+        store = IncidentStore(redis, ttl_seconds=0, max_per_namespace=3)
+        base = datetime.now(UTC)
+        for i in range(5):
+            await store.record(
+                "ns",
+                make_record(
+                    id=f"rec-{i}",
+                    timestamp=(base + timedelta(minutes=i)).isoformat(),
+                    thread_id=f"t-{i}",
+                ),
+            )
+        assert await store.count("ns") == 3
+        remaining = {r.id for r in await store.load_recent("ns")}
+        assert remaining == {"rec-2", "rec-3", "rec-4"}
+        # Evicted records' keys are actually deleted, not just de-indexed.
+        assert await redis.get("kubently:incidents:rec:ns:rec-0") is None
+
+    async def test_cap_is_per_namespace(self, redis):
+        store = IncidentStore(redis, ttl_seconds=0, max_per_namespace=2)
+        for ns in ("a", "b"):
+            for i in range(2):
+                await store.record(ns, make_record(id=f"{ns}-{i}", thread_id=f"{ns}-t{i}"))
+        assert await store.count("a") == 2
+        assert await store.count("b") == 2
+
+    async def test_rewrite_same_id_updates_not_duplicates(self, store):
+        rec = make_record()
+        await store.record("ns", rec)
+        updated = make_record(resolution="a better fix")
+        await store.record("ns", updated)
+        assert await store.count("ns") == 1
+        results = await store.search("ns", "payment-api")
+        assert results[0][1].resolution == "a better fix"
+
+
+# -- scoring & retrieval ------------------------------------------------------
+
+
+class TestScoring:
+    def test_resource_and_symptom_outrank_vague_text(self):
+        rec = make_record()
+        strong = score_incident(rec, "payment-api CrashLoopBackOff in payments", "prod-east")
+        vague = score_incident(rec, "the container memory something")
+        assert strong > vague
+
+    def test_unrelated_query_scores_zero(self):
+        rec = make_record()
+        assert score_incident(rec, "ingress 404 on marketing site in eu-cluster") == 0
+
+    def test_workload_name_matches_hashed_pod_name(self):
+        """Query says 'payment-api'; the stored resource is the pod
+        payment-api-7f9d8-x2v. Prefix matching must connect them."""
+        rec = make_record()
+        assert score_incident(rec, "payment-api failing again") > 0
+
+    def test_cluster_match_contributes(self):
+        rec = make_record()
+        with_cluster = score_incident(rec, "oomkilled", "prod-east")
+        without = score_incident(rec, "oomkilled", "other-cluster")
+        assert with_cluster > without
+
+    async def test_search_ranks_best_first(self, store):
+        await store.record("ns", make_record())
+        await store.record(
+            "ns",
+            make_record(
+                id="dns-1",
+                thread_id="t-dns",
+                root_cause="CoreDNS ConfigMap typo broke cluster DNS",
+                cluster_id="prod-east",
+                resources=("kube-system/coredns",),
+                symptoms=("dns", "timeout"),
+                resolution=None,
+            ),
+        )
+        results = await store.search("ns", "coredns dns lookups timing out")
+        assert results[0][1].id == "dns-1"
+
+    async def test_empty_query_lists_newest_first(self, store):
+        base = datetime.now(UTC)
+        for i in range(3):
+            await store.record(
+                "ns",
+                make_record(
+                    id=f"r{i}",
+                    thread_id=f"t{i}",
+                    timestamp=(base + timedelta(minutes=i)).isoformat(),
+                ),
+            )
+        results = await store.search("ns", "")
+        assert [r.id for _, r in results] == ["r2", "r1", "r0"]
+
+    async def test_search_limit(self, store):
+        for i in range(10):
+            await store.record("ns", make_record(id=f"r{i}", thread_id=f"t{i}"))
+        assert len(await store.search("ns", "payment-api", limit=3)) == 3
+
+
+# -- auto-surface -------------------------------------------------------------
+
+
+class TestAutoSurface:
+    async def test_strong_match_surfaces(self, store):
+        await store.record("ns", make_record())
+        match = await store.best_match(
+            "ns", "payment-api pods CrashLoopBackOff in payments", cluster_id="prod-east"
+        )
+        assert match is not None
+        score, rec = match
+        assert score >= DEFAULT_SURFACE_MIN_SCORE
+        assert rec.id == "abc123"
+
+    async def test_weak_match_stays_silent(self, store):
+        """Vague topical similarity (a couple of shared generic words) must
+        not inject notes into every investigation."""
+        await store.record("ns", make_record())
+        assert await store.best_match("ns", "why is the memory usage graph flat") is None
+
+    async def test_own_thread_excluded(self, store):
+        """Turn 2 of a conversation must not surface turn 1's own diagnosis
+        back at itself."""
+        await store.record("ns", make_record(thread_id="thread-1"))
+        match = await store.best_match(
+            "ns",
+            "payment-api pods CrashLoopBackOff in payments",
+            cluster_id="prod-east",
+            exclude_thread_id="thread-1",
+        )
+        assert match is None
+
+    async def test_exclude_ids_skips_already_surfaced(self, store):
+        await store.record("ns", make_record())
+        match = await store.best_match(
+            "ns",
+            "payment-api pods CrashLoopBackOff in payments",
+            cluster_id="prod-east",
+            exclude_ids={"abc123"},
+        )
+        assert match is None
+
+    def test_threshold_env_override(self, monkeypatch):
+        monkeypatch.delenv("KUBENTLY_INCIDENT_SURFACE_MIN_SCORE", raising=False)
+        assert surface_min_score() == DEFAULT_SURFACE_MIN_SCORE
+        monkeypatch.setenv("KUBENTLY_INCIDENT_SURFACE_MIN_SCORE", "75")
+        assert surface_min_score() == 75
+
+    def test_surface_note_frames_verification_and_citation(self):
+        note = build_surface_note(make_record())
+        assert "SIMILAR PAST INCIDENT" in note
+        assert make_record().date() in note
+        assert "verify" in note.lower()
+        assert "cite" in note.lower()
+        # The one-liner, not a transcript dump.
+        assert len(note) < 800
+
+
+# -- presentation -------------------------------------------------------------
+
+
+class TestFormatting:
+    def test_results_include_citation_guidance(self):
+        text = format_search_results([(65, make_record())])
+        assert "root cause" in text.lower()
+        assert "cite" in text.lower()
+        assert "prod-east" in text
+        assert "Lower -Xmx" in text
+
+    def test_empty_results_are_explicit(self):
+        text = format_search_results([])
+        assert "No matching past incidents" in text


### PR DESCRIPTION
Track P6c (Roadmap Phase 6): "have we seen this before?" — retrieval over stored incident summaries, deliberately not a learning system.

- Concluded investigations persist a compact record (timestamp, cluster, resources, symptom keywords, root-cause one-liner, outcome) in Redis under the checkpointer's namespace discipline — per-namespace isolation tested as a security boundary; configurable TTL (default 90d) + per-namespace cap; env kill-switch.
- `search_past_incidents` agent tool (keyword/resource/cluster scoring, embedding-backend slot for later) plus an auto-surface: strong matches inject a one-line "similar past incident" note with verify-don't-assume guidance; RCAs cite past incidents that informed them.
- Validated locally on the fully converged tree (post C2a + P8): 130 passed, 3 expected skips across incident/MCP-client/GitOps/checkpointer selections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7QembZz4UtCQwbpQiMPzX)_