### PR TITLE
fix(a2a): never leave message/stream as a 200 with an empty body (refs #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -432,6 +432,28 @@
   enforce-only — setting it to anything but `true` raises at startup instead
   of silently pretending auth was disabled. Regression check:
   `tests/test_config_provider.py`
+- **A2A `message/stream` no longer answers 200 with an empty body when the
+  agent fails to start (#65).** `message/stream` is served as SSE, so the 200
+  and the `text/event-stream` headers are flushed *before*
+  `KubentlyAgentExecutor.execute()` runs. Everything up to the first
+  `enqueue_event()` — notably `initialize()`, which raises on an unconfigured
+  `LLM_PROVIDER` — was outside any handler, so the client got 200 with zero
+  bytes: no events, no error, nothing. `message/send` reported the identical
+  failure as a JSON-RPC error, which is why only streaming looked broken.
+  `execute()` now publishes the task first and runs the rest under a guard
+  that emits an error artifact plus a terminal `failed` status, so a stream is
+  never left empty. (A `message/send` startup failure now comes back as a task
+  carrying that artifact rather than a JSON-RPC error — the two transports
+  finally agree.)
+
+### Changed
+- **`kind-e2e.sh` streaming smoke now fails on an empty stream.** The check
+  grepped the response for error strings, which an empty response passes —
+  that is how "streaming returns nothing" stayed green. It now asserts a
+  non-empty body containing `data:` SSE frames, and sends
+  `Accept: text/event-stream`. New `tests/test_a2a_streaming.py` asserts the
+  same invariant at unit level against the real
+  `A2AStarletteApplication` + `KubentlyAgentExecutor`.
 
 ## [Unreleased] - 2026-08-16
 

--- a/deployment/scripts/kind-e2e.sh
+++ b/deployment/scripts/kind-e2e.sh
@@ -126,10 +126,18 @@ done
 [ "$ok" = 1 ] || { red "executor did NOT register — kubectl -n $NS logs deploy/kubently-executor"; fail=1; }
 
 step "Smoke: agent LLM round-trip (real tool call through executor)"
-resp=$(curl -s -m 90 -X POST http://localhost:8080/a2a/ \
-  -H "Content-Type: application/json" -H "X-API-Key: test-api-key" \
+resp=$(curl -s -N -m 90 -X POST http://localhost:8080/a2a/ \
+  -H "Content-Type: application/json" -H "Accept: text/event-stream" -H "X-API-Key: test-api-key" \
   -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"message/stream\",\"params\":{\"message\":{\"messageId\":\"smoke\",\"role\":\"user\",\"parts\":[{\"partId\":\"p1\",\"text\":\"In cluster $CLUSTER_ID, list pods in kube-system and report what you see.\"}]}}}")
-if printf '%s' "$resp" | grep -qiE "not_found_error|error code: 4|encountered an error"; then
+# #65: message/stream is SSE, so the 200 + text/event-stream headers are flushed
+# before the agent runs. A failure inside the executor then arrives as a 200 with
+# a ZERO-LENGTH body. This check used to grep $resp for error strings, which an
+# empty response passes — that is how "streaming returns nothing" stayed green.
+if [ -z "$resp" ]; then
+  red "message/stream returned an EMPTY body (200, 0 bytes) — see #65. kubectl -n $NS logs deploy/kubently-api"; fail=1
+elif ! printf '%s' "$resp" | grep -q '^data:'; then
+  red "message/stream returned no SSE data frames. Response:"; printf '%s\n' "$resp" | head -3; fail=1
+elif printf '%s' "$resp" | grep -qiE "not_found_error|error code: 4|encountered an error"; then
   red "agent round-trip FAILED — likely bad ANTHROPIC_MODEL_NAME. Response:"; printf '%s\n' "$resp" | grep -o '"text":"[^"]*"' | head -3; fail=1
 else
   grn "agent round-trip OK"

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
@@ -48,15 +48,77 @@ class KubentlyAgentExecutor(AgentExecutor):
         context: RequestContext,
         event_queue: EventQueue,
     ) -> None:
-        print("=== EXECUTE CALLED ===")  # Debug print to confirm execution
+        """Run the agent, guaranteeing the event stream is never left empty.
+
+        `message/stream` is served as SSE: the 200 and the `text/event-stream`
+        headers are flushed before this coroutine runs. Anything that raised in
+        here *before* the first `enqueue_event()` therefore reached the client
+        as a 200 with a zero-length body — no events, no error, nothing (#65).
+        `message/send` surfaced the very same failure as a JSON-RPC error,
+        which is why only the streaming path looked broken.
+
+        So: publish the task first, then run everything else under a guard that
+        turns any failure into a visible error artifact and a terminal status
+        event.
+        """
         logger.info("=== KubentlyAgentExecutor.execute() CALLED ===")
-        
+
+        if not context.message:
+            raise Exception("No message provided")
+
+        task = context.current_task
+        if not task:
+            task = new_task(context.message)
+            await event_queue.enqueue_event(task)
+
+        try:
+            await self._execute(context, event_queue, task)
+        except Exception as e:
+            logger.exception("A2A execute() failed before the task reached a terminal state")
+            await self._emit_failure(event_queue, task, e)
+
+    async def _emit_failure(self, event_queue: EventQueue, task, error: Exception) -> None:
+        """End a stream that failed outside the agent loop with a visible error."""
+        message = f"Kubently could not run this request: {error}"
+        try:
+            await event_queue.enqueue_event(
+                TaskArtifactUpdateEvent(
+                    append=False,
+                    contextId=task.contextId,
+                    taskId=task.id,
+                    lastChunk=True,
+                    artifact=new_text_artifact(
+                        name="debug_result",
+                        description="Kubernetes debugging analysis and findings",
+                        text=message,
+                    ),
+                )
+            )
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    status=TaskStatus(
+                        state=TaskState.failed,
+                        message=new_agent_text_message(message, task.contextId, task.id),
+                    ),
+                    final=True,
+                    contextId=task.contextId,
+                    taskId=task.id,
+                )
+            )
+        except Exception:
+            logger.exception("Failed to emit the terminal error event")
+
+    async def _execute(
+        self,
+        context: RequestContext,
+        event_queue: EventQueue,
+        task,
+    ) -> None:
         # Ensure agent is initialized in the correct event loop
         await self.initialize()
-        
+
         query = context.get_user_input()
-        task = context.current_task
-        
+
         # Use context_id from message like mas-agent-atlassian does
         contextId = context.message.context_id if context.message else None
 
@@ -80,13 +142,6 @@ class KubentlyAgentExecutor(AgentExecutor):
         from .agent import _namespaced_thread_id
 
         traceThreadId = _namespaced_thread_id(contextId)
-
-        if not context.message:
-            raise Exception("No message provided")
-
-        if not task:
-            task = new_task(context.message)
-            await event_queue.enqueue_event(task)
 
         # Let the agent handle all queries including cluster discovery
         # The agent's memory and prompt will maintain context properly

--- a/tests/test_a2a_streaming.py
+++ b/tests/test_a2a_streaming.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Regression guard for #65: `message/stream` must never answer 200 with an empty body.
+
+`message/stream` is served as SSE, so the 200 and the `text/event-stream` headers
+are flushed *before* the agent executor runs. Any exception raised before the
+first `enqueue_event()` therefore reaches the client as a 200 with a zero-length
+body — no events, no error, nothing. `message/send` surfaces the same failure as
+a JSON-RPC error, which is why only the streaming path looked broken.
+
+These tests drive the real `A2AStarletteApplication` + `KubentlyAgentExecutor`
+mounted the way `kubently/main.py` mounts them, and assert the stream always
+carries at least one `data:` frame and a terminal event.
+"""
+
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("a2a")
+pytest.importorskip("deepagents")  # agent_executor -> agent -> deepagents
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from a2a.server.apps import A2AStarletteApplication  # noqa: E402
+from a2a.server.request_handlers import DefaultRequestHandler  # noqa: E402
+from a2a.server.tasks import InMemoryTaskStore  # noqa: E402
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from kubently.modules.a2a.protocol_bindings.a2a_server.agent_executor import (  # noqa: E402
+    KubentlyAgentExecutor,
+)
+
+STREAM_REQUEST = {
+    "jsonrpc": "2.0",
+    "id": "s1",
+    "method": "message/stream",
+    "params": {
+        "message": {
+            "messageId": "m1",
+            "role": "user",
+            "parts": [{"partId": "p1", "text": "say hi"}],
+        }
+    },
+}
+
+
+def _client(executor):
+    card = AgentCard(
+        name="Kubently Kubernetes Debugger",
+        description="test card",
+        url="http://localhost:8080/a2a/",
+        version="1.0.0",
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
+        capabilities=AgentCapabilities(streaming=True, pushNotifications=False),
+        skills=[AgentSkill(id="k", name="k", description="d", tags=["k8s"])],
+    )
+    handler = DefaultRequestHandler(
+        agent_executor=executor, task_store=InMemoryTaskStore()
+    )
+    inner = A2AStarletteApplication(agent_card=card, http_handler=handler).build()
+    # Mounted under /a2a exactly like kubently/main.py does.
+    outer = FastAPI()
+    outer.mount("/a2a", inner)
+    # raise_server_exceptions=False so we see what the wire sees, not the traceback.
+    return TestClient(outer, raise_server_exceptions=False)
+
+
+def _post_stream(executor):
+    with _client(executor) as client:
+        return client.post(
+            "/a2a/",
+            headers={"Accept": "text/event-stream", "Content-Type": "application/json"},
+            json=STREAM_REQUEST,
+        )
+
+
+def _assert_usable_stream(response):
+    """The invariant #65 violated: a 200 must carry actual SSE events."""
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers.get("content-type", "")
+    assert len(response.content) > 0, "message/stream returned 200 with an EMPTY body (#65)"
+    assert "data:" in response.text, "no SSE data frames in the stream"
+
+
+def _failing_executor(exc: Exception) -> KubentlyAgentExecutor:
+    executor = KubentlyAgentExecutor(redis_client=None)
+
+    async def boom():
+        raise exc
+
+    executor.initialize = boom  # simulate e.g. an unconfigured/unreachable LLM
+    return executor
+
+
+def test_stream_is_not_empty_when_agent_startup_fails():
+    """The exact #65 signature: the executor blows up before enqueuing anything."""
+    response = _post_stream(
+        _failing_executor(ValueError("Unsupported LLM_PROVIDER ''"))
+    )
+    _assert_usable_stream(response)
+    assert "Unsupported LLM_PROVIDER" in response.text
+    assert '"final":true' in response.text, "stream never reached a terminal event"
+
+
+def test_stream_reports_the_failure_as_a_task_artifact():
+    """A failed run still produces an artifact, so CLI/dashboard clients show something."""
+    response = _post_stream(_failing_executor(RuntimeError("redis is down")))
+    _assert_usable_stream(response)
+    assert "redis is down" in response.text
+    assert "debug_result" in response.text


### PR DESCRIPTION
Refs #65. **Deliberately does not close it** — the root cause of the reported production symptom is in the private control plane, not here. See the verdict comment on #65.

## What this changes

`message/stream` is served as SSE, so the `200` and the `text/event-stream` headers are flushed **before** `KubentlyAgentExecutor.execute()` runs. Everything up to the first `enqueue_event()` — notably `initialize()`, which raises on an unconfigured `LLM_PROVIDER` — sat outside any handler. The client got a 200 with **zero bytes**: no events, no error, nothing.

`message/send` surfaced the identical failure as a JSON-RPC error, which is exactly why only the streaming path looked broken.

Reproduced against the real `A2AStarletteApplication` + `KubentlyAgentExecutor` on `main` (72d4212), no LLM configured:

```
REAL STREAM  status 200  ctype text/event-stream  len 0
REAL SEND    status 200  ctype application/json   len 161
             {"error":{"code":-32603,"message":"Unsupported LLM_PROVIDER ''..."}}
```

After:

```
REAL STREAM  status 200  ctype text/event-stream  len 1486   (task + error artifact + final failed)
```

`execute()` now publishes the task first, then runs the rest under a guard that emits an error artifact plus a terminal `failed` status.

Behaviour note: a startup failure on `message/send` now comes back as a task carrying that error artifact instead of a JSON-RPC error. The two transports finally agree, and it matches how the existing agent-loop `except` already reports failures.

## Guards

Nothing caught this while the agent card advertised `streaming=True`, so:

- **`tests/test_a2a_streaming.py`** — drives the real `A2AStarletteApplication` + `KubentlyAgentExecutor`, mounted under `/a2a` the way `main.py` mounts it, and fails if `message/stream` answers 200 with a zero-length body. Verified **red** on the parent commit, **green** here.
  ```
  E  AssertionError: message/stream returned 200 with an EMPTY body (#65)
  ```
- **`deployment/scripts/kind-e2e.sh`** — the streaming smoke grepped `$resp` for error strings, which an empty response passes. That is how "streaming returns nothing" stayed green through every e2e run. It now requires a non-empty body containing `data:` frames, and sends `Accept: text/event-stream`.

These gate merges: since #96 (issue #83), `.github/workflows/ci.yml` runs `python -m pytest tests/ -v` with no `|| true`, and installs `.[dev,test,a2a,cloud]` — so `a2a-sdk` and `deepagents` are present and `tests/test_a2a_streaming.py` actually executes rather than skipping.

## What this does *not* fix

The reported production symptom has a second, independent cause that lives outside this repo — an ASGI wrapper in front of `/a2a` whose request-body replay shim hands the app `http.disconnect` on the second `receive()`. `sse_starlette`'s disconnect listener sees it and tears the response down before a single event is written. Same signature (200, `text/event-stream`, 0 bytes, sub-second), same `send`-works/`stream`-empty asymmetry. Details in the #65 comment; the fix belongs in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
