### PR TITLE
fix: unblock Helm chart publishing (chart 1.1.0) and fail PRs that skip the version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,27 @@ jobs:
       # or a broken guard fails here.
       - name: Render Helm chart
         run: make helm-template
+
+  chart-version:
+    name: Helm chart version bumped
+    runs-on: ubuntu-latest
+    # PR-only: on main the chart is already merged and the release job is the
+    # one that has to succeed.
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history + tags: the check diffs against the base branch and
+          # asks whether the new version was already released.
+          fetch-depth: 0
+
+      # A chart change without a version bump makes chart-releaser fail on main
+      # with `tag_name already_exists`, which blocks nothing and publishes
+      # nothing -- three days of chart fixes went unshipped that way (#100).
+      # Catch it here, on the PR, where it is one line to fix.
+      - name: Chart version bumped
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/check-chart-version.sh "origin/$BASE_REF"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [Unreleased] - 2026-08-19
+
+### Fixed
+- **Helm chart had not published since 2026-08-16 (#100).** `Release Helm Chart`
+  failed on nine consecutive pushes to `main`, always the same way: chart-releaser
+  creates a GitHub release tagged `kubently-<Chart.yaml version>`, and
+  `deployment/helm/kubently/Chart.yaml` was still pinned at `version: 1.0.5` —
+  the tag released on 2026-08-16 — so every run died with
+  `tag_name: already_exists`. Because a release workflow does not gate merges and
+  never shows on a PR, this was invisible for three days while the dashboard's
+  generated install command kept serving 1.0.5, including to users hitting the
+  `executor.existingSecret` API-startup bug (#85) whose fix (#95) was merged but
+  unpublishable. The chart version is now `1.1.0`: `version` is the chart's own
+  packaging version and has been bumped once per chart-touching change since
+  1.0.0, while `appVersion` tracks the application and is unrelated (images are
+  pinned by `image.tag`, not by `appVersion`), so only `version` moves here. It
+  is a minor rather than a patch bump because the chart has gained templates and
+  values keys since 1.0.5 — scheduled-check CronJobs, runbook ingestion, the
+  Prometheus / log-search / cloud-telemetry / MCP-client / GitOps toolsets —
+  not just fixes.
+- **A chart change without a version bump now fails its own PR.** New
+  `scripts/check-chart-version.sh`, wired into `ci.yml` as the `chart-version`
+  job on pull requests: if the PR touches `deployment/helm/kubently/**` it must
+  also raise `version:` in `Chart.yaml`, to a version no `kubently-*` tag has
+  already claimed. The failure message names the old and new versions and says
+  what to do. Deliberately *not* fixed with `cr --skip-existing`, which would
+  make the release job green while publishing nothing — the same defect class as
+  #98 and #83. The release job keeps failing loudly if a stale version ever
+  reaches `main`.
+
 ## [Unreleased] - 2026-08-18
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,14 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 3. If you've changed APIs, update the documentation
 4. Ensure the test suite passes
 5. Make sure your code follows the existing code style
-6. Issue that pull request!
+6. If you change anything under `deployment/helm/kubently/`, bump `version:` in
+   `deployment/helm/kubently/Chart.yaml`. The chart is published by
+   chart-releaser on every merge to `main`, and it releases a tag named after
+   that version — reuse one and the release fails and nothing is published. CI
+   checks this on the PR (`scripts/check-chart-version.sh`, runnable locally).
+   `appVersion` tracks the application, not the chart; leave it alone unless the
+   application version actually changed.
+7. Issue that pull request!
 
 ## Development Setup
 

--- a/deployment/helm/kubently/Chart.yaml
+++ b/deployment/helm/kubently/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubently
 description: Kubently - Troubleshooting Kubernetes Agentically
 type: application
-version: 1.0.5
+version: 1.1.0
 appVersion: "1.0.0"
 home: https://github.com/kubently/kubently
 maintainers:

--- a/scripts/check-chart-version.sh
+++ b/scripts/check-chart-version.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Fail if the Helm chart changed without a bump to `version:` in Chart.yaml.
+#
+# Why this exists: `Release Helm Chart` runs chart-releaser on every push to
+# main that touches deployment/helm/kubently/**. chart-releaser creates a
+# GitHub release tagged `kubently-<version>`, so an unchanged version makes it
+# die with `tag_name already_exists` -- a failure that shows up only on main,
+# blocks nothing, and leaves every chart fix unpublished (issue #100).
+#
+# Usage: scripts/check-chart-version.sh [base-ref]   (default: origin/main)
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+CHART_DIR="deployment/helm/kubently"
+CHART_FILE="${CHART_DIR}/Chart.yaml"
+TAG_PREFIX="kubently-"
+
+chart_version_at() {
+  # $1: git ref, or "-" for the working tree
+  if [ "$1" = "-" ]; then cat "$CHART_FILE"; else git show "$1:$CHART_FILE"; fi |
+    awk '$1 == "version:" { print $2; exit }'
+}
+
+if git diff --quiet "$BASE_REF" -- "$CHART_DIR"; then
+  echo "No changes under ${CHART_DIR}/ against ${BASE_REF} -- nothing to check."
+  exit 0
+fi
+
+new="$(chart_version_at -)"
+old="$(chart_version_at "$BASE_REF")"
+
+echo "Chart changed against ${BASE_REF}:"
+git diff --name-only "$BASE_REF" -- "$CHART_DIR" | sed 's/^/  /'
+echo "Chart version: ${old} (${BASE_REF}) -> ${new} (this branch)"
+
+fail() {
+  echo
+  echo "FAIL: $*"
+  echo
+  echo "This branch changes the Helm chart, so it must also bump 'version:' in"
+  echo "${CHART_FILE}. Without a bump the release job on main dies with"
+  echo "'tag_name already_exists' and the chart is never published (issue #100)."
+  echo "Pick the next unused version above ${old} and add a CHANGELOG entry."
+  exit 1
+}
+
+[ -n "$new" ] || fail "could not read 'version:' from ${CHART_FILE}."
+[ -n "$old" ] || fail "could not read 'version:' from ${CHART_FILE} at ${BASE_REF}."
+
+[ "$new" != "$old" ] || fail "chart version is still ${new}."
+
+# Reject a downgrade or a sideways edit: the new version must sort above the old.
+[ "$(printf '%s\n%s\n' "$old" "$new" | sort -V | tail -1)" = "$new" ] ||
+  fail "chart version ${new} is not greater than ${old}."
+
+# Reject a version chart-releaser has already released.
+if git rev-parse -q --verify "refs/tags/${TAG_PREFIX}${new}" >/dev/null; then
+  fail "${TAG_PREFIX}${new} is already a released tag."
+fi
+
+echo "OK: chart version bumped ${old} -> ${new}, and ${TAG_PREFIX}${new} is unreleased."


### PR DESCRIPTION
Closes #100

## What was broken

`Release Helm Chart` has failed on **nine consecutive pushes to `main`** since 2026-08-16. chart-releaser creates a GitHub release tagged `kubently-<Chart.yaml version>`, and `deployment/helm/kubently/Chart.yaml` was still pinned at `version: 1.0.5` — the tag released on 2026-08-16 — so every run died with:

```
Error: error creating GitHub release kubently-1.0.5:
POST .../releases: 422 Validation Failed
[{Resource:Release Field:tag_name Code:already_exists Message:}]
```

The dashboard's generated install command installs *from the chart repo*, so three days of chart changes never reached a user — including #95, the fix for #85 where `executor.existingSecret` was ignored by the API init container and blocked API pod startup.

## `version` vs `appVersion`

Checked the chart's history rather than guessing:

- `version` has moved once per chart-touching change since the initial commit: `1.0.0 → 1.0.1 → 1.0.2 → 1.0.3 → 1.0.4 → 1.0.5`, each in the commit that changed the chart. It is the chart's own packaging version and it is what chart-releaser tags.
- `appVersion` has been `"1.0.0"` since the initial commit and has never moved. It is not referenced by any template (`grep -rn appVersion` finds only `Chart.yaml` and two docs), and images are pinned by `image.tag` (`latest`) in `values.yaml`, so nothing installs differently because of it. `docs/DEVELOPMENT.md` treats it as the *application* release version, bumped as part of a tagged app release — a separate cadence.

So: **bump `version` only, leave `appVersion` at `"1.0.0"`.** Touching `appVersion` here would claim an application release that did not happen.

**1.0.5 → 1.1.0**, minor rather than patch: since 1.0.5 the chart has gained templates and values keys (scheduled-check CronJobs, runbook ingestion, and the Prometheus / log-search / cloud-telemetry / MCP-client / GitOps toolsets), which is added functionality, not a fix roll-up.

## Stopping the recurrence

The CI-check option from the issue, not `--skip-existing`.

`scripts/check-chart-version.sh` fails when a branch changes `deployment/helm/kubently/**` without raising `version:` in `Chart.yaml`. It rejects three things: an unchanged version, a version that does not sort above the base branch's, and a version some `kubently-*` tag has already released. It runs as the `chart-version` job in `ci.yml` on pull requests (`fetch-depth: 0` for tags; base ref passed through `env`, not interpolated into `run:`), and locally with no arguments.

`cr --skip-existing` is deliberately **not** used, even as a belt-and-braces addition: it would turn the loud failure into a silent no-publish, which is the defect class of #98 and #83. With this check on the PR, the release job failing on `main` stays a real signal.

`CONTRIBUTING.md` gained the rule next to the other PR requirements.

## Verification

The check was run against real commits, failing first, then passing.

**FAILING** — commit touching `templates/api-deployment.yaml` with `version` left at 1.0.5:

```
$ git log --oneline -1
2561a4b demo: change a chart template without bumping the version
$ scripts/check-chart-version.sh
Chart changed against origin/main:
  deployment/helm/kubently/templates/api-deployment.yaml
Chart version: 1.0.5 (origin/main) -> 1.0.5 (this branch)

FAIL: chart version is still 1.0.5.

This branch changes the Helm chart, so it must also bump 'version:' in
deployment/helm/kubently/Chart.yaml. Without a bump the release job on main dies with
'tag_name already_exists' and the chart is never published (issue #100).
Pick the next unused version above 1.0.5 and add a CHANGELOG entry.
EXIT CODE: 1
```

**FAILING** — same commit with `version: 1.0.4`, i.e. a sideways edit to an already-released version:

```
Chart version: 1.0.5 (origin/main) -> 1.0.4 (this branch)

FAIL: chart version 1.0.4 is not greater than 1.0.5.
EXIT CODE: 1
```

**PASSING** — same template change, version bumped:

```
$ git log --oneline -1
62d6976 demo: bump the chart version
$ scripts/check-chart-version.sh
Chart changed against origin/main:
  deployment/helm/kubently/Chart.yaml
  deployment/helm/kubently/templates/api-deployment.yaml
Chart version: 1.0.5 (origin/main) -> 1.1.0 (this branch)
OK: chart version bumped 1.0.5 -> 1.1.0, and kubently-1.1.0 is unreleased.
EXIT CODE: 0
```

**PASSING** — this PR itself, and the no-chart-change control:

```
$ scripts/check-chart-version.sh
Chart version: 1.0.5 (origin/main) -> 1.1.0 (this branch)
OK: chart version bumped 1.0.5 -> 1.1.0, and kubently-1.1.0 is unreleased.
EXIT CODE: 0

$ scripts/check-chart-version.sh HEAD     # empty chart diff
No changes under deployment/helm/kubently/ -- nothing to check.
EXIT CODE: 0
```

The demo commits were on a throwaway branch and are not part of this PR. `make helm-template` still renders.

## What this PR cannot prove

**Publication cannot be observed from a PR.** `release-chart.yml` triggers only on `push` to `main`, so nothing here exercises chart-releaser. After merge, please check:

1. `gh run list --workflow=release-chart.yml --limit 1` — the run for the merge commit should be **success**, ending the nine-failure streak.
2. `gh release view kubently-1.1.0` — a new release with `kubently-1.1.0.tgz` attached.
3. `helm repo add kubently https://kubently.github.io/kubently && helm repo update && helm search repo kubently/kubently` — should report **1.1.0**. This is the one that matters: it is what the dashboard's install command pulls.
4. Sanity-check that the #95 fix actually shipped: `helm show chart kubently/kubently | grep version`, and confirm the API init container honours `executor.existingSecret` in `helm template kubently/kubently --set executor.existingSecret=foo`.

If step 1 is green but step 3 still shows 1.0.5, the failure is in the gh-pages `index.yaml` publish rather than the release, which is a different bug from this one.


### The job as wired, in real CI

Run [32259311512](https://github.com/kubently/kubently/actions/runs/32259311512) on this PR — all five jobs green, including the new one:

```
Helm chart version bumped -> success
  BASE_REF: main
  Chart changed against origin/main:
    deployment/helm/kubently/Chart.yaml
  Chart version: 1.0.5 (origin/main) -> 1.1.0 (this branch)
  OK: chart version bumped 1.0.5 -> 1.1.0, and kubently-1.1.0 is unreleased.
```

To be precise about what that does and does not show: the *failing* cases above were run against real commits locally, on the same script the job invokes, not inside Actions — proving the failure inside Actions would take a second throwaway PR, since the job is `if: github.event_name == 'pull_request'`. The job's only step is `scripts/check-chart-version.sh`, so its non-zero exit fails the step under the runner's default `bash -e`.
