### PR TITLE
docs: document cloud-telemetry env vars and correct install/getting-started drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## [Unreleased] - 2026-08-17
 
+### Documentation
+- **Doc-drift sweep against the code and the Helm chart.** Documentation
+  only; no behaviour changed.
+  - `docs/ENVIRONMENT_VARIABLES.md`: documented the shipped cloud-telemetry
+    executor variables (`KUBENTLY_CLOUD_MODE` with `off`/`auto`/`aws`/`gcp`,
+    `KUBENTLY_CLOUD_AWS_REGION`, `KUBENTLY_CLOUD_GCP_PROJECT`,
+    `KUBENTLY_CLOUD_REFRESH_INTERVAL`) together with the two behaviours that
+    surprise operators — cloud mode forces capability reporting on, and a
+    missing boto3/google-cloud SDK logs a warning and disables the feature
+    rather than failing the executor — plus the API-side
+    `KUBENTLY_CLOUD_TOOLS` switch. Swept `kubently/` for undocumented
+    variables and added the OIDC set, `REDIS_PASSWORD`,
+    `KUBENTLY_SSL_VERIFY`, `KUBENTLY_CA_CERT`,
+    `KUBENTLY_REPORT_CAPABILITIES`, `KUBENTLY_HEARTBEAT_INTERVAL`,
+    `EXECUTOR_VERSION`, `KUBENTLY_MAX_OUTPUT_CHARS`,
+    `KUBENTLY_PROMPT_FILE`, `GOOGLE_MODEL_NAME`,
+    `ANTHROPIC_CONTEXT_CLEARING`. Corrected: `LLM_PROVIDER` is required with
+    no default (Ollama is not implemented), `ANTHROPIC_MODEL_NAME` defaults
+    to `claude-sonnet-4-6`, `REDIS_HOST` defaults to
+    `kubently-redis-master`, the whitelist variable is
+    `KUBENTLY_WHITELIST_CONFIG`, and `AGENT_TOKEN_<ID>`, `WHITELIST_PATH`,
+    `REFRESH_INTERVAL`, `TIMEOUT_SECONDS`, `OPENAI_ENDPOINT`, `PORT` and
+    `REDIS_URL` are not read by the running API/executor.
+  - `docs/GETTING_STARTED.md`, `docs/QUICK_START.md`, `docs/DEPLOYMENT.md`,
+    `README.md`: install instructions now match
+    `deployment/helm/kubently/values.yaml`. Stated the single-chart model
+    (`api.enabled` / `redis.enabled` / `executor.enabled`; an executor-only
+    install is the same chart, not a `kubently/executor` chart), replaced
+    `executor.rbac.create`/`.rules` with `executor.rbacRules`, removed
+    `executor.replicaCount` (the Deployment is pinned to one replica),
+    corrected `api.replicaCount` / `redis.master.persistence` /
+    `api.existingSecret` defaults, and replaced references to images and
+    manifests that do not exist (`kubently/api`, `kubently/executor`,
+    `deploy/quickstart.yaml`) with the real ones. Documented when the API's
+    `sync-executor-tokens` init container registers an executor token and
+    when the admin API must be used instead.
+  - `docs/INDEX.md`: rebuilt the index — it listed 8 of 26 docs and pointed
+    at a `kubently/agent/README.md` that no longer exists.
+
 ### Added
 - **Incident history (Track P6c)** — past diagnoses become searchable
   institutional memory ("have we seen this before?"). When an investigation

--- a/README.md
+++ b/README.md
@@ -200,30 +200,51 @@ ANTHROPIC_API_KEY=sk-... ./deployment/scripts/kind-e2e.sh
 
 ### LLM Providers
 
-Configure your preferred LLM provider in `.env`:
+Pick a provider with `LLM_PROVIDER` and supply that provider's key. There is
+no default provider — the agent refuses to start without `LLM_PROVIDER`. For
+local development with `deployment/docker-compose.yaml`, put both in `.env`
+(see `deployment/.env.example`):
 
 ```bash
-# Google Gemini
-GOOGLE_API_KEY=your-gemini-api-key
+# Anthropic
+LLM_PROVIDER=anthropic-claude
+ANTHROPIC_API_KEY=your-anthropic-api-key
 
-# OpenAI
+# OpenAI (also matches Azure and OpenAI-compatible endpoints)
+LLM_PROVIDER=openai
 OPENAI_API_KEY=your-openai-api-key
 
-# Anthropic
-ANTHROPIC_API_KEY=your-anthropic-api-key
+# Google Gemini
+LLM_PROVIDER=google-gemini
+GOOGLE_API_KEY=your-gemini-api-key
 ```
+
+In Kubernetes the keys come from the `kubently-llm-secrets` secret and
+`LLM_PROVIDER` goes under `api.env`.
 
 ### Helm Deployment
 
 Customize deployment using Helm values:
 
-```bash
-# Edit deployment configuration
-vim deployment/helm/test-values.yaml
+Kubently ships as a single chart. Its components are switched on and off with
+`api.enabled`, `redis.enabled` and `executor.enabled` — an executor-only
+install on a remote cluster is the same chart with the first two disabled.
 
-# Deploy with custom values
-helm install kubently deployment/helm -f deployment/helm/test-values.yaml
+```bash
+# From a checkout
+helm install kubently ./deployment/helm/kubently -n kubently \
+  -f deployment/helm/test-values.yaml
+
+# Or from the published chart repository
+helm repo add kubently https://kubently.github.io/kubently
+helm install kubently kubently/kubently -n kubently -f my-values.yaml
 ```
+
+`LLM_PROVIDER` is required and has no chart default — set it under `api.env`
+(`anthropic-claude`, `openai`, or `google-gemini`). See
+[ENVIRONMENT_VARIABLES.md](docs/ENVIRONMENT_VARIABLES.md) for the full
+configuration surface, and [GETTING_STARTED.md](docs/GETTING_STARTED.md) for
+the production walkthrough.
 
 ### Operator Runbooks
 
@@ -327,6 +348,7 @@ The diagnostic agent investigates with a small set of read-only tools:
 - **`search_past_incidents`** — keyword search over this deployment's incident history (see below). On by default when Redis is available; disable with `KUBENTLY_INCIDENT_HISTORY=false`
 - **`get_manifest_file`** *(optional)* — read-only fetch of a file from the configured GitOps manifests repo, so proposed fixes are diffed against the real manifest instead of a hallucinated one. Enabled with `gitRemediation` in Helm values (off by default)
 - **`propose_fix_pr`** *(optional)* — proposes a high-confidence manifest fix as a **pull request** against the configured GitOps manifests repo (GitHub or GitLab): branch → commit → PR with the investigation evidence in a body clearly marked machine-proposed. The agent **never merges** — a human reviews and merges, and your GitOps controller applies. Size-capped (files/changed lines), token never enters model context, cluster access stays read-only. See [GitOps PR Remediation](docs/GITOPS_REMEDIATION.md)
+- **`query_cloud_logs`**, **`query_cloud_metrics`**, **`get_recent_cloud_changes`** *(optional)* — read-only cloud telemetry for a cluster: CloudWatch Logs Insights / CloudWatch metrics / CloudTrail on AWS, Cloud Logging / Cloud Monitoring / GKE audit logs on GCP. The executor answers them using the workload identity **you** grant its ServiceAccount (EKS Pod Identity, IRSA, or GKE Workload Identity) — no cloud key is ever stored by Kubently, and revoking the IAM role kills the capability instantly. Enabled per cluster with `executor.cloud.enabled` in Helm values (off by default); each call re-checks that the target cluster's executor actually reports an identity. Operations are additionally limited by a code-level allowlist. See [Cloud Telemetry](docs/CLOUD_TELEMETRY.md)
 - **`mcp_<server>_*`** *(optional)* — tools from external MCP servers (streamable HTTP, e.g. Grafana Cloud's or Datadog's remote MCP) configured via `mcpServers` in Helm values (unset by default). Tool names are prefixed with the server name to avoid collisions; results are treated as untrusted input (framed and size-capped) and credentials stay in Kubernetes secrets. **Connect read-scoped servers/credentials only** — Kubently cannot enforce read-only semantics on a remote server's tools. See `docs/MCP_CLIENT_TOOLS.md`
 
 ## Documentation
@@ -342,6 +364,8 @@ The diagnostic agent investigates with a small set of read-only tools:
 - **[MCP Connect Guide](docs/MCP.md)** - Connect MCP clients (Claude Desktop, Cursor, custom agents)
 - **[Environment Variables](docs/ENVIRONMENT_VARIABLES.md)** - Configuration reference
 - **[GitOps PR Remediation](docs/GITOPS_REMEDIATION.md)** - Agent-proposed fix PRs (human-merged, default off)
+- **[Cloud Telemetry](docs/CLOUD_TELEMETRY.md)** - Read-only CloudWatch / Cloud Logging access via workload identity (default off)
+- **[External MCP Tools](docs/MCP_CLIENT_TOOLS.md)** - Mounting third-party MCP servers into the agent, including per-request injection
 
 ### Architecture & Development
 - **[Architecture](docs/ARCHITECTURE.md)** - System design and components

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,15 +14,22 @@
 
 ### Required Components
 - Kubernetes cluster v1.24+ with RBAC enabled
-- Redis 7.0+ (can be deployed in-cluster or external)
+- Redis — the chart deploys `redis/redis-stack-server` as a StatefulSet
+  (`redis.enabled: true`). Redis Stack is used because the default
+  conversation-memory backend needs the RediSearch module; on a managed Redis
+  without it, set `KUBENTLY_CHECKPOINTER_BACKEND=plain-redis`
 - kubectl configured with cluster access
-- Docker registry for container images
+- An LLM API key (Anthropic, OpenAI, or Google)
+
+Images are published to `ghcr.io/kubently/kubently` (API + A2A) and
+`ghcr.io/kubently/kubently-executor`; you only need your own registry if you
+build them yourself.
 
 ### Required Tools
 - `kubectl` v1.24+
-- `helm` v3.0+ (optional, for Helm deployment)
-- `docker` or `podman` for building images
-- `openssl` for generating tokens
+- `helm` v3.0+
+- `openssl` for generating API keys and tokens
+- `docker`/`podman` only if you build images from source
 
 ### Network Requirements
 - API service requires external ingress (LoadBalancer or Ingress)
@@ -32,434 +39,262 @@
 
 ## Deployment Options
 
-### Option 1: Quick Start (Development)
+Kubently ships **one Helm chart** (`deployment/helm/kubently`, published as
+`kubently/kubently`). What it deploys is decided by three switches:
+
+| Switch | Default | Deploys |
+|--------|---------|---------|
+| `api.enabled` | `true` | API server + A2A + MCP endpoint, ingress, prompt/runbook ConfigMaps, proactive CronJobs |
+| `redis.enabled` | `true` | The Redis Stack StatefulSet the API stores sessions, tokens and incident history in |
+| `executor.enabled` | `true` | The in-cluster executor, its ServiceAccount, read-only ClusterRole and command whitelist |
+
+A **central install** is the chart with `executor.enabled=false`. An
+**executor-only install** on a monitored cluster is the *same chart* with
+`api.enabled=false` and `redis.enabled=false`. There is no separate executor
+chart.
+
+### Option 1: `kubently install` (fastest)
 
 ```bash
-# Deploy everything with default settings
-kubectl apply -f https://raw.githubusercontent.com/kubently/kubently/main/deploy/quickstart.yaml
-
-# This includes:
-# - Namespace creation
-# - Redis deployment
-# - API deployment
-# - Basic executor deployment
+npm install -g @kubently/cli
+kubently install
 ```
 
-### Option 2: Helm Chart (Recommended)
+The CLI runs Helm for you, creates the secrets, registers the executor token
+and port-forwards the API. `kubently install --help` lists the flags
+(`--provider`, `--chart ./deployment/helm/kubently` to install from a
+checkout, and so on).
+
+### Option 2: Helm (recommended for production)
 
 ```bash
-# Add Helm repository
+# From the published chart repository
 helm repo add kubently https://kubently.github.io/kubently
 helm repo update
 
-# Install with custom values
 helm install kubently kubently/kubently \
   --namespace kubently \
   --create-namespace \
   --values custom-values.yaml
+
+# ...or from a checkout
+helm install kubently ./deployment/helm/kubently \
+  --namespace kubently --create-namespace --values custom-values.yaml
 ```
 
-### Option 3: Manual Deployment (Production)
+See [GETTING_STARTED.md](GETTING_STARTED.md) for the full walkthrough with
+secrets, ingress and remote executors.
 
-Follow the detailed steps in the [Production Deployment](#production-deployment) section.
+### Option 3: Raw manifests
+
+There is no committed all-in-one manifest. Generate manifests from the chart
+instead — this keeps them in step with the chart rather than drifting from it:
+
+```bash
+make helm-template   # writes generated-manifests/kubently-manifests.yaml
+# or directly:
+helm template kubently ./deployment/helm/kubently \
+  --namespace kubently --values custom-values.yaml > kubently.yaml
+```
 
 ## Production Deployment
 
-### Step 1: Create Namespace and Secrets
+### Step 1: Create Secrets
+
+All secrets are created manually — the chart never generates credentials.
 
 ```bash
-# Create namespace
 kubectl create namespace kubently
 
-# Generate API keys for clients
-export API_KEY_1=$(openssl rand -hex 32)
-export API_KEY_2=$(openssl rand -hex 32)
+# Redis password (required; redis.auth.existingSecret defaults to this name)
+kubectl create secret generic kubently-redis-password -n kubently \
+  --from-literal=password="$(openssl rand -base64 32)"
 
-# Create API keys secret
-kubectl create secret generic kubently-api-keys \
-  --from-literal=keys="${API_KEY_1},${API_KEY_2}" \
-  -n kubently
+# Client API keys. The 'keys' field holds one entry per line (or per comma);
+# each entry is either "key" or "service:key". Clients send the KEY part only.
+export ADMIN_KEY=$(openssl rand -hex 32)
+kubectl create secret generic kubently-api-keys -n kubently \
+  --from-literal=keys="admin:${ADMIN_KEY}"
 
-# Generate executor tokens
-export CLUSTER_1_TOKEN=$(openssl rand -hex 32)
-export CLUSTER_2_TOKEN=$(openssl rand -hex 32)
-
-# Create executor tokens secret
-kubectl create secret generic kubently-executor-tokens \
-  --from-literal=tokens='{"cluster-1":"'${CLUSTER_1_TOKEN}'","cluster-2":"'${CLUSTER_2_TOKEN}'"}' \
-  -n kubently
+# LLM provider credentials. The secret NAME is fixed in the chart; every key
+# inside it is optional, so include only the provider you use.
+kubectl create secret generic kubently-llm-secrets -n kubently \
+  --from-literal=ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
-### Step 2: Deploy Redis
-
-#### Option A: In-Cluster Redis
+### Step 2: Write your values file
 
 ```yaml
-# redis-deployment.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redis-config
-  namespace: kubently
-data:
-  redis.conf: |
-    maxmemory 2gb
-    maxmemory-policy allkeys-lru
-    save 900 1
-    save 300 10
-    save 60 10000
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: redis-data
-  namespace: kubently
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: redis
-  namespace: kubently
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: redis
-  template:
-    metadata:
-      labels:
-        app: redis
-    spec:
-      containers:
-      - name: redis
-        image: redis:7-alpine
-        command:
-          - redis-server
-          - /etc/redis/redis.conf
-        ports:
-        - containerPort: 6379
-        volumeMounts:
-        - name: config
-          mountPath: /etc/redis
-        - name: data
-          mountPath: /data
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "500m"
-          limits:
-            memory: "2Gi"
-            cpu: "1000m"
-      volumes:
-      - name: config
-        configMap:
-          name: redis-config
-      - name: data
-        persistentVolumeClaim:
-          claimName: redis-data
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: redis
-  namespace: kubently
-spec:
-  selector:
-    app: redis
-  ports:
-  - port: 6379
-    targetPort: 6379
+# custom-values.yaml
+api:
+  replicaCount: 3
+  existingSecret: "kubently-api-keys"
+  env:
+    # Required — the agent has no default provider.
+    LLM_PROVIDER: "anthropic-claude"
+    LOG_LEVEL: "INFO"
+    A2A_EXTERNAL_URL: "https://kubently.example.com/a2a/"
+
+redis:
+  enabled: true
+  auth:
+    existingSecret: "kubently-redis-password"
+  master:
+    persistence:
+      enabled: true
+      size: 5Gi          # chart default is 2Gi
+
+# Executors live on the monitored clusters, not here.
+executor:
+  enabled: false
 ```
 
-#### Option B: External Redis
+Redis persistence matters: executor tokens, sessions, cluster state and
+incident history all live there. With persistence off, every token registered
+through the admin API disappears on pod restart.
 
-```yaml
-# external-redis-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: redis-connection
-  namespace: kubently
-type: Opaque
-data:
-  url: cmVkaXM6Ly91c2VyOnBhc3N3b3JkQHJlZGlzLmV4YW1wbGUuY29tOjYzNzk= # base64 encoded
+### Step 3: Install and verify
+
+```bash
+helm install kubently kubently/kubently \
+  --namespace kubently --values custom-values.yaml
+
+kubectl get pods -n kubently
+kubectl port-forward -n kubently svc/kubently-api 8080:8080 &
+
+curl http://localhost:8080/healthz   # unauthenticated probe -> {"status":"ok"}
+curl http://localhost:8080/health    # detailed: redis, modules, tls, version
 ```
 
-### Step 3: Deploy Kubently API
+### Step 4: Configure Ingress (optional)
 
-```yaml
-# api-deployment.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubently-config
-  namespace: kubently
-data:
-  config.yaml: |
-    redis_url: redis://redis:6379
-    api_port: 8080
-    api_workers: 4
-    command_timeout: 10
-    session_ttl: 300
-    result_ttl: 60
-    max_commands_per_fetch: 10
-    long_poll_timeout: 30
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: kubently-api
-  namespace: kubently
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: kubently-api
-  template:
-    metadata:
-      labels:
-        app: kubently-api
-    spec:
-      containers:
-      - name: api
-        image: kubently/api:latest
-        ports:
-        - containerPort: 8080
-        env:
-        - name: KUBENTLY_REDIS_URL
-          value: redis://redis:6379
-        - name: KUBENTLY_API_KEYS
-          valueFrom:
-            secretKeyRef:
-              name: kubently-api-keys
-              key: keys
-        - name: KUBENTLY_AGENT_TOKENS
-          valueFrom:
-            secretKeyRef:
-              name: kubently-executor-tokens
-              key: tokens
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "250m"
-          limits:
-            memory: "512Mi"
-            cpu: "1000m"
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kubently-api
-  namespace: kubently
-spec:
-  selector:
-    app: kubently-api
-  ports:
-  - port: 80
-    targetPort: 8080
-  type: LoadBalancer
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: kubently-api
-  namespace: kubently
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: kubently-api
-  minReplicas: 2
-  maxReplicas: 10
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 70
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
-```
-
-### Step 4: Configure Ingress (Optional)
-
-```yaml
-# ingress.yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: kubently-api
-  namespace: kubently
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
-spec:
-  tls:
-  - hosts:
-    - api.kubently.example.com
-    secretName: kubently-tls
-  rules:
-  - host: api.kubently.example.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: kubently-api
-            port:
-              number: 80
-```
+Set `ingress.enabled: true` with your controller's `className`, hosts and TLS
+secret. The chart follows the "bring your own certificate" pattern — see
+[deployment/helm/kubently/examples/](../deployment/helm/kubently/examples/)
+for cert-manager, cloud load balancer, manual certificate and self-signed
+patterns.
 
 ## Executor Deployment
 
-### Deploy Executor to Target Cluster
+Executors run on each monitored cluster and dial **outbound** to the API, so
+they need no inbound ingress of their own.
+
+### Step 1: Register the token with the API
+
+The API accepts an executor only if a matching token exists in Redis under
+`executor:token:{cluster_id}`.
+
+The chart writes that key for you in exactly one case: a **co-located** release
+where `api.enabled` and `executor.enabled` are both true and the token came
+from `executor.token`. The API Deployment's `sync-executor-tokens` init
+container then seeds it before the API starts. A remote executor is a separate
+release with no API pod, so nothing runs that init container — register the
+token through the admin API first.
 
 ```bash
-# 1. Generate token for this cluster
 export CLUSTER_ID="production-cluster-1"
-export TOKEN=$(openssl rand -hex 32)
-echo "Cluster: $CLUSTER_ID"
-echo "Token: $TOKEN"
 
-# 2. Save token on API side (add to executor tokens)
-kubectl patch secret kubently-executor-tokens -n kubently \
-  --type='json' -p='[{"op":"add","path":"/data/tokens","value":"..."}]'
+# Let the API generate the token...
+curl -X POST https://kubently.example.com/admin/agents/${CLUSTER_ID}/token \
+  -H "X-API-Key: ${ADMIN_KEY}"
 
-# 3. Create executor namespace in target cluster
+# ...or supply your own (32-128 chars, letters/digits/hyphens/underscores)
+curl -X POST https://kubently.example.com/admin/agents/${CLUSTER_ID}/token \
+  -H "X-API-Key: ${ADMIN_KEY}" -H 'Content-Type: application/json' \
+  -d '{"token": "token-from-your-secrets-manager"}'
+```
+
+The response carries `{"token": ..., "clusterId": ..., "createdAt": ...}`. A
+409 means a token already exists for that cluster id — delete it first with
+`DELETE /admin/agents/{cluster_id}/token`.
+
+Related admin endpoints: `GET /admin/agents` lists registered clusters and
+`GET /admin/agents/{cluster_id}/status` reports one cluster's state.
+
+### Step 2: Deploy the executor to the target cluster
+
+```bash
+kubectl config use-context ${CLUSTER_ID}
 kubectl create namespace kubently
 
-# 4. Create token secret
-kubectl create secret generic kubently-executor-token \
-  --from-literal=token=$TOKEN \
-  -n kubently
+kubectl create secret generic kubently-executor-token -n kubently \
+  --from-literal=token="<token from step 1>"
 
-# 5. Apply executor deployment
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kubently-executor
-  namespace: kubently
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubently-executor-readonly
-rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["get", "list", "watch"]
-- nonResourceURLs: ["*"]
-  verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kubently-executor-readonly
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubently-executor-readonly
-subjects:
-- kind: ServiceAccount
-  name: kubently-executor
-  namespace: kubently
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: kubently-executor
-  namespace: kubently
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: kubently-executor
-  template:
-    metadata:
-      labels:
-        app: kubently-executor
-    spec:
-      serviceAccountName: kubently-executor
-      containers:
-      - name: executor
-        image: kubently/executor:latest
-        env:
-        - name: KUBENTLY_API_URL
-          value: "https://api.kubently.example.com"
-        - name: CLUSTER_ID
-          value: "${CLUSTER_ID}"
-        - name: KUBENTLY_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: kubently-executor-token
-              key: token
-        - name: LOG_LEVEL
-          value: "INFO"
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
-          limits:
-            memory: "256Mi"
-            cpu: "200m"
-EOF
+helm install kubently-executor kubently/kubently \
+  --namespace kubently \
+  --set api.enabled=false \
+  --set redis.enabled=false \
+  --set executor.enabled=true \
+  --set executor.clusterId="${CLUSTER_ID}" \
+  --set executor.apiUrl="https://kubently.example.com" \
+  --set executor.existingSecret=kubently-executor-token
+```
+
+Notes:
+
+- **No `replicaCount`.** The executor Deployment hardcodes `replicas: 1`: an
+  executor *is* a cluster identity, and a second replica would register a
+  duplicate agent for the same `clusterId`.
+- **RBAC** comes from the chart's built-in read-only ClusterRole (pods and
+  `pods/log`, services, endpoints, configmaps, PVs/PVCs, nodes, namespaces,
+  events, quotas, workloads, jobs, ingresses, networkpolicies, RBAC objects,
+  storage classes, HPAs, PDBs — Secrets deliberately excluded). Set
+  `executor.rbacRules` only to *replace* that list, e.g. to add CRDs.
+- **Command whitelist** is a second boundary on top of RBAC:
+  `executor.security.mode` defaults to `readOnly`. `fullAccess` additionally
+  requires the top-level `fullAccessAcknowledged: true`.
+- **Cluster id** falls back to the release namespace when `executor.clusterId`
+  is left empty.
+- **`executor.existingSecret` and `api.enabled` together**: the API's
+  `sync-executor-tokens` init container reads the chart-created
+  `<release>-executor-token` secret by name and does not follow
+  `executor.existingSecret`. In a co-located release that sets
+  `existingSecret`, that secret does not exist and the API pod will not start.
+  On an executor-only release (`api.enabled=false`, as above) there is no init
+  container, so `existingSecret` is the right choice there.
+- **TLS**: `KUBENTLY_SSL_VERIFY` / `KUBENTLY_CA_CERT` cover private CAs — see
+  [MULTI_CLUSTER_TLS.md](MULTI_CLUSTER_TLS.md).
+
+### Step 3: Verify
+
+```bash
+kubectl logs -n kubently -l app.kubernetes.io/component=executor
+# look for the SSE connection being established
+
+curl https://kubently.example.com/admin/agents -H "X-API-Key: ${ADMIN_KEY}"
 ```
 
 ### Multi-Cluster Executor Deployment
 
-For deploying executors across multiple clusters, use this script:
+Repeat the two steps per cluster — each needs its own `clusterId` and token:
 
 ```bash
 #!/bin/bash
 # deploy-executors.sh
-
 CLUSTERS=("cluster-1" "cluster-2" "cluster-3")
-API_URL="https://api.kubently.example.com"
+API_URL="https://kubently.example.com"
 
 for CLUSTER in "${CLUSTERS[@]}"; do
   echo "Deploying to $CLUSTER..."
 
-  # Generate token
-  TOKEN=$(openssl rand -hex 32)
+  # 1. Register the cluster with the API and capture the generated token
+  TOKEN=$(curl -sS -X POST "${API_URL}/admin/agents/${CLUSTER}/token" \
+    -H "X-API-Key: ${ADMIN_KEY}" | jq -r '.token')
 
-  # Switch context
-  kubectl config use-context $CLUSTER
+  # 2. Deploy the executor onto that cluster
+  kubectl config use-context "$CLUSTER"
+  kubectl create namespace kubently --dry-run=client -o yaml | kubectl apply -f -
+  kubectl create secret generic kubently-executor-token -n kubently \
+    --from-literal=token="$TOKEN" --dry-run=client -o yaml | kubectl apply -f -
 
-  # Deploy executor
-  helm install kubently-executor kubently/executor \
+  helm install kubently-executor kubently/kubently \
     --namespace kubently \
-    --create-namespace \
-    --set cluster.id=$CLUSTER \
-    --set cluster.token=$TOKEN \
-    --set api.url=$API_URL
-
-  echo "Executor deployed to $CLUSTER with token: $TOKEN"
+    --set api.enabled=false \
+    --set redis.enabled=false \
+    --set executor.enabled=true \
+    --set executor.clusterId="$CLUSTER" \
+    --set executor.apiUrl="$API_URL" \
+    --set executor.existingSecret=kubently-executor-token
 done
 ```
 
@@ -467,10 +302,17 @@ done
 
 ### Environment-Specific Configurations
 
+Use the real value paths — `api.replicaCount` (not `api.replicas`) and
+`redis.master.persistence` / `redis.master.resources` (not `redis.persistence`).
+The chart has no `monitoring` block; the Prometheus integration is
+`prometheus.url`, which points the agent's `query_prometheus` tool at a
+Prometheus the executor can reach.
+
 ```yaml
 # values-production.yaml
 api:
-  replicas: 3
+  replicaCount: 3
+  existingSecret: "kubently-api-keys"
   resources:
     requests:
       memory: 512Mi
@@ -478,41 +320,59 @@ api:
     limits:
       memory: 1Gi
       cpu: 2000m
+  env:
+    LLM_PROVIDER: "anthropic-claude"
+    LOG_LEVEL: "INFO"
 
 redis:
-  persistence:
-    enabled: true
-    size: 20Gi
-  resources:
-    requests:
-      memory: 2Gi
-      cpu: 1000m
+  auth:
+    existingSecret: "kubently-redis-password"
+  master:
+    persistence:
+      enabled: true
+      size: 20Gi
+    resources:
+      requests:
+        memory: 2Gi
+        cpu: 1000m
 
-monitoring:
-  enabled: true
-  prometheus:
-    enabled: true
-  grafana:
-    enabled: true
+executor:
+  enabled: false
+
+# Optional read-only telemetry the agent can query through each executor
+prometheus:
+  url: "http://prometheus-operated.monitoring.svc.cluster.local:9090"
+loki:
+  url: "http://loki.monitoring.svc.cluster.local:3100"
 ```
 
 ```yaml
 # values-staging.yaml
 api:
-  replicas: 2
+  replicaCount: 2
+  existingSecret: "kubently-api-keys"
   resources:
     requests:
       memory: 256Mi
       cpu: 250m
+  env:
+    LLM_PROVIDER: "anthropic-claude"
 
 redis:
-  persistence:
-    enabled: true
-    size: 10Gi
+  master:
+    persistence:
+      enabled: true
+      size: 10Gi
 
-monitoring:
+executor:
   enabled: false
 ```
+
+For the optional feature blocks — `runbooks`, `mcpServers`, `fleetReport`,
+`scheduledChecks`, `verifyDeployment`, `changeCorrelation`, `gitRemediation`,
+`executor.cloud` — the annotated defaults in
+`deployment/helm/kubently/values.yaml` are the reference, and every variable
+they set is listed in [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md).
 
 ### Secret Management
 
@@ -547,15 +407,21 @@ spec:
     name: vault-backend
     kind: SecretStore
   target:
-    name: kubently-secrets
+    # Must match api.existingSecret, and the key inside must be named "keys"
+    name: kubently-api-keys
   data:
-  - secretKey: api-keys
+  - secretKey: keys
     remoteRef:
       key: kubently/api-keys
-  - secretKey: executor-tokens
-    remoteRef:
-      key: kubently/executor-tokens
 ```
+
+Kubently expects several small, purpose-named secrets rather than one combined
+one: `kubently-api-keys` (key `keys`), `kubently-redis-password` (key
+`password`), `kubently-llm-secrets` (keys `ANTHROPIC_API_KEY` /
+`OPENAI_API_KEY` / `GOOGLE_API_KEY` / `LANGSMITH_API_KEY`), and
+`kubently-executor-token` (key `token`) on each monitored cluster. Executor
+tokens are not consumed from a secret by the API — they are registered through
+`POST /admin/agents/{cluster_id}/token`.
 
 ## Security Hardening
 
@@ -804,11 +670,14 @@ kubectl set env deployment/kubently-executor LOG_LEVEL=DEBUG -n kubently
 # API health
 curl https://api.kubently.example.com/health
 
-# Redis health
-kubectl exec -n kubently deployment/redis -- redis-cli ping
+# API probe endpoint (unauthenticated)
+curl https://api.kubently.example.com/healthz
+
+# Redis health (the chart deploys a StatefulSet named <release>-redis-master)
+kubectl exec -n kubently kubently-redis-master-0 -- redis-cli ping
 
 # Executor status
-kubectl get pods -n kubently -l app=kubently-executor
+kubectl get pods -n kubently -l app.kubernetes.io/component=executor
 ```
 
 ## Backup and Recovery
@@ -868,14 +737,16 @@ kubectl rollout restart deployment/redis -n kubently
 ### Rolling Update
 
 ```bash
-# Update API
-kubectl set image deployment/kubently-api api=kubently/api:v2.0.0 -n kubently
+# Prefer `helm upgrade` so values and manifests stay in step:
+helm upgrade kubently kubently/kubently -n kubently \
+  --values custom-values.yaml --set api.image.tag=v2.0.0
 
 # Monitor rollout
 kubectl rollout status deployment/kubently-api -n kubently
 
-# Update executors (per cluster)
-kubectl set image deployment/kubently-executor executor=kubently/executor:v2.0.0 -n kubently
+# Update executors (per cluster) — same chart, executor image tag
+helm upgrade kubently-executor kubently/kubently -n kubently \
+  --values executor-values.yaml --set executor.image.tag=v2.0.0
 ```
 
 ### Blue-Green Deployment
@@ -885,7 +756,7 @@ kubectl set image deployment/kubently-executor executor=kubently/executor:v2.0.0
 helm install kubently-green kubently/kubently \
   --namespace kubently-green \
   --values values-production.yaml \
-  --set version=v2.0.0
+  --set api.image.tag=v2.0.0
 
 # Test green environment
 curl https://api-green.kubently.example.com/health

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -6,26 +6,42 @@
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `API_HOST` | `0.0.0.0` | No | Host IP to bind the API server |
-| `API_PORT` | `8080` | No | Port for the main API server |
-| `PORT` | `8080` | No | Alias for API_PORT (for compatibility) |
+| `API_HOST` | `0.0.0.0` | No | Host IP the API server binds (see the container note below) |
+| `API_PORT` | `8080` | No | Port the API server binds (see the container note below) |
 | `LOG_LEVEL` | `INFO` | No | Logging level (DEBUG, INFO, WARNING, ERROR) |
-| `DEBUG` | `false` | No | Enable debug mode with auto-reload |
+| `DEBUG` | `false` | No | Enables uvicorn auto-reload (see the container note below) |
+
+**Container note**: the published API image starts the server with a fixed
+command — `uvicorn kubently.main:app --host 0.0.0.0 --port 8080`
+(`deployment/docker/api/Dockerfile`). `API_HOST`, `API_PORT` and `DEBUG` are
+only consulted by the `if __name__ == "__main__"` block in `kubently/main.py`,
+so in a Kubernetes or Docker deployment they do **not** move the listening
+address. The Helm chart sets `PORT` and `API_PORT` under `api.env`; neither is
+read by application code today. To change what clients connect to in-cluster,
+change `api.service.port`.
 
 ### Redis Configuration
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `REDIS_HOST` | `redis` | No | Redis server hostname |
-| `REDIS_PORT` | `6379` | No | Redis server port |
+| `REDIS_HOST` | `kubently-redis-master` | No | Redis server hostname |
+| `REDIS_PORT` | `6379` | No | Redis server port. A `tcp://host:port` value (as injected by Kubernetes service links) is accepted — the port is parsed out of it |
 | `REDIS_DB` | `0` | No | Redis database number |
-| `REDIS_URL` | - | No | Full Redis URL (overrides individual settings) |
+| `REDIS_PASSWORD` | - | No | Password for an authenticated Redis. Passed as a connection parameter (not embedded in the URL), so special characters need no escaping. The chart wires it from `redis.auth.existingSecret` |
+
+The API builds its connection as `redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}`
+with `REDIS_PASSWORD` supplied separately. The chart also sets a `REDIS_URL`
+variable on the API pod, but the only code that reads it is
+`kubently/modules/storage/__init__.py`, which nothing in the API server
+imports — changing it has no effect on the running API. `REDIS_HOST` is
+rendered by the chart as `{release-name}-redis-master`, which is why the
+in-code default is `kubently-redis-master`.
 
 ### Session Management
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `SESSION_TTL` | `3600` | No | Session TTL in seconds (1 hour) |
+| `SESSION_TTL` | `3600` | No | Session TTL in seconds. Note the Helm chart overrides this to `300` under `api.env` |
 | `COMMAND_TIMEOUT` | `30` | No | Default command execution timeout in seconds |
 | `MAX_COMMANDS_PER_FETCH` | `10` | No | Maximum commands per fetch operation |
 
@@ -33,10 +49,32 @@
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `API_KEYS` | - | Yes* | Comma-separated list of valid API keys |
-| `AGENT_TOKEN_<ID>` | - | Yes* | Agent authentication tokens (per cluster) |
+| `API_KEYS` | - | Yes | Valid API keys, comma- **or** newline-separated. Both `service:key` and bare `key` forms are accepted. Startup fails with a clear error if unset — there is no default |
+| `REQUIRE_AUTH` | `true` | No | Parsed into the auth config but not currently consulted by any request path; authentication is always enforced |
 
-*Required for production deployments
+**There is no `AGENT_TOKEN_<ID>` / `EXECUTOR_TOKEN_<ID>` environment variable.**
+Executor tokens live in Redis under `executor:token:{cluster_id}` and are
+created through the admin API (`POST /admin/agents/{cluster_id}/token`, which
+accepts an auto-generated or a caller-supplied 32–128 character token). The
+executor side of the same token is `KUBENTLY_TOKEN` (see Executor
+Configuration).
+
+### OIDC / OAuth (optional)
+
+Off by default. When enabled, the API exposes auth discovery and validates
+bearer tokens alongside API keys — see `docs/AUTH_DISCOVERY.md` and
+`docs/OAUTH_USAGE.md` for the full flow.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `OIDC_ENABLED` | `false` | No | Master switch for OIDC/OAuth support |
+| `OIDC_ISSUER` | - | If enabled | Issuer URL; the endpoints below default to `{issuer}/jwks`, `{issuer}/token`, `{issuer}/device/code` when unset |
+| `OIDC_CLIENT_ID` | `kubently-cli` | No | Client id presented by the CLI |
+| `OIDC_AUDIENCE` | value of `OIDC_CLIENT_ID` | No | Expected token audience |
+| `OIDC_JWKS_URI` | `{OIDC_ISSUER}/jwks` | No | JWKS endpoint override |
+| `OIDC_TOKEN_ENDPOINT` | `{OIDC_ISSUER}/token` | No | Token endpoint override |
+| `OIDC_DEVICE_AUTH_ENDPOINT` | `{OIDC_ISSUER}/device/code` | No | Device-authorization endpoint override |
+| `OIDC_SCOPES` | `openid email profile groups` | No | Space-separated scope list |
 
 ### A2A (Agent-to-Agent) Configuration
 
@@ -47,6 +85,8 @@
 | `A2A_EXTERNAL_URL` | - | No | External URL for A2A agent card (e.g., `https://api.example.com/a2a/`) |
 | `KUBENTLY_MAX_FLEET_CLUSTERS` | `10` | No | Max clusters per `execute_kubectl_multi` fan-out call (each cluster adds up to ~4KB to the agent context) |
 | `A2A_SERVER_DEBUG` | `false` | No | Enable A2A debug logging |
+| `KUBENTLY_MAX_OUTPUT_CHARS` | `20000` | No | Per-cluster output cap applied to kubectl results before they enter the agent's context |
+| `KUBENTLY_PROMPT_FILE` | - | No | Explicit path to a prompt YAML file, overriding the role-based lookup under `/etc/kubently/prompts/` |
 
 ### Operator Runbooks (optional)
 
@@ -127,6 +167,22 @@ In Helm deployments set these under `api.env`. Recording and retrieval
 failures are logged and skipped — incident history can never break an
 investigation or a response.
 
+### Cloud Telemetry Tools (optional)
+
+The agent's three cloud tools — `query_cloud_logs`, `query_cloud_metrics` and
+`get_recent_cloud_changes` — are registered whenever cloud tooling is not
+explicitly switched off, but each one checks, per target cluster and per call,
+that the cluster's executor actually reports a cloud identity. A fleet with no
+cloud-enabled executors therefore sees the tools refuse every call rather than
+silently return nothing. The API holds no cloud credential of its own: it
+forwards whitelisted operations to the executor, which uses its pod's workload
+identity (see `KUBENTLY_CLOUD_MODE` under Executor Configuration and
+`docs/CLOUD_TELEMETRY.md`).
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `KUBENTLY_CLOUD_TOOLS` | `auto` | No | Set to `off` to skip registering the cloud tools entirely. Any other value (including the default) registers them, subject to the per-call executor capability check |
+
 ### Prometheus Metrics Tool (optional)
 
 When `PROMETHEUS_URL` is set on the API server, the agent registers the read-only `query_prometheus` tool and injects metrics guidance into the system prompt. When unset (default), the tool does not exist and the prompt never mentions metrics.
@@ -202,29 +258,64 @@ diagnoses (`/webhooks/alertmanager`), the fleet health digest
 
 ### LLM Configuration (for A2A)
 
+`LLM_PROVIDER` has **no default and is required**: the agent raises
+`Unsupported LLM_PROVIDER ...` at construction time if it is unset or
+unrecognised. The Helm chart does not set it either — supply it under
+`api.env` (`deployment/helm/test-values.yaml` and the `kubently install` CLI
+both do). Matching is substring-based on the lowercased value:
+
+| Value contains | Provider used | Model variable |
+|----------------|---------------|----------------|
+| `anthropic` or `claude` | Anthropic (`ChatAnthropic`) | `ANTHROPIC_MODEL_NAME` |
+| `openai` or `azure` | OpenAI-compatible (`ChatOpenAI`) | `OPENAI_MODEL_NAME` |
+| `google` or `gemini` | Google Gemini (`ChatGoogleGenerativeAI`) | `GOOGLE_MODEL_NAME` |
+
+The conventional values are `anthropic-claude`, `openai` and `google-gemini`.
+Ollama is **not** supported — there is no Ollama code path.
+
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `LLM_PROVIDER` | `openai` | No | LLM provider (openai, anthropic, ollama) |
-| `OPENAI_API_KEY` | - | If OpenAI | OpenAI API key |
-| `OPENAI_ENDPOINT` | `https://api.openai.com/v1` | No | OpenAI API endpoint |
+| `LLM_PROVIDER` | - | Yes | Provider selector (see table above). Unset or unrecognised = the agent fails to start |
+| `OPENAI_API_KEY` | - | If OpenAI | OpenAI API key. Read by the LangChain OpenAI client, not by Kubently code |
 | `OPENAI_MODEL_NAME` | `gpt-4o` | No | OpenAI model to use |
 | `OPENAI_MAX_TOKENS` | `4096` | No | Max completion tokens on the OpenAI path (parity with the Anthropic path). Note: previously unbounded — OpenAI-compatible brokers such as OpenRouter reserve `max_tokens` against the account balance per request, so an unbounded value can 402 on small balances. Raise it if long diagnoses are being truncated |
-| `ANTHROPIC_API_KEY` | - | If Anthropic | Anthropic API key |
-| `ANTHROPIC_MODEL_NAME` | `claude-3-5-sonnet-20241022` | No | Anthropic model to use |
-| `OLLAMA_BASE_URL` | `http://localhost:11434` | No | Ollama server URL |
-| `OLLAMA_MODEL` | `llama3` | No | Ollama model to use |
+| `ANTHROPIC_API_KEY` | - | If Anthropic | Anthropic API key. Read by the LangChain Anthropic client, not by Kubently code |
+| `ANTHROPIC_MODEL_NAME` | `claude-sonnet-4-6` | No | Anthropic model to use |
+| `ANTHROPIC_CONTEXT_CLEARING` | `true` | No | Anthropic path only. When `true`, the model is created with the `context-management-2025-06-27` beta and `clear_tool_uses_20250919` edits so long investigations do not overflow the context window. Set to `false` for a plain `ChatAnthropic` client |
+| `GOOGLE_API_KEY` | - | If Google | Google Gemini API key. Read by the LangChain Google client, not by Kubently code |
+| `GOOGLE_MODEL_NAME` | `gemini-2.0-flash` | No | Gemini model to use |
+
+The Helm chart wires `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`
+and `LANGSMITH_API_KEY` from a secret named `kubently-llm-secrets` (the name is
+fixed in `api-deployment.yaml`); every key is optional, so the secret only
+needs the provider you actually use.
 
 ### LangSmith Tracing (Production Observability)
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
+The `LANGSMITH_*` variables are consumed by the LangSmith/LangChain SDK, not by
+Kubently code — Kubently only passes them through the pod environment, so their
+exact semantics follow the SDK. The chart wires `LANGSMITH_API_KEY` from the
+`kubently-llm-secrets` secret; set the rest under `api.env`.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
 | `LANGSMITH_TRACING` | `false` | No | Enable LangSmith tracing for observability |
 | `LANGSMITH_API_KEY` | - | If tracing enabled | LangSmith API key (set via secret) |
-| `POSTHOG_API_KEY` | - | No | Enables PostHog LLM observability (model, tokens, cost, latency per generation). Unset = no telemetry is collected or sent |
-| `POSTHOG_HOST` | `https://us.i.posthog.com` | No | PostHog ingestion host (use `https://eu.i.posthog.com` for the EU region, or your own reverse proxy) |
 | `LANGSMITH_PROJECT` | `default` | No | Project name in LangSmith UI |
 | `LANGSMITH_ENDPOINT` | `https://api.smith.langchain.com` | No | LangSmith API endpoint |
-| `LANGSMITH_SAMPLE_RATE` | `1.0` | No | Sampling rate (0.0-1.0) for trace volume reduction |
+
+`POSTHOG_*` is a separate, independent integration implemented in
+`agent.py` (`_posthog_llm_callbacks`): when the key is set, a LangChain
+callback reports model, tokens, cost and latency per generation. A missing or
+too-old `posthog` SDK logs a warning and degrades to no telemetry rather than
+failing the agent.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `POSTHOG_API_KEY` | - | No | Enables PostHog LLM observability. Unset = no telemetry is collected or sent |
+| `POSTHOG_HOST` | `https://us.i.posthog.com` | No | PostHog ingestion host (use `https://eu.i.posthog.com` for the EU region, or your own reverse proxy) |
 
 **See**: `docs/LANGSMITH_TRACING.md` for detailed setup guide
 
@@ -234,18 +325,81 @@ diagnoses (`/webhooks/alertmanager`), the fleet health digest
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `KUBENTLY_API_URL` | - | Yes | URL of the Kubently API server |
-| `CLUSTER_ID` | - | Yes | Unique identifier for the cluster |
-| `KUBENTLY_TOKEN` | - | Yes | Authentication token for the executor |
+| `KUBENTLY_API_URL` | - | Yes | URL of the Kubently API server. The executor exits at startup if this, `CLUSTER_ID` or `KUBENTLY_TOKEN` is missing |
+| `CLUSTER_ID` | - | Yes | Unique identifier for the cluster. Set via Helm `executor.clusterId`; the chart falls back to the release namespace when that is empty |
+| `KUBENTLY_TOKEN` | - | Yes | Authentication token for the executor. Must match the value stored in Redis at `executor:token:{CLUSTER_ID}` on the API side |
 | `LOG_LEVEL` | `INFO` | No | Logging level |
+| `EXECUTOR_VERSION` | `unknown` | No | Version string reported in capability/heartbeat payloads |
+
+### TLS
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `KUBENTLY_SSL_VERIFY` | `true` | No | Set to `false` to skip TLS verification when dialling the API (development only) |
+| `KUBENTLY_CA_CERT` | - | No | Path to a CA bundle for an API server using a private/self-signed certificate. Verification stays on |
+
+An `http://` API URL with verification still enabled logs a warning at startup;
+it is intended for local development only.
+
+### Capability Reporting
+
+Off by default. When on, the executor advertises its command whitelist (and,
+when cloud mode is enabled, its detected cloud identity) to the central API so
+the agent knows what each cluster can do before sending commands. Reporting
+failures are logged and ignored — the executor keeps serving commands.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `KUBENTLY_REPORT_CAPABILITIES` | `false` | No | Enable capability reporting. Set via Helm `executor.capabilities.enabled`. Forced on when cloud mode is enabled (see below) |
+| `KUBENTLY_HEARTBEAT_INTERVAL` | `300` | No | Seconds between heartbeats that refresh the reported capabilities' TTL. Set via Helm `executor.capabilities.heartbeatInterval` |
 
 ### Whitelist Configuration
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `WHITELIST_PATH` | `/etc/kubently/whitelist.yaml` | No | Path to whitelist configuration |
-| `REFRESH_INTERVAL` | `30` | No | Whitelist refresh interval in seconds |
-| `TIMEOUT_SECONDS` | `30` | No | Command execution timeout |
+| `KUBENTLY_WHITELIST_CONFIG` | `/etc/kubently/whitelist.yaml` | No | Path to the whitelist YAML. The chart mounts the rendered ConfigMap at exactly this path |
+
+The whitelist's other knobs are fields **inside** that YAML file, not
+environment variables — `reloadIntervalSeconds` (default `30`), `timeoutSeconds`
+and `maxArguments`. Under Helm they come from
+`executor.security.commandWhitelist.reloadInterval`, `.timeoutSeconds` and
+`.maxArguments`. There are no `WHITELIST_PATH`, `REFRESH_INTERVAL` or
+`TIMEOUT_SECONDS` variables. (The chart also sets `KUBENTLY_WHITELIST_DB` on the
+executor pod; no code reads it today.)
+
+### Cloud Telemetry (optional, default off)
+
+The executor can answer read-only cloud telemetry queries — CloudWatch Logs
+Insights, CloudWatch metrics, EKS control-plane logs and CloudTrail on AWS;
+Cloud Logging, Cloud Monitoring and GKE audit logs on GCP — using the ambient
+identity its pod already holds (EKS Pod Identity, IRSA, or GKE Workload
+Identity). **No cloud credentials are configured here**: the variables below
+only say which identity to look for. The full onboarding guide, including the
+exact minimal IAM policy, is `docs/CLOUD_TELEMETRY.md`.
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `KUBENTLY_CLOUD_MODE` | `off` | No | `off` disables the feature; `auto` tries AWS then GCP; `aws` and `gcp` pin one provider. Set via Helm `executor.cloud.enabled` + `executor.cloud.provider` |
+| `KUBENTLY_CLOUD_AWS_REGION` | - (auto-detected) | No | Overrides the AWS region otherwise detected from the pod environment. Set via Helm `executor.cloud.awsRegion` |
+| `KUBENTLY_CLOUD_GCP_PROJECT` | - (auto-detected) | No | Overrides the GCP project otherwise detected from the pod environment. Set via Helm `executor.cloud.gcpProject` |
+| `KUBENTLY_CLOUD_REFRESH_INTERVAL` | `3600` | No | Seconds between re-detections of identity and usable permissions, so IAM grants and revocations are picked up without a pod restart. Set via Helm `executor.cloud.refreshInterval` |
+
+Behaviour worth knowing before you enable it:
+
+- **Cloud mode implies capability reporting.** The agent discovers cloud access
+  through the capability report, so when cloud mode is on the executor turns
+  `KUBENTLY_REPORT_CAPABILITIES` on itself and logs that it did.
+- **Missing SDKs degrade, they do not fail.** The cloud module needs the
+  `cloud` extra (`boto3`, `google-cloud-logging`, `google-cloud-monitoring`,
+  `google-auth`; already installed in the published executor image). If the
+  import fails, the executor logs
+  `KUBENTLY_CLOUD_MODE set but cloud module unavailable ...` and continues with
+  cloud operations disabled — kubectl work is unaffected.
+- **The allowlist is in code.** Only the operations enumerated in
+  `kubently/modules/executor/cloud/operations.py` can run, independently of how
+  broad the IAM role you grant happens to be.
+- **The API side has its own switch.** See `KUBENTLY_CLOUD_TOOLS` under API
+  Server Configuration.
 
 ### Log Search (search_pod_logs)
 
@@ -326,25 +480,24 @@ When deploying to Kubernetes, these variables are typically set automatically:
 
 | Variable | Set By | Description |
 |----------|--------|-------------|
-| `HOSTNAME` | Kubernetes | Pod hostname (used for routing) |
-| `NAMESPACE` | Kubernetes | Current namespace |
-| `POD_NAME` | Kubernetes | Current pod name |
-| `NODE_NAME` | Kubernetes | Node where pod is running |
+| `HOSTNAME` | Kubernetes / the chart | Pod name. The API deployment sets it explicitly from `metadata.name` and the code uses it to identify the serving instance |
 
 ### Docker Compose
 
 For local development with Docker Compose:
 
+`deployment/docker-compose.yaml` already sets the non-secret variables; the
+`.env` file next to it only needs the provider selection and its key (see
+`deployment/.env.example`):
+
 ```env
 # .env file example
-REDIS_HOST=redis
-REDIS_PORT=6379
-API_PORT=8080
-A2A_EXTERNAL_URL=http://localhost:8080/a2a/
-LOG_LEVEL=DEBUG
-API_KEYS=dev-key-1,dev-key-2
-AGENT_TOKEN_LOCAL=local-dev-token
+LLM_PROVIDER=anthropic-claude
+ANTHROPIC_API_KEY=sk-ant-...
 ```
+
+Executor tokens are not environment variables on the API side — create them
+through `POST /admin/agents/{cluster_id}/token` once the API is up.
 
 ## Configuration Precedence
 
@@ -359,27 +512,35 @@ AGENT_TOKEN_LOCAL=local-dev-token
 The following variables contain sensitive data and should be stored in Kubernetes Secrets or secure vaults:
 
 - `API_KEYS`
-- `AGENT_TOKEN_*`
-- `OPENAI_API_KEY`
-- `ANTHROPIC_API_KEY`
-- `KUBENTLY_TOKEN`
+- `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`
+- `KUBENTLY_TOKEN` (the executor's copy of its cluster token)
+- `REDIS_PASSWORD`
+- `ARGOCD_TOKEN`
+- `SLACK_WEBHOOK_URL` (anyone holding it can post to your channel)
+- `LANGSMITH_API_KEY`, `POSTHOG_API_KEY`
+- MCP bearer tokens referenced by `bearer_token_env` / `headers_env`
 - `KUBENTLY_GITOPS_TOKEN` (scope it to the manifests repo only — see the GitOps PR Remediation section)
 
 ### Example Kubernetes Secret
 
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kubently-secrets
-type: Opaque
-stringData:
-  API_KEYS: "key1,key2,key3"
-  AGENT_TOKEN_PROD: "secure-token-here"
-  OPENAI_API_KEY: "sk-..."
+The chart expects two separately named secrets rather than one combined one:
+`kubently-api-keys` (key: `keys`) for client API keys, and
+`kubently-llm-secrets` (keys: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+`GOOGLE_API_KEY`, `LANGSMITH_API_KEY`) for provider credentials.
+
+```bash
+kubectl create secret generic kubently-api-keys -n kubently \
+  --from-literal=keys="admin:$(openssl rand -hex 32)"
+
+kubectl create secret generic kubently-llm-secrets -n kubently \
+  --from-literal=ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
 ## Environment-Specific Configurations
+
+These examples assume running the API directly (`python -m kubently.main`),
+where `API_HOST`/`API_PORT`/`DEBUG` are honoured. In containers the port is
+fixed by the image command — see the container note under Core Settings.
 
 ### Development
 
@@ -388,6 +549,7 @@ export API_PORT=8080
 export LOG_LEVEL=DEBUG
 export DEBUG=true
 export REDIS_HOST=localhost
+export LLM_PROVIDER=anthropic-claude
 ```
 
 ### Staging
@@ -415,8 +577,9 @@ export SESSION_TTL=7200  # 2 hours
 
 1. **Redis connection errors**: Check `REDIS_HOST` and `REDIS_PORT`
 2. **A2A not accessible**: A2A is always enabled. Ensure you're accessing it at the `/a2a` path on the main API port
-3. **Authentication failures**: Verify `API_KEYS` and `AGENT_TOKEN_*` are set
+3. **Authentication failures**: Verify `API_KEYS` is set on the API, and that the executor's `KUBENTLY_TOKEN` matches `executor:token:{CLUSTER_ID}` in Redis
 4. **Wrong A2A URL in agent card**: Set `A2A_EXTERNAL_URL` correctly
+5. **Agent fails with `Unsupported LLM_PROVIDER`**: `LLM_PROVIDER` is required and has no default — set it under `api.env`
 
 ### Debug Commands
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -9,6 +9,23 @@ Kubently uses a central API server architecture:
 - **Executors**: Lightweight agents deployed to each Kubernetes cluster you want to manage
 - **CLI**: Command-line tool for administration and querying clusters
 
+**One chart, three switches.** There is a single Helm chart —
+`deployment/helm/kubently` in this repo, published as `kubently/kubently` —
+and you choose what it deploys with `api.enabled`, `redis.enabled` and
+`executor.enabled`. A "central API install" is that chart with
+`executor.enabled=false`; an "executor-only install" is the *same* chart with
+`api.enabled=false` and `redis.enabled=false`. There is no separate executor
+chart.
+
+Both forms are shown below. To install from the published repository instead
+of a checkout:
+
+```bash
+helm repo add kubently https://kubently.github.io/kubently
+helm repo update
+# then substitute `kubently/kubently` for `./deployment/helm/kubently`
+```
+
 ## Prerequisites
 
 - Kubernetes cluster for the central API (v1.24+)
@@ -77,30 +94,46 @@ Create a `values.yaml` file for your deployment:
 ```yaml
 # my-values.yaml
 api:
+  # Chart default is 3; the API scales horizontally via the connection registry
   replicaCount: 2
   image:
     repository: ghcr.io/kubently/kubently
     tag: "latest"
 
+  # Name of the API-key secret you created above. The chart default is ""
+  # (empty), in which case the deployment falls back to "<release>-api-keys" —
+  # which happens to be "kubently-api-keys" for a release named "kubently".
+  # Set it explicitly so the reference survives a differently named release,
+  # and so a helm upgrade never replaces your manually created secret.
+  existingSecret: "kubently-api-keys"
+
   env:
-    LLM_PROVIDER: "anthropic-claude"  # or "openai" or "google-gemini"
-    ANTHROPIC_MODEL_NAME: "claude-sonnet-4-20250514"
+    # REQUIRED — the agent has no default provider and fails to start without
+    # this. Must contain "anthropic"/"claude", "openai"/"azure", or
+    # "google"/"gemini".
+    LLM_PROVIDER: "anthropic-claude"
     LOG_LEVEL: "INFO"
     A2A_EXTERNAL_URL: "https://kubently.yourdomain.com/a2a/"  # Update after ingress setup
 
 redis:
   enabled: true
-  # Auth defaults to kubently-redis-password secret (created in Step 2.1)
+  # Auth defaults to the kubently-redis-password secret (created in Step 2.1)
   master:
     persistence:
       enabled: true
-      size: 5Gi
-      storageClass: ""  # Uses cluster default
+      size: 5Gi          # Chart default is 2Gi
+      storageClass: ""   # Uses cluster default
 
-# Executor not deployed with API (deploy separately to other clusters)
+# Executor not deployed with the API (deploy separately to other clusters).
+# The chart default is true, so an API-only install must set this explicitly.
 executor:
   enabled: false
 ```
+
+**Provider keys**: the chart reads `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+`GOOGLE_API_KEY` and `LANGSMITH_API_KEY` from a secret whose name is fixed at
+`kubently-llm-secrets` — the one created in Step 2.1. Every key is optional,
+so only the provider you selected needs to be present.
 
 Deploy with Helm:
 
@@ -123,7 +156,8 @@ kubectl get pods -n kubently
 # Check API health
 kubectl port-forward -n kubently svc/kubently-api 8080:8080 &
 curl http://localhost:8080/health
-# Should return: {"status":"healthy"}
+# Returns {"status":"healthy", "redis":"connected", "modules":"initialized", ...}
+# /healthz is the unauthenticated probe endpoint and returns {"status":"ok"}
 ```
 
 ## Step 3: Configure External Access (Optional)
@@ -160,10 +194,12 @@ ingress:
       hosts:
         - kubently.yourdomain.com
 
-# Secret references (already set by default)
-# redis.auth.existingSecret: "kubently-redis-password"
-# api.existingSecret: "kubently-api-keys"
-# You only need to override these if using custom secret names
+# Secret references:
+#   redis.auth.existingSecret defaults to "kubently-redis-password" — override
+#     only if you named the secret differently.
+#   api.existingSecret defaults to "" — set it (as in my-values.yaml above) so
+#     the chart uses your manually created kubently-api-keys secret instead of
+#     rendering one from api.apiKeys.
 ```
 
 Deploy with ingress and production secrets:
@@ -258,7 +294,7 @@ kubectl create namespace kubently
 kubectl create secret generic kubently-executor-token -n kubently \
   --from-literal=token="<paste-token-from-5.1>"
 
-# Create executor values
+# Create executor values — same chart, API and Redis switched off
 cat > executor-values.yaml <<EOF
 # Disable API and Redis (executor only)
 api:
@@ -270,28 +306,37 @@ redis:
 # Enable executor
 executor:
   enabled: true
-  clusterId: "production-us-west"  # Must match the cluster ID used when creating token
+  clusterId: "production-us-west"  # Must match the cluster ID used when creating the token
   apiUrl: "https://kubently.yourdomain.com"
-  replicaCount: 1
 
-  # Service account permissions
-  rbac:
-    create: true
-    # Executors need read access to cluster resources
-    rules:
-    - apiGroups: ["*"]
-      resources: ["*"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: [""]
-      resources: ["pods/log"]
-      verbs: ["get"]
+  # Use the secret created above rather than putting the token in values
+  existingSecret: "kubently-executor-token"
+  existingSecretKey: "token"
 EOF
 
-# Deploy executor with Helm
+# Deploy executor with Helm — the same chart as the API install
 helm install kubently-executor ./deployment/helm/kubently \
   --namespace kubently \
   --values executor-values.yaml
 ```
+
+Notes on the executor values, all verifiable in
+`deployment/helm/kubently/values.yaml`:
+
+- **No `replicaCount`.** Executors always run one replica: the deployment
+  hardcodes `replicas: 1` because each executor *is* a cluster identity, and a
+  second replica would register a duplicate agent for the same `clusterId`.
+- **RBAC is `executor.rbacRules`, a flat list** — there is no
+  `executor.rbac.create` / `executor.rbac.rules`. Leave it empty (the default)
+  to get the chart's built-in read-only ClusterRole, which already covers pods,
+  `pods/log`, services, endpoints, configmaps, PVs/PVCs, nodes, namespaces,
+  events, quotas, deployments, daemonsets, statefulsets, replicasets, jobs,
+  cronjobs, ingresses, networkpolicies, RBAC objects, storage classes, HPAs and
+  PDBs — and deliberately excludes Secrets. Set `rbacRules` only to *replace*
+  those defaults, e.g. to add CRDs.
+- **Command whitelist**: `executor.security.mode` defaults to `readOnly`, which
+  is a second boundary on top of RBAC. `fullAccess` additionally requires
+  the top-level `fullAccessAcknowledged: true`.
 
 ### 5.3 Verify Executor Connection
 
@@ -481,7 +526,8 @@ Each cluster needs its own unique token and cluster ID.
 - **Review Architecture**: See [ARCHITECTURE.md](ARCHITECTURE.md) for system design
 - **Configure Advanced Auth**: See [A2A_AUTHENTICATION.md](A2A_AUTHENTICATION.md) for OAuth/OIDC
 - **Set Up Monitoring**: See [DEPLOYMENT.md](DEPLOYMENT.md#monitoring-setup) for observability
-- **Production Hardening**: See [PRODUCTION_DEPLOYMENT_PLAN_REVIEWED.md](PRODUCTION_DEPLOYMENT_PLAN_REVIEWED.md)
+- **Cloud Telemetry**: See [CLOUD_TELEMETRY.md](CLOUD_TELEMETRY.md) to let executors answer CloudWatch/Cloud Logging questions via workload identity
+- **Configuration Reference**: See [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md) for every variable the API and executor read
 
 ## Support
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,18 +2,43 @@
 
 ## 📚 Documentation Structure
 
-### Core Documentation
-
-#### System Overview
+### Getting Started
 - **[README.md](../README.md)** - Project overview, quick start, and feature highlights
-- **[SYSTEM_DESIGN.md](SYSTEM_DESIGN.md)** - Complete system architecture and design philosophy
-- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Detailed technical architecture and component design
+- **[QUICK_START.md](QUICK_START.md)** - Single-cluster install in about five minutes
+- **[GETTING_STARTED.md](GETTING_STARTED.md)** - Production setup: secrets, ingress, remote executors
+- **[DEPLOYMENT.md](DEPLOYMENT.md)** - Deployment options, configuration management, hardening, upgrades
+- **[ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md)** - Every variable the API and executor read
 
-#### Operational Guides
-- **[DEPLOYMENT.md](DEPLOYMENT.md)** - Production deployment, configuration, and operations
-- **[API.md](API.md)** - Complete API reference with endpoints and examples
-- **[MCP.md](MCP.md)** - MCP (Model Context Protocol) server connect guide
+### Architecture
+- **[SYSTEM_DESIGN.md](SYSTEM_DESIGN.md)** - System architecture and design philosophy
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Technical architecture and component design
+- **[SSE_ARCHITECTURE.md](SSE_ARCHITECTURE.md)** - SSE + POST + Redis pub/sub command channel
+
+### Protocols & Integrations
+- **[API.md](API.md)** - REST API reference with endpoints and examples
+- **[TEST_QUERIES.md](TEST_QUERIES.md)** - Exact A2A protocol request examples
+- **[A2A_CONFIGURATION.md](A2A_CONFIGURATION.md)** - A2A server configuration and agent card
+- **[MCP.md](MCP.md)** - Kubently **as** an MCP server (Claude Desktop, Cursor, custom agents)
+- **[MCP_CLIENT_TOOLS.md](MCP_CLIENT_TOOLS.md)** - Kubently **as** an MCP client: mounting external MCP servers, including per-request injection
+- **[AGENTGATEWAY_SETUP.md](AGENTGATEWAY_SETUP.md)** - Running agentgateway in front of Kubently
+
+### Agent Capabilities
+- **[PROMPTS.md](PROMPTS.md)** - How the A2A system prompt is externalized and overridden
+- **[CLOUD_TELEMETRY.md](CLOUD_TELEMETRY.md)** - Read-only CloudWatch / Cloud Logging access via workload identity (default off)
+- **[CLOUD_AUTH.md](CLOUD_AUTH.md)** - How the executor pod obtains a cloud identity for `kubectl`
+- **[GITOPS_REMEDIATION.md](GITOPS_REMEDIATION.md)** - Agent-proposed fix PRs, human-merged (default off)
+
+### Security & Auth
+- **[A2A_AUTHENTICATION.md](A2A_AUTHENTICATION.md)** - Authenticating A2A callers
+- **[AUTH_DISCOVERY.md](AUTH_DISCOVERY.md)** - Auth discovery endpoint and OIDC configuration
+- **[OAUTH_USAGE.md](OAUTH_USAGE.md)** - OAuth/OIDC login flow for the CLI
+- **[TLS_DEPLOYMENT.md](TLS_DEPLOYMENT.md)** - TLS termination patterns
+- **[MULTI_CLUSTER_TLS.md](MULTI_CLUSTER_TLS.md)** - TLS between remote executors and the central API
+
+### Operations & Development
 - **[DEVELOPMENT.md](DEVELOPMENT.md)** - Developer guide, testing, and contribution guidelines
+- **[DOCKER_BUILD_GUIDE.md](DOCKER_BUILD_GUIDE.md)** - Building and publishing images to ghcr.io
+- **[LANGSMITH_TRACING.md](LANGSMITH_TRACING.md)** - Production tracing and observability
 
 ### Module Specifications
 
@@ -26,11 +51,19 @@ Located in `docs/modules/`:
 5. **[05-agent.md](modules/05-agent.md)** - Agent module specification
 6. **[06-models.md](modules/06-models.md)** - Data models and primitives specification
 7. **[07-deployment.md](modules/07-deployment.md)** - Deployment automation specification
+8. **[08-cli.md](modules/08-cli.md)** - CLI specification
 
 ### Component Documentation
 
-- **[kubently/agent/README.md](../kubently/agent/README.md)** - Agent deployment and operation guide
 - **[deployment/README.md](../deployment/README.md)** - Deployment directory structure and usage
+- **[deployment/helm/kubently/values.yaml](../deployment/helm/kubently/values.yaml)** - The chart's annotated defaults; the source of truth for every Helm setting
+- **[CLAUDE.md](../CLAUDE.md)** - Development guidelines and repository conventions
+
+### Planning Notes
+
+`docs/plans/` and **[RESUME_PUNCHLIST.md](RESUME_PUNCHLIST.md)** hold
+forward-looking planning material. They describe intent, not shipped behaviour
+— check the code or the guides above before relying on anything in them.
 
 ## 📖 Reading Order
 
@@ -99,6 +132,4 @@ When updating documentation:
 
 ---
 
-*Last Updated: 2024*
-*Documentation Version: 1.0.0*
-*For Kubently Version: 1.0.0*
+*Chart version: see `deployment/helm/kubently/Chart.yaml`*

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -57,18 +57,28 @@ helm install kubently ./deployment/helm/kubently -n kubently \
 kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kubently -n kubently --timeout=120s
 ```
 
-## Register the Executor Token
+## How the Executor Gets Authenticated
 
-Helm puts the token in a Secret for the executor to *present*, but nothing in
-the chart tells the API to *accept* it — the API validates against Redis key
-`executor:token:{cluster_id}`, which only the admin API writes. Register it
-once, and the executor's next reconnect attempt succeeds:
+The API only accepts an executor whose token matches Redis key
+`executor:token:{cluster_id}`. In this single-cluster layout you get that for
+free: because `api.enabled` and `executor.enabled` are on in the *same* release
+and the token came from `--set executor.token=...`, the API Deployment's
+`sync-executor-tokens` init container writes the key into Redis before the API
+starts.
+
+Two cases where that does **not** happen, and you must register the token
+yourself through the admin API:
+
+- **A remote executor** installed as its own release (`api.enabled=false`) —
+  there is no API pod in that release to run the init container. This is the
+  normal multi-cluster case; see
+  [GETTING_STARTED.md - Step 5](GETTING_STARTED.md#step-5-register-and-deploy-executors).
+- **Rotating a token on an existing release**, where `helm upgrade` may not
+  restart the API pod and so never re-runs the init container.
 
 ```bash
-# Port-forward the API
 kubectl port-forward -n kubently svc/kubently-api 8080:8080 &
 
-# Teach the API about this executor's token
 curl -X POST http://localhost:8080/admin/agents/local/token \
   -H "X-API-Key: $(cat ~/kubently-admin-key.txt)" \
   -H 'Content-Type: application/json' \
@@ -77,7 +87,7 @@ curl -X POST http://localhost:8080/admin/agents/local/token \
 
 The endpoint returns 409 if a token already exists for that cluster id; delete
 it first (`DELETE /admin/agents/local/token`) to replace it. Custom tokens must
-be 32–128 characters of letters, digits, hyphens or underscores — the
+be 32-128 characters of letters, digits, hyphens or underscores — the
 `openssl rand -hex 32` value above qualifies.
 
 ## Configure CLI

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -9,6 +9,10 @@ Get Kubently running locally in 5 minutes. For production deployment with extern
 - Node.js 18+ (for CLI)
 - LLM API key (Anthropic, OpenAI, or Google)
 
+The fastest path is `kubently install`, which does everything below for you
+(see the README). The steps here are the manual equivalent, for when you want
+to see or customise each piece.
+
 ## Install & Deploy
 
 ```bash
@@ -39,8 +43,11 @@ kubectl create secret generic kubently-api-keys -n kubently \
   --from-literal=keys="admin:${ADMIN_KEY}"
 echo $ADMIN_KEY > ~/kubently-admin-key.txt
 
-# Deploy (API + executor in same cluster)
+# Deploy (API + executor in same cluster — one chart, all components on)
+# LLM_PROVIDER is required: the agent has no default provider.
 helm install kubently ./deployment/helm/kubently -n kubently \
+  --set api.existingSecret=kubently-api-keys \
+  --set api.env.LLM_PROVIDER=anthropic-claude \
   --set executor.enabled=true \
   --set executor.clusterId=local \
   --set executor.apiUrl=http://kubently-api:8080 \
@@ -50,10 +57,33 @@ helm install kubently ./deployment/helm/kubently -n kubently \
 kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kubently -n kubently --timeout=120s
 ```
 
+## Register the Executor Token
+
+Helm puts the token in a Secret for the executor to *present*, but nothing in
+the chart tells the API to *accept* it — the API validates against Redis key
+`executor:token:{cluster_id}`, which only the admin API writes. Register it
+once, and the executor's next reconnect attempt succeeds:
+
+```bash
+# Port-forward the API
+kubectl port-forward -n kubently svc/kubently-api 8080:8080 &
+
+# Teach the API about this executor's token
+curl -X POST http://localhost:8080/admin/agents/local/token \
+  -H "X-API-Key: $(cat ~/kubently-admin-key.txt)" \
+  -H 'Content-Type: application/json' \
+  -d "{\"token\": \"${EXECUTOR_TOKEN}\"}"
+```
+
+The endpoint returns 409 if a token already exists for that cluster id; delete
+it first (`DELETE /admin/agents/local/token`) to replace it. Custom tokens must
+be 32–128 characters of letters, digits, hyphens or underscores — the
+`openssl rand -hex 32` value above qualifies.
+
 ## Configure CLI
 
 ```bash
-# Port-forward API
+# Port-forward API (skip if you already started one above)
 kubectl port-forward -n kubently svc/kubently-api 8080:8080 &
 
 # Set environment variables


### PR DESCRIPTION
## Description

Documentation-only sweep. The docs on kubently.io were rewritten from this repo as the source of truth, and doing so surfaced places where this repo's own docs disagree with the code and the Helm chart. This fixes them at the source. Every statement was verified against the file that implements it before being written; no code or chart behaviour changed.

### 1. `docs/ENVIRONMENT_VARIABLES.md` — cloud telemetry + a full sweep

The shipped cloud-telemetry executor variables were entirely undocumented. Added, with the two behaviours that surprise operators:

| Variable | Default | Notes |
|----------|---------|-------|
| `KUBENTLY_CLOUD_MODE` | `off` | `off` / `auto` / `aws` / `gcp` (`sse_executor.py:106`) |
| `KUBENTLY_CLOUD_AWS_REGION` | auto-detected | `sse_executor.py:111` |
| `KUBENTLY_CLOUD_GCP_PROJECT` | auto-detected | `sse_executor.py:112` |
| `KUBENTLY_CLOUD_REFRESH_INTERVAL` | `3600` | `sse_executor.py:114` |
| `KUBENTLY_CLOUD_TOOLS` | `auto` | API side; `off` skips tool registration (`cloud_tools.py:176`) |

- Enabling cloud mode **implies capability reporting** — the executor turns `KUBENTLY_REPORT_CAPABILITIES` on itself, because the agent discovers cloud access through the capability report.
- Absent boto3 / google-cloud SDKs **log a warning and disable the feature**; the executor keeps serving kubectl.

Then grepped `kubently/` for every `os.environ.get` / `os.getenv` / env-name constant and reconciled against the doc.

**Added** (existed in code, undocumented): the OIDC set (`OIDC_ENABLED`, `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_AUDIENCE`, `OIDC_JWKS_URI`, `OIDC_TOKEN_ENDPOINT`, `OIDC_DEVICE_AUTH_ENDPOINT`, `OIDC_SCOPES`), `REDIS_PASSWORD`, `KUBENTLY_SSL_VERIFY`, `KUBENTLY_CA_CERT`, `KUBENTLY_REPORT_CAPABILITIES`, `KUBENTLY_HEARTBEAT_INTERVAL`, `EXECUTOR_VERSION`, `KUBENTLY_MAX_OUTPUT_CHARS`, `KUBENTLY_PROMPT_FILE`, `GOOGLE_MODEL_NAME`, `ANTHROPIC_CONTEXT_CLEARING`.

**Corrected** (documented default disagreed with code):

- `LLM_PROVIDER` was documented as optional with default `openai`. It has **no default and is required** — `agent.py` raises `Unsupported LLM_PROVIDER` when unset, and no chart default supplies it. Documented the substring matching (`anthropic`/`claude`, `openai`/`azure`, `google`/`gemini`).
- **Ollama is not implemented.** `OLLAMA_BASE_URL` / `OLLAMA_MODEL` removed — there is no Ollama code path.
- `ANTHROPIC_MODEL_NAME` default is `claude-sonnet-4-6`, not `claude-3-5-sonnet-20241022`.
- `REDIS_HOST` default is `kubently-redis-master`, not `redis`.
- Whitelist path is `KUBENTLY_WHITELIST_CONFIG`. `WHITELIST_PATH`, `REFRESH_INTERVAL` and `TIMEOUT_SECONDS` do not exist; those knobs are fields inside the whitelist YAML.
- `AGENT_TOKEN_<ID>` does not exist. Executor tokens live in Redis at `executor:token:{cluster_id}`, written by the admin API.
- `OPENAI_ENDPOINT` is not read anywhere.
- `PORT` is not read; and `API_HOST`/`API_PORT`/`DEBUG` only apply to the `__main__` block, since the image pins `uvicorn --host 0.0.0.0 --port 8080`.
- `REDIS_URL` is set by the chart but read only by an unimported module.
- LangSmith variables are SDK-consumed, not read by Kubently; PostHog is a separate integration.

### 2. Install / getting-started text vs `values.yaml`

- Stated the **one-chart model** up front (`api.enabled` / `redis.enabled` / `executor.enabled`). `DEPLOYMENT.md` told readers to `helm install kubently-executor kubently/executor` — that chart does not exist; an executor-only install is the same chart with api and redis off. Added the `helm repo add kubently https://kubently.github.io/kubently` form, which the `release-chart.yml` workflow actually publishes.
- Executor RBAC is `executor.rbacRules`, a flat list that **replaces** the chart's built-in read-only ClusterRole — not `executor.rbac.create` / `executor.rbac.rules`.
- Removed `executor.replicaCount`: the Deployment hardcodes `replicas: 1` because an executor is a cluster identity.
- Corrected defaults: `api.replicaCount` is 3, `redis.master.persistence.size` is 2Gi, `api.existingSecret` is `""` (falls back to `<release>-api-keys`), and `executor.enabled` defaults to **true**, so an API-only install must disable it explicitly.
- `redis.persistence` / `api.replicas` / a `monitoring:` block do not exist; corrected to `redis.master.persistence`, `api.replicaCount`, and `prometheus.url` / `loki.url`.
- Replaced things that are not in the repo: `deploy/quickstart.yaml`, images `kubently/api` and `kubently/executor` (real: `ghcr.io/kubently/kubently`, `ghcr.io/kubently/kubently-executor`), a `kubently-config` ConfigMap, and env vars the code never reads (`KUBENTLY_REDIS_URL`, `KUBENTLY_API_KEYS`, `KUBENTLY_AGENT_TOKENS`, `api_workers`, `result_ttl`, `long_poll_timeout`).
- Documented the **executor token lifecycle** precisely: the API Deployment's `sync-executor-tokens` init container seeds `executor:token:{cluster_id}` only in a co-located release where the token came from `executor.token`; a remote executor release has no API pod, so the admin API is required there.
- Corrected the `/health` example output and pointed probes at `/healthz`.
- Fixed a dead link (`PRODUCTION_DEPLOYMENT_PLAN_REVIEWED.md`).

### 3. General sweep

- `README.md`: the Helm example pointed at `deployment/helm`, which is not a chart directory. The Agent Toolset list omitted the three cloud tools `cloud_tools.py` registers (`query_cloud_logs`, `query_cloud_metrics`, `get_recent_cloud_changes`) — added with their real enablement path and guardrails. LLM configuration now leads with the required `LLM_PROVIDER`.
- `docs/INDEX.md` listed 8 of 26 docs and linked a `kubently/agent/README.md` that no longer exists. Rebuilt, grouped by purpose, with `docs/plans/` and `RESUME_PUNCHLIST.md` flagged as planning material rather than shipped behaviour.
- Verified against their modules and found **accurate, left alone**: Prometheus / Loki / log-search, change correlation (helm history, ArgoCD), deployment verification and scheduled checks, operator runbooks, incident history, GitOps PR remediation, and MCP-client support including the `KubentlyAgent.run(mcp_servers=[...])` per-request seam. These were written alongside their code and match it.
- All relative links in the touched files resolve.

## Type of change

- [x] Documentation update

## How Has This Been Tested?

No code paths changed, so there is nothing to execute. Verification was by reading the implementation for every claim:

- Every environment variable cross-checked against the `os.environ.get` / `os.getenv` call or env-name constant that reads it, and against the Helm template that sets it.
- Every Helm value cross-checked against `deployment/helm/kubently/values.yaml` and the template that consumes it.
- Every documented endpoint cross-checked against its route decorator in `kubently/main.py` or `kubently/modules/webhook/`.
- Relative links in all touched files checked programmatically; all resolve.

**Test Configuration**: n/a — documentation only.

## Checklist:

- [x] My code follows the style guidelines of this project (existing doc conventions and table formats preserved)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (this PR is the documentation change)
- [x] My changes generate no new warnings
- [x] I have updated the CHANGELOG.md with my changes

Not applicable: unit/integration tests and dependent downstream changes — no code changed.

## Additional Notes:

Two things found while verifying that are **code/chart issues, deliberately not fixed here** (documentation-only PR):

1. **`executor.existingSecret` + `api.enabled` in one release breaks the API pod.** The `sync-executor-tokens` init container in `api-deployment.yaml` reads `{{ include "kubently.fullname" . }}-executor-token` by name and does not follow `executor.existingSecret`. When `existingSecret` is set, `executor-secret.yaml` does not create that secret, so the init container's `secretKeyRef` points at a missing secret and the API pod cannot start. Documented as a caveat in `DEPLOYMENT.md`; a fix would make the init container honour `executor.existingSecret` / `existingSecretKey`.

2. **`REQUIRE_AUTH`, `API_DEBUG` and `CORS_ORIGINS` are parsed but never applied.** `EnvConfigProvider.get_api_config()` is defined but never called, so `API_DEBUG` and `CORS_ORIGINS` have no effect (there is no `CORSMiddleware` in `main.py` at all). `REQUIRE_AUTH` reaches `AuthConfig.require_auth`, which no request path consults. Setting `REQUIRE_AUTH=false` silently does nothing — safe by accident, but misleading. Documented as parsed-but-not-honoured rather than removed.

Also noted, harmless: the chart sets `KUBENTLY_WHITELIST_DB` on the executor pod and `REDIS_URL` on the API pod; no code reads either.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXUpciQQ6FHqeSz441C5k2)_