### PR TITLE
fix: tool-call thread id race across concurrent requests; PostHog client leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,25 @@
   parsing, window filtering, truncation) and `tests/test_change_runners.py`
   (helm/argocd runner allowlists and caps, rollout whitelist rule)
 
+### Fixed
+- **Cross-request tool-call attribution race (#63)** — `KubentlyAgent` is one
+  shared instance serving every A2A request, and the tool-call thread id was
+  stored on it (`self._current_thread_id`), so two concurrent turns raced:
+  request A's tool call could be recorded under request B's thread id and
+  streamed into **B's** SSE as a `🔧 Tool Call` event carrying A's command
+  args and kubectl output. The id now lives in a module-level `ContextVar`
+  (`agent.current_thread_id`), which is per-task and inherited by the tasks the
+  agent graph spawns — the same mechanism
+  `kubently.modules.auth.context.current_api_key` already uses. New
+  `tests/test_tool_call_thread_isolation.py` runs two deterministically
+  interleaved in-flight turns and asserts each records under its own id
+- **PostHog client leaked on the degraded telemetry path (#64)** —
+  `_posthog_llm_callbacks()` constructed the `Posthog` client (background flush
+  thread + connection pool) before importing
+  `posthog.ai.langchain.CallbackHandler`, so a partial/older SDK left an idle
+  client that was never used or shut down. Both imports now happen before the
+  client is built. New `tests/test_posthog_callbacks.py`
+
 ## [Unreleased] - 2026-08-16
 
 ### Added

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -4,6 +4,7 @@ import logging
 import os
 import uuid
 from collections.abc import AsyncIterable
+from contextvars import ContextVar
 from datetime import UTC, datetime
 
 import httpx
@@ -49,6 +50,15 @@ def structured_log(log_data: dict, thread_id: str = None):
 
 
 _POSTHOG_CLIENT = None  # module-level singleton, see _posthog_llm_callbacks
+
+# The tool-call thread id is REQUEST scoped, not agent scoped: KubentlyAgent is a
+# single shared instance serving every A2A request, so keeping it on `self` lets
+# two concurrent turns race — request A's tool call gets recorded under request
+# B's thread id and is streamed into B's SSE, leaking A's command args and
+# kubectl output. A ContextVar is per-task and is inherited by the tasks the
+# graph spawns, the same pattern kubently.modules.auth.context uses for the
+# caller's API key.
+current_thread_id: ContextVar[str | None] = ContextVar("current_thread_id", default=None)
 
 
 def _user_message_text(messages: list[dict]) -> str:
@@ -108,13 +118,19 @@ def _posthog_llm_callbacks():
     if not key:
         return []
 
+    # Import BOTH pieces before constructing anything: the client owns a
+    # background flush thread and a connection pool, so building it first and
+    # then bailing on a missing CallbackHandler (older/partial SDK) leaks an
+    # idle client that nothing will ever use or shut down.
+    try:
+        from posthog import Posthog
+        from posthog.ai.langchain import CallbackHandler
+    except Exception as e:  # SDK missing/too old — never fail the agent for telemetry
+        logger.warning(f"PostHog LLM observability requested but unavailable: {e}")
+        return []
+
     global _POSTHOG_CLIENT
     if _POSTHOG_CLIENT is None:
-        try:
-            from posthog import Posthog
-        except Exception as e:  # SDK missing/too old — never fail the agent for telemetry
-            logger.warning(f"PostHog LLM observability requested but unavailable: {e}")
-            return []
         # Singleton: the client owns a background flush thread and connection
         # pool, and initialize() runs per agent construction — a client per call
         # would leak both.
@@ -122,11 +138,6 @@ def _posthog_llm_callbacks():
             key, host=os.getenv("POSTHOG_HOST", "https://us.i.posthog.com")
         )
 
-    try:
-        from posthog.ai.langchain import CallbackHandler
-    except Exception as e:
-        logger.warning(f"PostHog LangChain callback unavailable: {e}")
-        return []
     return [CallbackHandler(client=_POSTHOG_CLIENT)]
 
 
@@ -231,7 +242,6 @@ class KubentlyAgent:
         # Investigation tracking
         self.investigation_steps = []
         self.min_investigation_steps = 4  # Minimum steps for thoroughness
-        self._current_thread_id = None
 
     async def track_investigation_step(self, command: str, purpose: str, findings: str):
         """Track each investigation step for thoroughness."""
@@ -247,7 +257,7 @@ class KubentlyAgent:
             "investigation_step": len(self.investigation_steps),
             "command": command,
             "purpose": purpose
-        }, thread_id=self._current_thread_id)
+        }, thread_id=current_thread_id.get())
 
     def should_continue_investigation(self, steps_taken: int) -> bool:
         """Encourage continued investigation."""
@@ -444,7 +454,7 @@ class KubentlyAgent:
             tool_call_id = await interceptor.record_tool_call(
                 tool_name="list_clusters",
                 args={},
-                thread_id=getattr(self, '_current_thread_id', None)
+                thread_id=current_thread_id.get()
             )
 
             async with httpx.AsyncClient(timeout=30.0) as client:
@@ -575,7 +585,7 @@ class KubentlyAgent:
                     "extra_args": extra_args,
                     "parsed": cmd_info
                 },
-                thread_id=getattr(self, '_current_thread_id', None)
+                thread_id=current_thread_id.get()
             )
 
             # Track investigation step
@@ -706,7 +716,7 @@ class KubentlyAgent:
             tool_call_id = await interceptor.record_tool_call(
                 tool_name="execute_kubectl_multi",
                 args={"cluster_ids": cluster_ids, "command": command, "namespace": namespace},
-                thread_id=getattr(self, "_current_thread_id", None),
+                thread_id=current_thread_id.get(),
             )
             try:
                 output = await run_fleet_command(
@@ -790,7 +800,7 @@ class KubentlyAgent:
                     "resource_type": resource_type,
                     "window": window,
                 },
-                thread_id=getattr(self, "_current_thread_id", None),
+                thread_id=current_thread_id.get(),
             )
 
             try:
@@ -996,7 +1006,7 @@ class KubentlyAgent:
                     "namespace": namespace,
                     "window": window,
                 },
-                thread_id=getattr(self, "_current_thread_id", None),
+                thread_id=current_thread_id.get(),
             )
 
             try:
@@ -1158,7 +1168,7 @@ class KubentlyAgent:
                     "previous": previous,
                     "context_lines": context_lines,
                 },
-                thread_id=getattr(self, "_current_thread_id", None),
+                thread_id=current_thread_id.get(),
             )
             payload = build_log_search_payload(
                 namespace=namespace,
@@ -1239,7 +1249,7 @@ class KubentlyAgent:
                 tool_call_id = await interceptor.record_tool_call(
                     tool_name="search_past_incidents",
                     args={"query": query, "cluster_id": cluster_id, "limit": limit},
-                    thread_id=getattr(self, "_current_thread_id", None),
+                    thread_id=current_thread_id.get(),
                 )
                 try:
                     # Same per-caller namespace derivation as conversation
@@ -1317,7 +1327,7 @@ class KubentlyAgent:
                         "limit": limit,
                         "direction": direction,
                     },
-                    thread_id=getattr(self, "_current_thread_id", None),
+                    thread_id=current_thread_id.get(),
                 )
                 payload = build_loki_payload(
                     query, start=start, end=end, limit=limit, direction=direction
@@ -1343,7 +1353,7 @@ class KubentlyAgent:
                 api_url,
                 api_key,
                 interceptor,
-                lambda: getattr(self, "_current_thread_id", None),
+                lambda: current_thread_id.get(),
             )
         )
 
@@ -1417,7 +1427,7 @@ class KubentlyAgent:
                         "step": step,
                         "time": time,
                     },
-                    thread_id=getattr(self, "_current_thread_id", None),
+                    thread_id=current_thread_id.get(),
                 )
 
                 payload = build_prometheus_payload(
@@ -1472,7 +1482,7 @@ class KubentlyAgent:
         self.tools.extend(
             build_gitops_tools(
                 interceptor,
-                lambda: getattr(self, "_current_thread_id", None),
+                lambda: current_thread_id.get(),
             )
         )
 
@@ -1490,7 +1500,7 @@ class KubentlyAgent:
             mcp_tools = await build_mcp_tools(
                 static_mcp_specs,
                 interceptor,
-                lambda: getattr(self, "_current_thread_id", None),
+                lambda: current_thread_id.get(),
             )
             self.tools.extend(mcp_tools)
             logger.info(
@@ -1532,8 +1542,8 @@ class KubentlyAgent:
         # tenants. Falls back to the raw id for unauthenticated/local invocation.
         thread_id = _namespaced_thread_id(thread_id)
 
-        # Store thread ID for tool call tracking
-        self._current_thread_id = thread_id
+        # Store thread ID for tool call tracking (per-request, see current_thread_id)
+        current_thread_id.set(thread_id)
 
         # This turn's user text: matched against runbooks and past incidents,
         # and kept as the "query" on any incident record this turn produces.
@@ -1562,7 +1572,7 @@ class KubentlyAgent:
             request_tools = await build_mcp_tools(
                 specs,
                 get_tool_call_interceptor(),
-                lambda: getattr(self, "_current_thread_id", None),
+                lambda: current_thread_id.get(),
             )
             if request_tools:
                 from deepagents import create_deep_agent

--- a/tests/test_posthog_callbacks.py
+++ b/tests/test_posthog_callbacks.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""PostHog telemetry must not allocate anything on the degraded path.
+
+`Posthog(...)` starts a background flush thread and a connection pool. It used
+to be constructed *before* the `posthog.ai.langchain.CallbackHandler` import, so
+an SDK that ships `posthog` but not the LangChain callback (older/partial
+install) left an idle client running that nothing ever used or shut down.
+Issue #64.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from kubently.modules.a2a.protocol_bindings.a2a_server import agent as agent_mod  # noqa: E402
+
+
+def _fake_posthog(monkeypatch, constructed, *, with_callback):
+    """Install a stub `posthog` package, optionally missing the LangChain part."""
+
+    class FakePosthog:
+        def __init__(self, key, host=None):
+            constructed.append((key, host))
+
+    posthog = types.ModuleType("posthog")
+    posthog.Posthog = FakePosthog
+    monkeypatch.setitem(sys.modules, "posthog", posthog)
+
+    if with_callback:
+        # A real package needs __path__ for submodule imports to resolve.
+        posthog.__path__ = []
+        langchain = types.ModuleType("posthog.ai.langchain")
+        langchain.CallbackHandler = lambda client=None: ("handler", client)
+        ai = types.ModuleType("posthog.ai")
+        ai.__path__ = []
+        ai.langchain = langchain
+        posthog.ai = ai
+        monkeypatch.setitem(sys.modules, "posthog.ai", ai)
+        monkeypatch.setitem(sys.modules, "posthog.ai.langchain", langchain)
+
+    monkeypatch.setattr(agent_mod, "_POSTHOG_CLIENT", None)
+    monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+
+
+def test_no_client_constructed_when_callback_handler_is_missing(monkeypatch):
+    constructed = []
+    _fake_posthog(monkeypatch, constructed, with_callback=False)
+
+    assert agent_mod._posthog_llm_callbacks() == []
+    assert constructed == [], "a PostHog client was leaked on the degraded path"
+    assert agent_mod._POSTHOG_CLIENT is None
+
+
+def test_client_constructed_once_when_sdk_is_complete(monkeypatch):
+    constructed = []
+    _fake_posthog(monkeypatch, constructed, with_callback=True)
+
+    first = agent_mod._posthog_llm_callbacks()
+    second = agent_mod._posthog_llm_callbacks()
+
+    assert len(first) == 1 and len(second) == 1
+    assert len(constructed) == 1, "the client must stay a singleton"
+
+
+def test_no_client_constructed_without_an_api_key(monkeypatch):
+    constructed = []
+    _fake_posthog(monkeypatch, constructed, with_callback=True)
+    monkeypatch.delenv("POSTHOG_API_KEY")
+
+    assert agent_mod._posthog_llm_callbacks() == []
+    assert constructed == []

--- a/tests/test_tool_call_thread_isolation.py
+++ b/tests/test_tool_call_thread_isolation.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Concurrent requests must not steal each other's tool-call thread id.
+
+KubentlyAgent is ONE shared instance serving every A2A request. The thread id
+that tool calls are recorded under used to live on `self`, so with two turns in
+flight the second one's assignment clobbered the first's: request A's tool call
+was recorded under B's thread id, and therefore streamed into B's SSE as a
+"🔧 Tool Call" event carrying A's command args and kubectl output. Issue #63.
+
+The interleaving here is forced with events, not sleeps, so both tests are
+deterministic. `test_shared_instance_attribute_races` pins the failure mode
+against the old carrier (proving this harness actually detects the bug), and
+`test_contextvar_isolates_concurrent_requests` shows the shipped carrier — a
+ContextVar, which is per-task — does not have it.
+"""
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from kubently.modules.a2a.protocol_bindings.a2a_server.agent import (  # noqa: E402
+    _namespaced_thread_id,
+    current_thread_id,
+)
+from kubently.modules.a2a.protocol_bindings.a2a_server.tool_call_interceptor import (  # noqa: E402
+    ToolCallInterceptor,
+)
+from kubently.modules.auth.context import current_api_key  # noqa: E402
+
+AGENT_SRC = (
+    Path(__file__).parent.parent
+    / "kubently/modules/a2a/protocol_bindings/a2a_server/agent.py"
+).read_text()
+
+
+async def _two_interleaved_turns(store, load):
+    """Two A2A turns in flight at once, sharing one agent.
+
+    Both callers pick the same client-supplied contextId (the realistic
+    collision) but authenticate as different tenants, so each turn's namespaced
+    thread id is distinct. Turn B stores its thread id *between* turn A storing
+    its own and turn A recording a tool call — the exact window that races.
+
+    `store`/`load` are the carrier under test: how run() saves the thread id and
+    how a tool reads it back.
+
+    Returns (interceptor, (a_own, a_observed), (b_own, b_observed)).
+    """
+    interceptor = ToolCallInterceptor()
+    a_stored = asyncio.Event()
+    b_stored = asyncio.Event()
+
+    async def turn_a():
+        current_api_key.set("tenant-a-key")  # set by the auth layer per request
+        own = _namespaced_thread_id("shared-context")  # what run() derives
+        store(own)
+        a_stored.set()
+        await b_stored.wait()  # the other turn is now also in flight
+        observed = load()  # what a tool reads just before recording its call
+        await interceptor.record_tool_call(
+            "execute_kubectl", {"command": "get secrets"}, observed
+        )
+        return own, observed
+
+    async def turn_b():
+        current_api_key.set("tenant-b-key")
+        await a_stored.wait()
+        own = _namespaced_thread_id("shared-context")
+        store(own)
+        b_stored.set()
+        observed = load()
+        await interceptor.record_tool_call(
+            "execute_kubectl", {"command": "get pods"}, observed
+        )
+        return own, observed
+
+    # gather() wraps each coroutine in its own Task, which is what gives each
+    # one an independent copy of the context — same as one asyncio task per
+    # inbound A2A request.
+    a_result, b_result = await asyncio.gather(turn_a(), turn_b())
+    return interceptor, a_result, b_result
+
+
+@pytest.mark.asyncio
+async def test_contextvar_isolates_concurrent_requests():
+    """Each in-flight turn's tool call carries its OWN thread id."""
+    interceptor, (a_own, a_seen), (b_own, b_seen) = await _two_interleaved_turns(
+        current_thread_id.set, current_thread_id.get
+    )
+
+    assert a_own != b_own, "the two tenants must namespace the shared contextId apart"
+    assert a_seen == a_own, f"turn A recorded under {a_seen}, not its own {a_own}"
+    assert b_seen == b_own, f"turn B recorded under {b_seen}, not its own {b_own}"
+
+    # End-to-end through the real interceptor: each thread sees only its own
+    # call, so neither caller's SSE stream can carry the other's kubectl output.
+    a_calls = await interceptor.get_tool_calls_for_thread(a_own)
+    b_calls = await interceptor.get_tool_calls_for_thread(b_own)
+    assert [c["args"]["command"] for c in a_calls] == ["get secrets"]
+    assert [c["args"]["command"] for c in b_calls] == ["get pods"]
+
+
+@pytest.mark.asyncio
+async def test_shared_instance_attribute_races():
+    """The pre-fix carrier, under the identical interleaving, misattributes.
+
+    Not a test of shipped behaviour — it is the control that proves the harness
+    above would fail if the thread id ever moved back onto the shared instance.
+    """
+    shared = types.SimpleNamespace(thread_id=None)
+    interceptor, (a_own, a_seen), (b_own, b_seen) = await _two_interleaved_turns(
+        lambda tid: setattr(shared, "thread_id", tid), lambda: shared.thread_id
+    )
+
+    assert a_seen == b_own != a_own, "expected A's tool call to land on B's thread"
+    leaked = await interceptor.get_tool_calls_for_thread(b_own)
+    assert {c["args"]["command"] for c in leaked} == {"get secrets", "get pods"}, (
+        "B's thread should have picked up both turns' tool calls"
+    )
+    assert await interceptor.get_tool_calls_for_thread(a_own) == []
+
+
+def test_thread_id_is_not_instance_state():
+    """Regression guard: the id lives in the ContextVar, never back on self."""
+    assert "_current_thread_id" not in AGENT_SRC, (
+        "the tool-call thread id is back on the shared agent instance — "
+        "concurrent requests will cross-attribute tool calls again"
+    )
+    assert "current_thread_id.set(thread_id)" in AGENT_SRC

--- a/tests/test_tool_trace_thread_match.py
+++ b/tests/test_tool_trace_thread_match.py
@@ -50,7 +50,7 @@ def test_agent_records_under_namespaced_id():
     """The recording side still namespaces (the other half of the contract)."""
     assert "thread_id = _namespaced_thread_id(thread_id)" in AGENT_SRC
     idx_ns = AGENT_SRC.index("thread_id = _namespaced_thread_id(thread_id)")
-    idx_store = AGENT_SRC.index("self._current_thread_id = thread_id", idx_ns)
+    idx_store = AGENT_SRC.index("current_thread_id.set(thread_id)", idx_ns)
     assert idx_store > idx_ns, "namespacing must happen before the id is stored"
 
 


### PR DESCRIPTION
Two fixes found in an end-to-end pass against a kind deployment built from HEAD.

## #87 — the A2A agent card was stale

**Root cause (URL).** `kubently/main.py` read the setting as
`config.get("a2a_external_url", "http://localhost:{port}/a2a/")`, but the key is
*always present* in the config dict (set to `None` when `A2A_EXTERNAL_URL` is
unset), so `dict.get`'s default never applied. `None` reached `A2AModule`, which
fell back to `f"http://{host}:{port}/"` — the **bind** address, `0.0.0.0`. A
setting for this already existed (`A2A_EXTERNAL_URL`, documented in
`docs/A2A_CONFIGURATION.md`); nothing new was added. The fallback is now a
reachable `http://localhost:{port}/a2a/` (path included, since A2A is mounted at
`/a2a`) and logs a warning telling the operator to set `A2A_EXTERNAL_URL`.

**Root cause (skills).** The card had one hand-written skill that had not moved
since the kubectl-only release, while `agent.py::_initialize_tools` had grown
nine more tool families, each behind its own configuration gate.

The capability list was derived from what the agent **actually registers today**,
by reading `_initialize_tools` and the builder modules rather than the issue text
(an AST sweep for `@tool`-decorated functions cross-checks it). Skills now come
from the same gating predicates that decide registration — `kubently/modules/a2a/skills.py`:

| skill | tools | gate |
|---|---|---|
| `kubernetes-debug` | `list_clusters`, `execute_kubectl`, `get_events_for_resource` | always |
| `fleet-query` | `execute_kubectl_multi` | always |
| `pod-log-search` | `search_pod_logs` | always |
| `change-correlation` | `get_recent_changes` | always |
| `incident-history` | `search_past_incidents` | `incidents_enabled()` + Redis |
| `loki-log-search` | `query_loki` | `loki_tool_enabled()` |
| `prometheus-metrics` | `query_prometheus` | `prometheus_tool_enabled()` |
| `cloud-telemetry` | `query_cloud_logs`, `query_cloud_metrics`, `get_recent_cloud_changes` | `cloud_tools_enabled()` |
| `gitops-remediation` | `get_manifest_file`, `propose_fix_pr` | `gitops_tools_enabled()` |
| `external-mcp-tools` | dynamic `mcp_*` | `mcp_client_enabled()` |

`cloud_tools_enabled()` is new only as a *name* for the inline
`KUBENTLY_CLOUD_TOOLS=off` check `build_cloud_tools` already performed, so the
card and the registration read the same predicate. The top-level description no
longer says "through kubectl commands".

**Check left behind** (`tests/test_agent_card.py`): every `@tool` function in the
a2a_server package must be claimed by a skill (and vice versa), so the next track
cannot ship a toolset the card does not advertise; plus gating tests
(`PROMETHEUS_URL` on/off flips the skill) and a test that the advertised URL is
never a bind address.

Out of scope here, still open from the issue: `protocolVersion 0.2.6` and the
`/.well-known/agent-card.json` path — left for #76 as the issue suggests.

## #88 — deployment verification failed healthy rollouts

**Root cause.** The verification brief asked "Any Warning events for the workload
or its pods since the rollout?" with nothing anchoring *since*, and the verdict
contract says "when in doubt, FAIL". Two things made an unrelated, chronic
warning look like rollout damage:

1. **Name-prefix scoping is not kind scoping.** The HPA in the report is named
   `kubently-api`, exactly like the Deployment, so name matching alone cannot
   exclude it (`changes.event_changes` matches `name == p or name.startswith(p + "-")`).
2. **Last-seen looks like now.** A warning repeating every ~15s ("x281") always
   has a fresh `lastTimestamp`; only `firstTimestamp`/`count` reveal it predates
   the deploy.

**Fix.** Warnings are classified deterministically in
`kubently/modules/webhook/verify_deployment.py::scope_warnings` before the agent
reasons about them, scoped three ways — namespace, the workload's ownership chain
(Deployment/StatefulSet/DaemonSet/ReplicaSet/Pod, so a same-named HPA/Service
drops out), and **first-seen** time against the moment verification started. The
brief hands the agent both lists and says plainly that only the first is grounds
for FAIL and the second is context it should still report. This is not a
FAIL→WARN downgrade: a `BackOff` on a pod of the new ReplicaSet still fails the
deploy, and the "agent PASS cannot overrule an unsettled rollout" asymmetry is
untouched.

**Check left behind** (`tests/test_verify_deployment.py`):
`test_chronic_unrelated_warning_is_not_grounds_for_fail` replays the exact
reported event — `HorizontalPodAutoscaler/kubently-api`, `FailedGetResourceMetric`,
`count: 281`, first seen an hour before the rollout, still firing after it — and
asserts it lands in the pre-existing bucket with the caused-by-rollout list empty.
Verified it actually catches the regression: re-running that test against the
pre-fix classification (name-prefix only, last-seen freshness) fails with
`a pre-existing, unrelated warning must not count as rollout damage`. Companion
tests cover a real rollout warning still counting, ReplicaSet-level warnings,
other-namespace/other-workload/Normal events, and malformed JSON.

## Context for #65 (not fixed here)

While in the card code: the card does advertise `streaming=True`, and I did not
turn it off, because the capability does not look absent on HEAD —

- The reporter of #87 exercised `message/stream` on a HEAD kind deployment in the
  same session and got a real `text/event-stream` with incremental task lifecycle
  events, i.e. **#65 did not reproduce on HEAD**.
- The ASGI auth wrapper the A2A app is mounted behind
  (`kubently/modules/mcp/server.py::add_api_key_auth`) is a straight passthrough —
  it inspects `scope`, never `receive`/`send` bodies — so it cannot be buffering
  or truncating an SSE response, and an unauthenticated request gets a 401, not
  an empty 200.

So #65's "HTTP 200, 0 bytes" is more likely specific to the deployed image /
environment it was observed on than to a card advertising a capability the code
never had. Worth re-testing against HEAD before changing the card.

## Testing

`635 passed` on the unit suite (`make test` scope). The 2 failures on this branch
(`test_change_runners.py::test_enabled_but_no_binary`, `test_mcp_server.py::test_build_mcp_server_registers_expected_tools`)
reproduce identically on `main` in the same environment — missing `helm` binary
and missing `deepagents` module, unrelated to this change.

Closes #87
Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
