### PR TITLE
Make the cluster registry executor-owned; gate cloud tools on cloud identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   make the release job green while publishing nothing — the same defect class as
   #98 and #83. The release job keeps failing loudly if a stale version ever
   reaches `main`.
+- **Chart 1.1.1** — the shipped prompt (`prompts/system.prompt.yaml`) no longer
+  hardcodes the "## Cloud Telemetry" section; it arrives through the new
+  `{{cloud_guidance}}` variable only when the cloud tools register (#90). A
+  chart-content change, so it takes the patch bump the new `chart-version` job
+  requires.
 
 ## [Unreleased] - 2026-08-18
 
@@ -389,6 +394,31 @@
   executor Deployment does (`executor.existingSecret` /
   `executor.existingSecretKey`, falling back to the generated secret).
   Regression check: `tests/test_helm_executor_secret.py`
+- **The cluster registry is no longer writable by session creation (#89)** —
+  `POST /debug/session` accepted any `cluster_id`, and `GET /debug/clusters`
+  built its list from `cluster:active:*` / `cluster:session:*` as well as
+  executor tokens, so creating a session was enough to inject an arbitrary
+  name into the fleet the agent sees through `list_clusters` (a stray
+  `namespace` entry is how this was found). Fan-out then wasted a full
+  command timeout per phantom and could push real clusters out of the
+  10-cluster cap. Sessions now validate against a registered executor and
+  404 exactly like `/debug/execute`, and the listing is derived from
+  `executor:token:*` alone — executors define the registry, sessions only
+  consume it. Missing `X-API-Key` also answers `401` (with
+  `WWW-Authenticate`) instead of a `422` that leaked the parameter name
+- **Cloud telemetry tools are no longer registered when nothing can serve
+  them (#90)** — `query_cloud_logs` / `query_cloud_metrics` /
+  `get_recent_cloud_changes` were registered unconditionally, so on a
+  default deployment (no cloud identity anywhere) a metrics question cost a
+  tool call that could only fail, and displaced the honest "I have no
+  metrics source" answer. They now follow the `LOKI_URL` / `PROMETHEUS_URL`
+  rule: registered only when some registered executor advertises a cloud
+  identity, with the prompt's cloud section (`{{cloud_guidance}}`) gated on
+  the same switch. The per-call capability check remains for mixed fleets,
+  and `KUBENTLY_CLOUD_TOOLS=off` still forces them off. The agent card's
+  `cloud-telemetry` skill (#87) keeps the configuration-level gate
+  (`cloud_tools_configured()`), because the card is built when the A2A app is
+  mounted — before any executor has reported a capability
 
 ### Removed
 - **Config knobs that were parsed and never applied (#86)** — `API_DEBUG` and

--- a/deployment/helm/kubently/Chart.yaml
+++ b/deployment/helm/kubently/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubently
 description: Kubently - Troubleshooting Kubernetes Agentically
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.0.0"
 home: https://github.com/kubently/kubently
 maintainers:

--- a/deployment/helm/kubently/prompts/system.prompt.yaml
+++ b/deployment/helm/kubently/prompts/system.prompt.yaml
@@ -23,6 +23,12 @@ variables:
   - name: gitops_guidance
     required: false
     default: ""
+  # Injected by the agent ONLY when some registered executor advertises a
+  # cloud identity; defaults to empty so deployments with no cloud telemetry
+  # never reference cloud tools the model cannot call.
+  - name: cloud_guidance
+    required: false
+    default: ""
   # Injected by the agent ONLY when external MCP servers are configured
   # (KUBENTLY_MCP_SERVERS / KUBENTLY_MCP_SERVERS_FILE set); defaults to empty
   # so unconfigured deployments never reference external tools.
@@ -416,19 +422,6 @@ content: |-
   - Keep fleet commands filtered and token-efficient (e.g. `-o wide`, `-o custom-columns`, `-l <selector>`); never dump unfiltered resources from every cluster. Do NOT use `--field-selector status.phase!=Running` for fleet health sweeps — CrashLoopBackOff pods have `phase=Running`, so a whole cluster can look healthy while pods crash on a loop.
   - For single-cluster questions keep using execute_kubectl.
 
-  ## Cloud Telemetry
-
-  Some clusters' executors hold a read-only cloud identity (AWS or GCP). For those clusters you can use query_cloud_logs, query_cloud_metrics, and get_recent_cloud_changes. The tools tell you when a cluster has no cloud access — do not retry them there; continue with kubectl.
-
-  Prefer CLOUD evidence over cluster evidence when the cause likely lives outside the cluster:
-  - IAM/permission errors (AccessDenied, 403 from cloud APIs, image pull auth failures against ECR/GCR/AR): check cloud logs and recent IAM changes, not just pod logs.
-  - Throttling/quota symptoms (RequestLimitExceeded, 429s, rate exceeded): cloud metrics and API logs show the source.
-  - Managed-service failures (RDS/CloudSQL, load balancers, node pools): the service's cloud logs/metrics, not kubectl, hold the answer.
-  - Control-plane issues (API server errors, webhook timeouts, authentication failures): EKS control-plane logs / GKE audit logs — kubectl cannot see the control plane's own logs.
-  - "It broke suddenly and nothing changed in-cluster": get_recent_cloud_changes correlates CloudTrail/GKE audit events (IAM edits, security-group changes, node-pool operations) with the incident window.
-
-  Prefer CLUSTER evidence (kubectl) for anything about workload state: pod status, events, container logs of live pods, manifests, scheduling. Start with kubectl; reach for cloud tools when in-cluster evidence dead-ends or points outward.
-
   ## Log Search
 
   Use search_pod_logs to grep across MANY pods/containers in one call instead of dumping full logs pod-by-pod. Reach for it when:
@@ -451,6 +444,8 @@ content: |-
   {{gitops_guidance}}
 
   {{mcp_guidance}}
+
+  {{cloud_guidance}}
 
   # Code References
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -123,6 +123,7 @@ Create a new debugging session.
 - `201 Created` - Session created successfully
 - `400 Bad Request` - Invalid request parameters
 - `401 Unauthorized` - Invalid or missing API key
+- `404 Not Found` - No executor is registered for that cluster
 - `429 Too Many Requests` - Rate limit exceeded
 
 #### GET /debug/session/{session_id}

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -262,11 +262,17 @@ app.include_router(discovery_router, tags=["auth"])
 
 # Dependency injection helpers
 async def verify_api_key(
-    x_api_key: str = Header(..., description="API key for authentication")
+    x_api_key: Optional[str] = Header(None, description="API key for authentication")
 ) -> Tuple[bool, Optional[str]]:
     """Verify API key and return service identity."""
     if not auth_service:
         raise HTTPException(503, "Service not initialized")
+
+    # Missing credentials are an authentication failure, not a malformed
+    # request: a required Header(...) would answer 422 and leak the parameter
+    # name, which is not what docs/AUTH_DISCOVERY.md advertises.
+    if not x_api_key:
+        raise HTTPException(401, "Missing API key", headers={"WWW-Authenticate": "ApiKey"})
 
     result = await auth_service.authenticate(api_key=x_api_key, authorization=None)
     
@@ -602,6 +608,34 @@ async def get_cluster_capabilities(
 # AI/User/A2A Service Endpoints
 
 
+async def require_registered_cluster(cluster_id: str) -> None:
+    """404 unless an executor is registered for `cluster_id`.
+
+    The cluster registry is executor-owned: only an executor token (written by
+    admin registration or the Helm bootstrap) defines a cluster. Callers that
+    merely *target* a cluster — session creation, command execution — are
+    consumers of that registry and must never be able to write to it.
+    """
+    if not redis_client:
+        raise HTTPException(503, "Service not initialized")
+
+    if await redis_client.exists(f"executor:token:{cluster_id}"):
+        return
+
+    valid_clusters = sorted(
+        (key.decode() if isinstance(key, bytes) else key).replace("executor:token:", "")
+        for key in await redis_client.keys("executor:token:*")
+    )
+    error_msg = f"Cluster '{cluster_id}' not found."
+    if valid_clusters:
+        error_msg += f" Available clusters: {', '.join(valid_clusters)}"
+    else:
+        error_msg += " No clusters are currently registered."
+
+    logger.warning(f"Invalid cluster requested: {cluster_id}")
+    raise HTTPException(404, error_msg)
+
+
 @app.post("/debug/session", response_model=SessionResponse, status_code=201)
 async def create_session(
     request: CreateSessionRequest,
@@ -615,9 +649,15 @@ async def create_session(
     Returns:
         201: Session created successfully
         401: Unauthorized
+        404: No executor registered for that cluster
     """
     if not session_module:
         raise HTTPException(503, "Service not initialized")
+
+    # Same validation /debug/execute performs: a session may only target a
+    # cluster that has a registered executor. Without it, session creation
+    # injected arbitrary ids into /debug/clusters (issue #89).
+    await require_registered_cluster(request.cluster_id)
 
     _, extracted_service = auth_info
     service_identity = x_service_identity or extracted_service or "direct"
@@ -1405,6 +1445,11 @@ async def list_clusters(
     """
     List available Kubernetes clusters.
 
+    Registered executors are the only source: `cluster:active:*` and
+    `cluster:session:*` are written by session creation, so including them
+    let any API-key holder inject a phantom cluster into the fleet the agent
+    sees (issue #89).
+
     Returns:
         JSON with list of cluster IDs that can be targeted for debugging
     """
@@ -1412,22 +1457,6 @@ async def list_clusters(
         clusters_set = set()
 
         if redis_client:
-            # Active cluster markers: cluster:active:<id>
-            active_prefix = "cluster:active:"
-            active_keys = await redis_client.keys(f"{active_prefix}*")
-            for key in active_keys:
-                raw = key.decode() if isinstance(key, bytes) else key
-                if raw.startswith(active_prefix):
-                    clusters_set.add(raw[len(active_prefix):])
-
-            # Active sessions per cluster: cluster:session:<id>
-            session_prefix = "cluster:session:"
-            session_keys = await redis_client.keys(f"{session_prefix}*")
-            for key in session_keys:
-                raw = key.decode() if isinstance(key, bytes) else key
-                if raw.startswith(session_prefix):
-                    clusters_set.add(raw[len(session_prefix):])
-
             # Executor tokens: executor:token:<id>
             token_prefix = "executor:token:"
             token_keys = await redis_client.keys(f"{token_prefix}*")

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -242,6 +242,8 @@ class KubentlyAgent:
         # Investigation tracking
         self.investigation_steps = []
         self.min_investigation_steps = 4  # Minimum steps for thoroughness
+        # Set in initialize(): whether any executor advertises a cloud identity.
+        self._cloud_tools_enabled = False
 
     async def track_investigation_step(self, command: str, purpose: str, findings: str):
         """Track each investigation step for thoroughness."""
@@ -359,10 +361,15 @@ class KubentlyAgent:
         # tool the model cannot call.
         from kubently.modules.config import get_prompt
 
+        from .cloud_tools import cloud_guidance, cloud_tools_enabled
         from .gitops import gitops_guidance
         from .logsearch import loki_guidance
         from .mcp_client import mcp_guidance
         from .prometheus import metrics_guidance
+
+        # Cloud telemetry has no URL to key off, so the equivalent signal is
+        # whether any registered executor advertises a cloud identity.
+        self._cloud_tools_enabled = await cloud_tools_enabled(self.redis_client)
 
         self.system_prompt = get_prompt(
             role="a2a",
@@ -371,6 +378,7 @@ class KubentlyAgent:
                 "metrics_guidance": metrics_guidance(),
                 "gitops_guidance": gitops_guidance(),
                 "mcp_guidance": mcp_guidance(),
+                "cloud_guidance": cloud_guidance(self._cloud_tools_enabled),
             },
         )
 
@@ -1341,21 +1349,26 @@ class KubentlyAgent:
             logger.info("Loki log search tool registered (LOKI_URL is set)")
 
         # Cloud telemetry tools (query_cloud_logs, query_cloud_metrics,
-        # get_recent_cloud_changes). They dispatch to whichever provider the
-        # target executor reports a workload identity for, and refuse per-call
-        # when a cluster's executor reports none.
+        # get_recent_cloud_changes). Registered only when some executor in the
+        # fleet advertises a cloud identity; they then dispatch to whichever
+        # provider the target executor reports, and refuse per-call when a
+        # cluster's executor reports none.
         from kubently.modules.a2a.protocol_bindings.a2a_server.cloud_tools import (
             build_cloud_tools,
         )
 
-        self.tools.extend(
-            build_cloud_tools(
-                api_url,
-                api_key,
-                interceptor,
-                lambda: current_thread_id.get(),
+        if self._cloud_tools_enabled:
+            self.tools.extend(
+                build_cloud_tools(
+                    api_url,
+                    api_key,
+                    interceptor,
+                    lambda: current_thread_id.get(),
+                )
             )
-        )
+            logger.info("Cloud telemetry tools registered (executor reports a cloud identity)")
+        else:
+            logger.info("No executor reports a cloud identity; cloud telemetry tools disabled")
 
         from kubently.modules.a2a.protocol_bindings.a2a_server.prometheus import (
             build_prometheus_payload,

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/cloud_tools.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/cloud_tools.py
@@ -29,8 +29,17 @@ CLOUD_UNAVAILABLE_MSG = (
 )
 
 
-def cloud_tools_enabled() -> bool:
-    """Whether the cloud telemetry tools should be registered (default ON)."""
+def cloud_tools_configured() -> bool:
+    """Whether this deployment has cloud telemetry switched on at all.
+
+    The configuration-level half of the gate, and the only half that can be
+    answered synchronously. The agent card (kubently/modules/a2a/skills.py) is
+    built once when the A2A app is mounted, before any executor has connected
+    or reported a capability, so it can only assert the operator's intent —
+    asking the fleet there would advertise "no cloud" on every deployment.
+    Tool registration additionally requires a live cloud identity; see
+    cloud_tools_enabled() below.
+    """
     return os.getenv("KUBENTLY_CLOUD_TOOLS", "auto").lower() != "off"
 
 
@@ -159,6 +168,60 @@ def build_changes_request(
 
 
 # --------------------------------------------------------------------------
+# Registration gate (mirrors LOKI_URL / PROMETHEUS_URL): when nothing in the
+# fleet can serve these tools they are not registered and the prompt section
+# below is omitted, so the model is never told about a tool it cannot call.
+# The per-call capability check stays, for mixed fleets where only some
+# executors hold a cloud identity.
+# --------------------------------------------------------------------------
+
+
+async def cloud_tools_enabled(redis_client) -> bool:
+    """Whether the cloud tools should be registered for this agent run.
+
+    Configured on *and* some registered executor advertises a cloud identity.
+    Evaluated at agent initialisation, which is late enough for the fleet's
+    capability reports to be present.
+    """
+    if not cloud_tools_configured():
+        logger.info("Cloud tools disabled via KUBENTLY_CLOUD_TOOLS=off")
+        return False
+    if redis_client is None:
+        return False
+    try:
+        from kubently.modules.capability import CapabilityModule
+
+        reports = await CapabilityModule(redis_client).list_all_capabilities()
+        return any(report.cloud for report in reports)
+    except Exception as e:
+        logger.warning(f"Cloud capability scan failed; cloud tools stay off: {e}")
+        return False
+
+
+# Injected into the system prompt (via the {{cloud_guidance}} variable) only
+# when the tools are registered.
+CLOUD_PROMPT_SECTION = """\
+## Cloud Telemetry
+
+Some clusters' executors hold a read-only cloud identity (AWS or GCP). For those clusters you can use query_cloud_logs, query_cloud_metrics, and get_recent_cloud_changes. The tools tell you when a cluster has no cloud access — do not retry them there; continue with kubectl.
+
+Prefer CLOUD evidence over cluster evidence when the cause likely lives outside the cluster:
+- IAM/permission errors (AccessDenied, 403 from cloud APIs, image pull auth failures against ECR/GCR/AR): check cloud logs and recent IAM changes, not just pod logs.
+- Throttling/quota symptoms (RequestLimitExceeded, 429s, rate exceeded): cloud metrics and API logs show the source.
+- Managed-service failures (RDS/CloudSQL, load balancers, node pools): the service's cloud logs/metrics, not kubectl, hold the answer.
+- Control-plane issues (API server errors, webhook timeouts, authentication failures): EKS control-plane logs / GKE audit logs — kubectl cannot see the control plane's own logs.
+- "It broke suddenly and nothing changed in-cluster": get_recent_cloud_changes correlates CloudTrail/GKE audit events (IAM edits, security-group changes, node-pool operations) with the incident window.
+
+Prefer CLUSTER evidence (kubectl) for anything about workload state: pod status, events, container logs of live pods, manifests, scheduling. Start with kubectl; reach for cloud tools when in-cluster evidence dead-ends or points outward.
+"""
+
+
+def cloud_guidance(enabled: bool) -> str:
+    """The prompt section to inject — empty when the tools are not registered."""
+    return CLOUD_PROMPT_SECTION if enabled else ""
+
+
+# --------------------------------------------------------------------------
 # Tool construction
 # --------------------------------------------------------------------------
 
@@ -172,12 +235,12 @@ def build_cloud_tools(
     """
     Build the three provider-agnostic cloud tools.
 
-    Returns [] when disabled via KUBENTLY_CLOUD_TOOLS=off. Tools are
-    registered whenever enabled, but each checks — per target cluster, per
-    call — that the executor actually reports a cloud identity, because
+    Call only when cloud_tools_enabled() said so. Returns [] when disabled
+    via KUBENTLY_CLOUD_TOOLS=off. Each tool still checks — per target cluster,
+    per call — that the executor actually reports a cloud identity, because
     executors join/leave and identities get granted/revoked at runtime.
     """
-    if not cloud_tools_enabled():
+    if not cloud_tools_configured():
         logger.info("Cloud tools disabled via KUBENTLY_CLOUD_TOOLS=off")
         return []
 

--- a/kubently/modules/a2a/skills.py
+++ b/kubently/modules/a2a/skills.py
@@ -191,9 +191,11 @@ def _is_enabled(gate: str, has_redis: bool) -> bool:
 
         return prometheus_tool_enabled()
     if gate == "cloud":
-        from .protocol_bindings.a2a_server.cloud_tools import cloud_tools_enabled
+        from .protocol_bindings.a2a_server.cloud_tools import cloud_tools_configured
 
-        return cloud_tools_enabled()
+        # The configuration gate, not the fleet gate: the card is built when the
+        # A2A app is mounted, before any executor has reported a cloud identity.
+        return cloud_tools_configured()
     if gate == "gitops":
         from .protocol_bindings.a2a_server.gitops import gitops_tools_enabled
 

--- a/prompts/system.prompt.yaml
+++ b/prompts/system.prompt.yaml
@@ -23,6 +23,12 @@ variables:
   - name: gitops_guidance
     required: false
     default: ""
+  # Injected by the agent ONLY when some registered executor advertises a
+  # cloud identity; defaults to empty so deployments with no cloud telemetry
+  # never reference cloud tools the model cannot call.
+  - name: cloud_guidance
+    required: false
+    default: ""
   # Injected by the agent ONLY when external MCP servers are configured
   # (KUBENTLY_MCP_SERVERS / KUBENTLY_MCP_SERVERS_FILE set); defaults to empty
   # so unconfigured deployments never reference external tools.
@@ -416,19 +422,6 @@ content: |-
   - Keep fleet commands filtered and token-efficient (e.g. `-o wide`, `-o custom-columns`, `-l <selector>`); never dump unfiltered resources from every cluster. Do NOT use `--field-selector status.phase!=Running` for fleet health sweeps — CrashLoopBackOff pods have `phase=Running`, so a whole cluster can look healthy while pods crash on a loop.
   - For single-cluster questions keep using execute_kubectl.
 
-  ## Cloud Telemetry
-
-  Some clusters' executors hold a read-only cloud identity (AWS or GCP). For those clusters you can use query_cloud_logs, query_cloud_metrics, and get_recent_cloud_changes. The tools tell you when a cluster has no cloud access — do not retry them there; continue with kubectl.
-
-  Prefer CLOUD evidence over cluster evidence when the cause likely lives outside the cluster:
-  - IAM/permission errors (AccessDenied, 403 from cloud APIs, image pull auth failures against ECR/GCR/AR): check cloud logs and recent IAM changes, not just pod logs.
-  - Throttling/quota symptoms (RequestLimitExceeded, 429s, rate exceeded): cloud metrics and API logs show the source.
-  - Managed-service failures (RDS/CloudSQL, load balancers, node pools): the service's cloud logs/metrics, not kubectl, hold the answer.
-  - Control-plane issues (API server errors, webhook timeouts, authentication failures): EKS control-plane logs / GKE audit logs — kubectl cannot see the control plane's own logs.
-  - "It broke suddenly and nothing changed in-cluster": get_recent_cloud_changes correlates CloudTrail/GKE audit events (IAM edits, security-group changes, node-pool operations) with the incident window.
-
-  Prefer CLUSTER evidence (kubectl) for anything about workload state: pod status, events, container logs of live pods, manifests, scheduling. Start with kubectl; reach for cloud tools when in-cluster evidence dead-ends or points outward.
-
   ## Log Search
 
   Use search_pod_logs to grep across MANY pods/containers in one call instead of dumping full logs pod-by-pod. Reach for it when:
@@ -451,6 +444,8 @@ content: |-
   {{gitops_guidance}}
 
   {{mcp_guidance}}
+
+  {{cloud_guidance}}
 
   # Code References
 

--- a/tests/test_a2a_sdk_contract.py
+++ b/tests/test_a2a_sdk_contract.py
@@ -298,7 +298,7 @@ class TestAgentCardContract:
         """
         from kubently.modules.a2a import A2AModule
         from kubently.modules.a2a.protocol_bindings.a2a_server.cloud_tools import (
-            cloud_tools_enabled,
+            cloud_tools_configured,
         )
         from kubently.modules.a2a.protocol_bindings.a2a_server.gitops import gitops_tools_enabled
         from kubently.modules.a2a.protocol_bindings.a2a_server.logsearch import loki_tool_enabled
@@ -320,7 +320,7 @@ class TestAgentCardContract:
         # Optional toolsets appear exactly when their tools would register.
         assert ("prometheus-metrics" in ids) is prometheus_tool_enabled()
         assert ("loki-log-search" in ids) is loki_tool_enabled()
-        assert ("cloud-telemetry" in ids) is cloud_tools_enabled()
+        assert ("cloud-telemetry" in ids) is cloud_tools_configured()
         assert ("gitops-remediation" in ids) is gitops_tools_enabled()
         assert ("external-mcp-tools" in ids) is mcp_client_enabled()
         assert "incident-history" not in ids

--- a/tests/test_cloud_tools.py
+++ b/tests/test_cloud_tools.py
@@ -115,6 +115,81 @@ class TestCloudToolsRegistration:
         ]
 
 
+class TestCloudToolsGate:
+    """Registration gate (issue #90): cloud tools are offered to the model only
+    when some registered executor advertises a cloud identity, the same rule
+    LOKI_URL / PROMETHEUS_URL apply to their toolsets."""
+
+    @pytest.fixture
+    def redis(self):
+        fakeredis = pytest.importorskip("fakeredis")
+        return fakeredis.FakeAsyncRedis(decode_responses=True)
+
+    async def _report(self, redis, cluster_id, cloud):
+        from kubently.modules.capability import CapabilityModule
+
+        await CapabilityModule(redis).store_capabilities(
+            ExecutorCapabilities(
+                cluster_id=cluster_id, mode="readOnly", allowed_verbs=["get"], cloud=cloud
+            )
+        )
+
+    async def test_off_when_no_executor_reports_cloud(self, redis, monkeypatch):
+        monkeypatch.delenv("KUBENTLY_CLOUD_TOOLS", raising=False)
+        from kubently.modules.a2a.protocol_bindings.a2a_server.cloud_tools import (
+            cloud_guidance,
+            cloud_tools_enabled,
+        )
+
+        await self._report(redis, "kind", None)
+        enabled = await cloud_tools_enabled(redis)
+        assert enabled is False
+        assert cloud_guidance(enabled) == ""
+
+    async def test_on_when_an_executor_reports_cloud(self, redis, monkeypatch):
+        monkeypatch.delenv("KUBENTLY_CLOUD_TOOLS", raising=False)
+        from kubently.modules.a2a.protocol_bindings.a2a_server.cloud_tools import (
+            cloud_guidance,
+            cloud_tools_enabled,
+        )
+
+        await self._report(redis, "kind", None)
+        await self._report(redis, "eks-prod", {"provider": "aws", "identity": "arn:..."})
+        enabled = await cloud_tools_enabled(redis)
+        assert enabled is True
+        assert "query_cloud_metrics" in cloud_guidance(enabled)
+
+    async def test_env_override_still_wins(self, redis, monkeypatch):
+        monkeypatch.setenv("KUBENTLY_CLOUD_TOOLS", "off")
+        from kubently.modules.a2a.protocol_bindings.a2a_server.cloud_tools import (
+            cloud_tools_enabled,
+        )
+
+        await self._report(redis, "eks-prod", {"provider": "aws"})
+        assert await cloud_tools_enabled(redis) is False
+
+    def test_prompt_does_not_hardcode_cloud_guidance(self):
+        """Guidance must arrive through {{cloud_guidance}}, so it disappears
+        with the tools instead of describing tools that are not registered."""
+        repo = os.path.join(os.path.dirname(__file__), "..")
+        for path in (
+            os.path.join(repo, "prompts", "system.prompt.yaml"),
+            os.path.join(repo, "deployment", "helm", "kubently", "prompts", "system.prompt.yaml"),
+        ):
+            with open(path, encoding="utf-8") as f:
+                content = f.read()
+            assert "query_cloud_metrics" not in content, path
+            assert "{{cloud_guidance}}" in content, path
+
+    async def test_off_without_redis(self, monkeypatch):
+        monkeypatch.delenv("KUBENTLY_CLOUD_TOOLS", raising=False)
+        from kubently.modules.a2a.protocol_bindings.a2a_server.cloud_tools import (
+            cloud_tools_enabled,
+        )
+
+        assert await cloud_tools_enabled(None) is False
+
+
 class TestCapabilityCloudPassthrough:
     def test_round_trip_preserves_cloud_section(self):
         cloud = {

--- a/tests/test_cluster_registry.py
+++ b/tests/test_cluster_registry.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""The cluster registry is executor-owned (issue #89).
+
+Session creation used to write `cluster:active:*` / `cluster:session:*`, and
+`/debug/clusters` scanned those keys — so POSTing /debug/session with any
+string put a phantom cluster into the fleet the agent sees via list_clusters.
+Only an executor registration (`executor:token:*`) may define a cluster.
+"""
+
+import os
+import sys
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+fakeredis = pytest.importorskip("fakeredis")
+
+import kubently.main as main
+from kubently.modules.api.models import CreateSessionRequest
+from kubently.modules.session.session import SessionModule
+
+AUTH = (True, "test-service")
+REGISTERED = "prod-1"
+PHANTOM = "totally-fake-cluster-xyz"
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """main.py wired to a fake Redis holding one registered executor."""
+    redis = fakeredis.FakeAsyncRedis(decode_responses=True)
+    monkeypatch.setattr(main, "redis_client", redis)
+    monkeypatch.setattr(main, "session_module", SessionModule(redis, default_ttl=300))
+    return redis
+
+
+async def _create_session(cluster_id):
+    return await main.create_session(
+        CreateSessionRequest(cluster_id=cluster_id),
+        auth_info=AUTH,
+        x_correlation_id=None,
+        x_service_identity=None,
+    )
+
+
+async def _clusters():
+    return (await main.list_clusters(auth_info=AUTH))["clusters"]
+
+
+async def test_executor_registration_flow_still_works(wired):
+    """The legitimate path: executor registered -> session -> listed."""
+    await wired.set(f"executor:token:{REGISTERED}", "tok")
+
+    session = await _create_session(REGISTERED)
+    assert session.cluster_id == REGISTERED
+
+    assert await _clusters() == [REGISTERED]
+
+
+async def test_session_for_unregistered_cluster_is_rejected(wired):
+    await wired.set(f"executor:token:{REGISTERED}", "tok")
+
+    with pytest.raises(HTTPException) as exc:
+        await _create_session(PHANTOM)
+    assert exc.value.status_code == 404
+    assert REGISTERED in exc.value.detail  # same shape as /debug/execute's 404
+
+
+async def test_session_creation_cannot_inject_a_cluster(wired):
+    """The boundary: a session must never add an id to /debug/clusters."""
+    await wired.set(f"executor:token:{REGISTERED}", "tok")
+
+    with pytest.raises(HTTPException):
+        await _create_session(PHANTOM)
+
+    clusters = await _clusters()
+    assert PHANTOM not in clusters
+    assert clusters == [REGISTERED]
+
+
+async def test_listing_ignores_session_written_keys(wired):
+    """Belt and braces: even pre-existing session keys (written before this
+    fix, or by any future session writer) are not part of the registry."""
+    await wired.set(f"executor:token:{REGISTERED}", "tok")
+    await wired.setex("cluster:session:namespace", 300, "some-session-uuid")
+    await wired.setex("cluster:active:namespace", 300, "some-session-uuid")
+
+    assert await _clusters() == [REGISTERED]
+
+
+async def test_no_executors_means_no_clusters(wired):
+    assert await _clusters() == []


### PR DESCRIPTION
Closes #89
Closes #90

## #89 — the cluster registry was writable by session creation

Root cause, confirmed in the code: three endpoints disagreed about what a
registered cluster is.

- `POST /debug/session` (`main.py`) created a session for **any** `cluster_id`,
  with no validation, while `/debug/execute` validates against
  `executor:token:*` and 404s.
- `SessionModule.create_session` writes `cluster:active:{id}` and
  `cluster:session:{id}`.
- `GET /debug/clusters` unioned `cluster:active:*`, `cluster:session:*` **and**
  `executor:token:*` — so a session was enough to inject an arbitrary name into
  the fleet the agent reads via `list_clusters`.

The trust boundary: an executor registration (`executor:token:{id}`, written by
`POST /admin/agents/{id}/token` or the Helm bootstrap init container) is the
only thing that may define a cluster. A session *targets* a cluster; it must
never create one.

Fix:
- `create_session` calls a new `require_registered_cluster()` — the same
  `executor:token:*` check and the same 404 shape `/debug/execute` returns.
- `list_clusters` derives from `executor:token:*` only. That set is a superset
  of the legitimate `cluster:active:*` entries (the SSE connect path only runs
  after executor auth against the token), so no real cluster disappears.
- Secondary item from the issue: a missing `X-API-Key` now answers `401` with
  `WWW-Authenticate` instead of the `422` that leaked the parameter name.

Registration flow is unchanged: admin/Helm writes the token, the executor
connects over SSE, the cluster is listed, sessions and commands work.

## #90 — cloud tools registered with no cloud identity anywhere

`build_cloud_tools()` was called unconditionally, gated only per call on the
target executor's advertised `cloud` capability. Every other optional toolset
follows the opposite rule (`loki_tool_enabled()` / `prometheus_tool_enabled()` /
`gitops_tools_enabled()`: no config, no registration, and the matching prompt
section omitted), so a default deployment offered the model three tools that
could only fail, plus prompt guidance for them.

Fix follows that existing pattern rather than a new mechanism:
- New `cloud_tools_enabled(redis_client)` — true when any registered executor's
  capability report carries a `cloud` section (`KUBENTLY_CLOUD_TOOLS=off` still
  forces false). Cloud telemetry has no URL to key off, so the fleet's
  capability reports are the equivalent signal.
- New `cloud_guidance(enabled)` + `CLOUD_PROMPT_SECTION`, injected through a new
  `{{cloud_guidance}}` prompt variable — the "## Cloud Telemetry" block moved
  out of `system.prompt.yaml` (both copies, root and chart) so it appears only
  when the tools do.
- The per-call capability check is untouched, for mixed fleets where only some
  executors hold an identity.

## Checks

`tests/test_cluster_registry.py` (new) drives the real `main.py` handlers
against fakeredis. The boundary assertion is
`test_session_creation_cannot_inject_a_cluster`: a session against an
unregistered id must 404 **and** that id must not appear in `/debug/clusters`.
Reverting `main.py` to `main` fails 3 of its 5 tests; with the fix all 5 pass.

`tests/test_cloud_tools.py::TestCloudToolsGate` covers the #90 gate: off with no
cloud-capable executor (and guidance empty), on when one reports a cloud
identity (and guidance carries the tool names), env override still wins, no
Redis means off, plus a guard that the shipped prompts no longer hardcode the
cloud section.

Full unit suite: 696 passed, 1 pre-existing failure
(`test_change_runners.py::test_enabled_but_no_binary`, fails on `main` too —
it asserts helm is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Rebase onto `main` @ b8bc44e (#82, #91, #92, #95, #96, #101)

Two conflicts, plus one semantic clash the textual merge did **not** flag:

**`CHANGELOG.md`** — additive, both sides kept (30 insertions, 0 deletions against `main`).

**`cloud_tools.py` / the #90 gate vs. the #92 agent card.** #92 landed a sync
`cloud_tools_enabled()` and made the agent card's `cloud-telemetry` skill derive
from it, so the card advertises exactly the toolsets that register. This branch
turns `cloud_tools_enabled` into `async cloud_tools_enabled(redis_client)`.
Auto-merge silently produced a module with *two* definitions of that name, the
second shadowing the first — `skills.py` and `test_a2a_sdk_contract.py` would
have called the async one with no argument and got a truthy coroutine.

Resolved by naming the two halves rather than picking a winner:

- `cloud_tools_configured()` — sync, `KUBENTLY_CLOUD_TOOLS != off`. What the
  **agent card** asks. The card is built when the A2A app is mounted, before any
  executor has connected, so the fleet cannot be consulted there; asking it would
  advertise "no cloud" on every deployment.
- `cloud_tools_enabled(redis_client)` — async, configured **and** some registered
  executor reports a cloud identity. What **tool registration and the prompt**
  ask, at agent init, when capability reports exist. Unchanged from this branch.

`skills.py` and `test_a2a_sdk_contract.py` now call the first; #92's invariant
(card gate == registration gate) holds at the level the card can actually evaluate.

**Chart bump for #101.** This branch edits
`deployment/helm/kubently/prompts/system.prompt.yaml`, so the new `chart-version`
job requires a bump: chart `1.1.0` -> `1.1.1` (`kubently-1.1.1` unreleased;
`scripts/check-chart-version.sh origin/main` passes).

## Evidence on the rebased head

Full suite **761 passed, 2 skipped, 0 failed**. The pre-existing
`test_change_runners.py::test_enabled_but_no_binary` failure noted above is gone —
fixed on `main` in the interim.

#89 boundary, `main.py` reverted to `origin/main` with the new tests unchanged:

```
3 failed, 2 passed
  FAILED test_session_for_unregistered_cluster_is_rejected
  FAILED test_session_creation_cannot_inject_a_cluster
  FAILED test_listing_ignores_session_written_keys
```

and the injection itself, one registered executor (`prod-1`) in Redis:

```
                       WITHOUT FIX                          WITH FIX
registry before      : ['prod-1']                           ['prod-1']
POST /debug/session  : 201 CREATED -> 'totally-fake-...'    404 Cluster '...' not found.
registry after       : ['prod-1', 'totally-fake-...']       ['prod-1']
PHANTOM INJECTED?    : YES  <-- issue #89                   NO   <-- boundary held
```

With the fix: 5 passed.

## `kubently-cloud` compatibility (read-only audit)

Does not break the control plane. It is not an HTTP consumer of these endpoints —
it wraps the OSS app in-process (`control-plane/cloud/app.py`) over shared Redis and
**writes `executor:token:{cluster_id}` itself** (`control-plane/cloud/tenants.py:235`),
so every cluster it knows is one the new validation accepts.
`require_registered_cluster` does a bare `exists("executor:token:{id}")` — no value
or format assumption, exactly what the cloud writes. Nothing there POSTs
`/debug/session` outside one e2e test whose cluster is seeded through the real sync
loop; nothing references `cluster:active` / `cluster:session` at all; its
`TenantScope._filtered_clusters` only *intersects* the upstream list; and its OSS
stub already models both the executor-token-only fleet and the 401-on-missing-key
behaviour this branch introduces.
