### PR TITLE
Fail loudly: gate A2A on an explicit setting (#97); delete the release job that cannot fire (#98)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,22 +47,24 @@ jobs:
           kubently-cli/nodejs/*.tgz
           kubently-cli/nodejs/dist/
 
-  release:
-    needs: build-cli
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    
-    steps:
-    - uses: actions/checkout@v7
-    
-    - name: Download all artifacts
-      uses: actions/download-artifact@v8
-    
-    - name: Create Release
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          nodejs-dist/*
-        draft: false
-        prerelease: false
+# There is deliberately no `release` job here (issue #98).
+#
+# The one this workflow used to carry could not fire: the job was gated on
+# `github.ref == 'refs/heads/main'` while its only real step (Create Release)
+# was gated on `startsWith(github.ref, 'refs/tags/')`. A ref cannot be both, so
+# `softprops/action-gh-release` never ran once, on any event -- and the job
+# still reported green, because a job whose steps all skip succeeds.
+#
+# Releases are tag-driven and already have owners, which is what the release
+# history shows:
+#   - CLI (`cli-v*.*.*` tags) -> .github/workflows/publish-npm.yml publishes to
+#     npm and creates the GitHub release. Every `CLI cli-v*` release came from it.
+#   - Helm chart -> .github/workflows/release-chart.yml (chart-releaser), which
+#     creates the `kubently-<version>` releases and attaches the packaged chart.
+#   - Images (`v*.*.*` tags) -> .github/workflows/publish-docker.yml
+#
+# A second workflow creating a release for the same `cli-v*` tag would race
+# publish-npm.yml's `gh release create`, so this workflow stays a build: the
+# `npm pack` output is published as a workflow artifact above. If the CLI
+# tarball should also be a release asset, attach it in publish-npm.yml where the
+# release is actually created -- do not reintroduce a second release owner here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,37 @@
   `{{cloud_guidance}}` variable only when the cloud tools register (#90). A
   chart-content change, so it takes the patch bump the new `chart-version` job
   requires.
+- **A2A no longer degrades silently when its SDK cannot be imported** (#97).
+  `kubently/modules/a2a/__init__.py` decided whether A2A existed by whether the
+  `a2a-sdk` import happened to succeed, flattening any failure into
+  `A2A_AVAILABLE = False` and one INFO line, and `create_a2a_server()` returned
+  `None` for every cause — missing SDK, moved symbol, broken constructor — so an
+  incompatible SDK (a2a-sdk 1.x deletes `a2a.server.apps`) could take the entire
+  A2A protocol surface away with nothing louder than a log line. Availability is
+  now an explicit setting, `KUBENTLY_A2A` (default `on`), following the same
+  shape as the other optional toolsets (`KUBENTLY_CLOUD_TOOLS=off`): when A2A is
+  enabled and the SDK will not import, module import logs at ERROR *with the
+  traceback* and `create_a2a_server()` raises `A2AUnavailableError` chained onto
+  the original `ImportError`, so `kubently/main.py` fails startup with the real
+  cause instead of a generic "A2A server initialization failed". `None` now means
+  exactly one thing — `KUBENTLY_A2A=off` — and `main.py` treats a `None` server
+  as fatal in any other case. New tests in `tests/test_a2a_sdk_contract.py`
+  reload the module against a meta-path finder that rejects every `a2a` import
+  and assert it raises rather than degrades, so a future SDK bump cannot restore
+  the swallow.
+- **`build.yml`'s release job could never publish a release** (#98). The job was
+  gated on `github.ref == 'refs/heads/main'` while its only real step was gated
+  on `startsWith(github.ref, 'refs/tags/')` — mutually exclusive, so
+  `softprops/action-gh-release` never executed on any event, and the job still
+  reported success because a job whose steps all skip succeeds (`Create Release`
+  is `skipped` in every run of the job in the repo's history). Releases are
+  tag-driven and already have owners: `publish-npm.yml` creates every
+  `CLI cli-v*` release on a `cli-v*.*.*` tag, `release-chart.yml` (chart-releaser)
+  creates the `kubently-<version>` chart releases, `publish-docker.yml` handles
+  `v*.*.*` image tags. A second workflow creating a release for the same tag
+  would race `publish-npm.yml`'s `gh release create`, so the dead job is removed
+  rather than rewired, with a comment recording where releases actually come from
+  and where to attach the CLI tarball if it is ever wanted as a release asset.
 
 ### Changed
 - **The CI lint job can now fail the build** (#79). Both ruff steps were

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -78,10 +78,15 @@ bearer tokens alongside API keys — see `docs/AUTH_DISCOVERY.md` and
 
 ### A2A (Agent-to-Agent) Configuration
 
-**Note**: A2A is core functionality and is always enabled. It is mounted at `/a2a` on the main API port.
+**Note**: A2A is core functionality and is enabled by default. It is mounted at
+`/a2a` on the main API port. Availability is decided by `KUBENTLY_A2A`, never by
+whether the SDK happened to import: when A2A is enabled and `a2a-sdk` is missing
+or incompatible, the API refuses to start with the underlying `ImportError`
+rather than coming up with the protocol surface silently absent.
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
+| `KUBENTLY_A2A` | `on` | No | Set to `off` to run deliberately without the A2A protocol surface (`/a2a` is not mounted). Any other value keeps A2A enabled, and a failed SDK import is then a fatal startup error |
 | `A2A_EXTERNAL_URL` | - | No | External URL for A2A agent card (e.g., `https://api.example.com/a2a/`) |
 | `KUBENTLY_MAX_FLEET_CLUSTERS` | `10` | No | Max clusters per `execute_kubectl_multi` fan-out call (each cluster adds up to ~4KB to the agent context) |
 | `A2A_SERVER_DEBUG` | `false` | No | Enable A2A debug logging |
@@ -576,7 +581,7 @@ export SESSION_TTL=7200  # 2 hours
 ### Common Issues
 
 1. **Redis connection errors**: Check `REDIS_HOST` and `REDIS_PORT`
-2. **A2A not accessible**: A2A is always enabled. Ensure you're accessing it at the `/a2a` path on the main API port
+2. **A2A not accessible**: A2A is enabled unless `KUBENTLY_A2A=off`. Ensure you're accessing it at the `/a2a` path on the main API port. If the API refuses to start with `A2AUnavailableError`, the installed `a2a-sdk` is incompatible with the bindings — the chained `ImportError` names the symbol that moved
 3. **Authentication failures**: Verify `API_KEYS` is set on the API, and that the executor's `KUBENTLY_TOKEN` matches `executor:token:{CLUSTER_ID}` in Redis
 4. **Wrong A2A URL in agent card**: Set `A2A_EXTERNAL_URL` correctly
 5. **Agent fails with `Unsupported LLM_PROVIDER`**: `LLM_PROVIDER` is required and has no default — set it under `api.env`

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -29,7 +29,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from kubently.config.provider import ConfigProvider, EnvConfigProvider
 from kubently.logging_config import get_logging_config
-from kubently.modules.a2a import create_a2a_server
+from kubently.modules.a2a import a2a_enabled, create_a2a_server
 from kubently.modules.api import (
     ArgoCDQueryRequest,
     CommandResponse,
@@ -166,9 +166,18 @@ async def lifespan(app: FastAPI):
         authed_a2a = add_api_key_auth(a2a_app, AuthModule(redis_client), public_well_known=True)
         app.mount(mount_path, authed_a2a)
         logger.info(f"A2A server mounted at {mount_path} (API-key auth enforced at mount)")
+    elif a2a_enabled():
+        # Defensive: create_a2a_server() raises rather than returning None when
+        # A2A is expected, so reaching here means that contract was broken.
+        # Never continue — a running API with no /a2a/ is the failure mode #97
+        # is about.
+        logger.error("A2A is enabled but no server was created - this is a critical failure")
+        raise RuntimeError("A2A server initialization failed while A2A is enabled")
     else:
-        logger.error("Failed to initialize A2A server - this is a critical failure")
-        raise RuntimeError("A2A server initialization failed")
+        logger.warning(
+            "A2A is disabled via KUBENTLY_A2A=off - /a2a/ is not mounted and the agent "
+            "protocol surface is unavailable"
+        )
 
     # Mount MCP server (optional - only if the `mcp` SDK is installed).
     # Exposes Kubently's troubleshooting agent as a single natural-language MCP tool.

--- a/kubently/modules/a2a/__init__.py
+++ b/kubently/modules/a2a/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from threading import Thread
 from typing import TYPE_CHECKING
 
@@ -20,6 +21,37 @@ if TYPE_CHECKING:
     from fastapi import FastAPI
 
 logger = logging.getLogger(__name__)
+
+# Environment switch that decides whether this deployment expects A2A. Whether a
+# module imported is NOT that decision (issue #97).
+A2A_ENABLED_ENV = "KUBENTLY_A2A"
+
+_OFF_VALUES = {"off", "false", "0", "no"}
+
+
+class A2AUnavailableError(RuntimeError):
+    """A2A is expected but its SDK cannot be imported.
+
+    Raised instead of degrading, so an incompatible ``a2a-sdk`` cannot start the
+    API with the whole A2A protocol surface missing behind one log line.
+    """
+
+
+def a2a_enabled() -> bool:
+    """Whether this deployment expects the A2A protocol surface.
+
+    Gated on an explicit setting, the same shape as the other optional toolsets
+    (``KUBENTLY_CLOUD_TOOLS=off``), not on whether an import happened to
+    succeed. Defaults to on: ``kubently/main.py`` mounts A2A at ``/a2a/`` and
+    treats its absence as a startup failure, so "enabled" is the normal state
+    and opting out has to be deliberate.
+    """
+    return os.getenv(A2A_ENABLED_ENV, "on").strip().lower() not in _OFF_VALUES
+
+
+# The ImportError itself, kept rather than discarded: it is the only description
+# of *why* A2A is unavailable, and it is chained onto A2AUnavailableError below.
+A2A_IMPORT_ERROR: BaseException | None = None
 
 # Try to import only the lightweight A2A server primitives at module import time.
 # Heavy dependencies (LangChain, LLMs, etc.) will be imported lazily inside get_app().
@@ -31,9 +63,20 @@ try:
     from a2a.types import AgentCapabilities, AgentCard, AgentSkill, Task
 
     A2A_AVAILABLE = True
-except Exception as e:  # Broad catch to avoid breaking the main API on optional features
+except Exception as e:  # Broad catch: the log level and fatality are decided below.
     A2A_AVAILABLE = False
-    logger.info(f"A2A support disabled at import time: {e}")
+    A2A_IMPORT_ERROR = e
+    if a2a_enabled():
+        # Expected but broken: ERROR with the traceback, and create_a2a_server()
+        # will refuse to hand back a half-built API.
+        logger.error(
+            "A2A is enabled (%s is not 'off') but the a2a-sdk could not be imported: %s",
+            A2A_ENABLED_ENV,
+            e,
+            exc_info=True,
+        )
+    else:
+        logger.info("A2A is disabled via %s=off; SDK import skipped: %s", A2A_ENABLED_ENV, e)
 
 
 if A2A_AVAILABLE:
@@ -58,7 +101,9 @@ class A2AModule:
     ):
         """Initialize the A2A server."""
         if not A2A_AVAILABLE:
-            raise ImportError("A2A dependencies not installed")
+            raise A2AUnavailableError(
+                f"a2a-sdk is not importable: {A2A_IMPORT_ERROR!r}"
+            ) from A2A_IMPORT_ERROR
 
         self.host = host
         self.port = port
@@ -218,13 +263,31 @@ class A2AModule:
 def create_a2a_server(
     host: str = "0.0.0.0", port: int = 8000, external_url: str | None = None, redis_client=None
 ) -> A2AModule | None:
-    """Create A2A server if dependencies are available."""
-    if not A2A_AVAILABLE:
-        logger.warning("A2A dependencies not installed")
+    """Create the A2A server, or return None only when A2A is explicitly disabled.
+
+    Returning None used to mean "something went wrong somewhere" — a missing SDK,
+    a bad card, a broken constructor — all flattened into one log line, which is
+    how an incompatible ``a2a-sdk`` could bring the API up with no A2A at all
+    (issue #97). Now None means exactly one thing: ``KUBENTLY_A2A=off``.
+
+    Raises:
+        A2AUnavailableError: A2A is expected but the SDK is missing/incompatible.
+        Exception: anything the A2A module raises while building — propagated
+            with its traceback rather than swallowed.
+    """
+    if not a2a_enabled():
+        logger.warning(
+            "A2A is disabled via %s=off; the /a2a/ protocol surface will not be served",
+            A2A_ENABLED_ENV,
+        )
         return None
 
-    try:
-        return A2AModule(host, port, external_url, redis_client)
-    except Exception as e:
-        logger.error(f"Failed to create A2A server: {e}")
-        return None
+    if not A2A_AVAILABLE:
+        raise A2AUnavailableError(
+            f"A2A is enabled ({A2A_ENABLED_ENV} is not 'off') but the a2a-sdk could not be "
+            f"imported: {A2A_IMPORT_ERROR!r}. Install the 'a2a' extra "
+            f'(pip install -e ".[a2a]"), or set {A2A_ENABLED_ENV}=off to run deliberately '
+            f"without the A2A protocol surface."
+        ) from A2A_IMPORT_ERROR
+
+    return A2AModule(host, port, external_url, redis_client)

--- a/tests/test_a2a_sdk_contract.py
+++ b/tests/test_a2a_sdk_contract.py
@@ -9,15 +9,18 @@ existing check (``test_tool_trace_thread_match.py``) reads ``agent_executor.py``
 as *text* and regexes it, so it passes even when the module cannot be imported.
 That made an a2a-sdk version bump completely unguarded.
 
-Worse, ``kubently/modules/a2a/__init__.py`` wraps its SDK imports in a bare
-``except Exception`` that sets ``A2A_AVAILABLE = False``. An SDK release that
-moves or renames a symbol therefore does not crash the API — it silently starts
-Kubently with the entire A2A protocol surface missing. A dependency bump could
-ship that regression with every test still green.
+``kubently/modules/a2a/__init__.py`` used to wrap its SDK imports in a bare
+``except Exception`` that set ``A2A_AVAILABLE = False``: an SDK release that
+moved or renamed a symbol did not crash the API, it silently started Kubently
+with the entire A2A protocol surface missing (issue #97). A2A is now gated on
+``KUBENTLY_A2A`` and an unimportable SDK raises ``A2AUnavailableError``; the
+tests at the bottom of this file are what keep that from regressing.
 
 Contracts under guard:
 - Every module path and symbol the codebase imports from ``a2a`` still resolves.
 - ``A2A_AVAILABLE`` is True, i.e. the SDK did not silently disable A2A.
+- An unimportable SDK is fatal when A2A is enabled, and returns None *only* when
+  it was explicitly switched off.
 - The helper functions produce real SDK event objects with the fields the
   protocol requires.
 - ``KubentlyAgentExecutor.execute()`` emits the documented event sequence.
@@ -500,3 +503,125 @@ class TestAgentExecutorEventSequence:
         assert isinstance(events[-1], TaskStatusUpdateEvent)
         assert events[-1].status.state == TaskState.completed
         assert events[-1].final is True
+
+
+# =============================================================================
+# Availability gating (issue #97)
+# =============================================================================
+
+
+class _RejectA2AImports:
+    """Meta-path finder that makes every ``a2a`` import fail.
+
+    Stands in for an incompatible SDK — a2a-sdk 1.x deletes ``a2a.server.apps``
+    outright — without needing to install one.
+    """
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "a2a" or fullname.startswith("a2a."):
+            raise ImportError(f"simulated incompatible a2a-sdk: cannot import {fullname}")
+        return None
+
+
+class TestA2AAvailabilityIsFatal:
+    """A missing or incompatible SDK must not be allowed to start the app quietly.
+
+    Before #97 the only consequence of an SDK that would not import was
+    ``A2A_AVAILABLE = False`` plus an INFO line, and ``create_a2a_server()``
+    returning None. Whether A2A exists is now an explicit setting
+    (``KUBENTLY_A2A``), and "expected but unavailable" raises.
+    """
+
+    def test_incompatible_sdk_raises_instead_of_degrading(self, monkeypatch):
+        """Reload the module against an unimportable SDK: it must refuse to build."""
+        import kubently.modules.a2a as a2a_module
+
+        monkeypatch.delenv("KUBENTLY_A2A", raising=False)
+        finder = _RejectA2AImports()
+        cached = {
+            name: mod
+            for name, mod in sys.modules.items()
+            if name == "a2a" or name.startswith("a2a.")
+        }
+        try:
+            for name in cached:
+                del sys.modules[name]
+            sys.meta_path.insert(0, finder)
+            broken = importlib.reload(a2a_module)
+
+            assert broken.A2A_AVAILABLE is False, "the simulated SDK should not have imported"
+            assert broken.A2A_IMPORT_ERROR is not None, (
+                "the ImportError must be kept, not discarded: it is the only "
+                "description of why A2A is unavailable"
+            )
+
+            error = None
+            try:
+                broken.create_a2a_server(external_url="https://example.test/a2a/")
+            except Exception as exc:  # the type is asserted below
+                error = exc
+
+            assert error is not None, (
+                "an unimportable a2a-sdk did not raise: create_a2a_server() handed back "
+                "a value, so the API would start with the whole A2A surface missing"
+            )
+            assert type(error).__name__ == "A2AUnavailableError", type(error).__name__
+            # The operator has to be able to see the cause, and the fix.
+            assert "simulated incompatible a2a-sdk" in str(error)
+            assert "KUBENTLY_A2A" in str(error)
+            assert error.__cause__ is broken.A2A_IMPORT_ERROR
+        finally:
+            sys.meta_path.remove(finder)
+            sys.modules.update(cached)
+            importlib.reload(a2a_module)
+
+    def test_explicitly_disabled_returns_none_without_raising(self, monkeypatch):
+        """``KUBENTLY_A2A=off`` is the only way to get a None server back."""
+        import kubently.modules.a2a as a2a_module
+
+        monkeypatch.setenv("KUBENTLY_A2A", "off")
+        assert a2a_module.a2a_enabled() is False
+        assert a2a_module.create_a2a_server(external_url="https://example.test/a2a/") is None
+
+    def test_enabled_by_default(self, monkeypatch):
+        """No setting means A2A is expected: main.py mounts it and cannot skip it."""
+        import kubently.modules.a2a as a2a_module
+
+        monkeypatch.delenv("KUBENTLY_A2A", raising=False)
+        assert a2a_module.a2a_enabled() is True
+        assert a2a_module.create_a2a_server(external_url="https://example.test/a2a/") is not None
+
+    def test_unavailable_sdk_is_tolerated_only_when_switched_off(self, monkeypatch):
+        """Disabled + missing SDK is a deliberate configuration, not a failure."""
+        import kubently.modules.a2a as a2a_module
+
+        monkeypatch.setattr(a2a_module, "A2A_AVAILABLE", False)
+        monkeypatch.setattr(
+            a2a_module, "A2A_IMPORT_ERROR", ImportError("no module named 'a2a.server.apps'")
+        )
+
+        monkeypatch.setenv("KUBENTLY_A2A", "off")
+        assert a2a_module.create_a2a_server(external_url="https://example.test/a2a/") is None
+
+        monkeypatch.setenv("KUBENTLY_A2A", "on")
+        with pytest.raises(a2a_module.A2AUnavailableError):
+            a2a_module.create_a2a_server(external_url="https://example.test/a2a/")
+
+    def test_main_startup_cannot_continue_without_a2a_when_enabled(self):
+        """main.py must not treat a missing A2A server as recoverable.
+
+        The mount block is the last place the failure could be swallowed, so
+        assert on the compiled source of ``lifespan``: with A2A enabled there is
+        no path from "no server" to a running app.
+        """
+        import inspect
+
+        import kubently.main as main
+
+        source = inspect.getsource(main.lifespan)
+        mount_block = source.split("a2a_server = create_a2a_server")[1]
+        assert "elif a2a_enabled():" in mount_block, (
+            "main.py must distinguish 'A2A explicitly off' from 'A2A missing'; "
+            "without that check a None server silently starts an API with no /a2a/"
+        )
+        assert "raise RuntimeError" in mount_block.split("else:")[0]


### PR DESCRIPTION
Closes #97
Closes #98

Two checks that cannot fire. In both cases a failure and a pass look identical from the outside.

## #97 — A2A availability was inferred from whether an import happened to succeed

`kubently/modules/a2a/__init__.py` wrapped its SDK imports in `except Exception`, set `A2A_AVAILABLE = False`, logged one INFO line, and `create_a2a_server()` then returned `None` — for *every* cause: SDK missing, symbol moved, agent card broken, constructor raising. `main.py` turned that `None` into `RuntimeError("A2A server initialization failed")`, a message with no cause in it, while the real `ImportError` had gone past at INFO during module import.

That is the trap #76 walks into: `a2a-sdk` 1.1.2 deletes `a2a.server.apps` and moves the `new_*` helpers, so every step of that migration would have surfaced as "A2A support disabled at import time" rather than as a failure.

Fixed the way PR #94 (now merged) gates the cloud telemetry tools — an explicit setting, not an inferred one. Note the naming: #94 ended up splitting `cloud_tools_configured()` (sync env gate) from `cloud_tools_enabled(redis_client)` (async fleet gate) because cloud availability has two dimensions. A2A has only one — there is no fleet state that can switch the protocol surface on — so this adds a single sync `a2a_enabled()` in `kubently/modules/a2a`, which does not collide with either name.

- **`KUBENTLY_A2A`** (default `on`) decides whether this deployment expects A2A, mirroring `KUBENTLY_CLOUD_TOOLS=off`. Default on, because `main.py` mounts `/a2a/` and treats its absence as a startup failure: opting out has to be deliberate.
- The `ImportError` is **kept** in `A2A_IMPORT_ERROR` instead of discarded, and logged at **ERROR with `exc_info=True`** when A2A is expected (INFO when it was switched off — a deployment without the `a2a` extra and with `KUBENTLY_A2A=off` is a valid configuration, not an incident).
- `create_a2a_server()` raises **`A2AUnavailableError`** chained (`raise ... from`) onto that `ImportError` when A2A is expected but unavailable, and no longer swallows constructor failures either. **`None` now means exactly one thing: `KUBENTLY_A2A=off`.**
- `main.py` mounts when it gets a server, raises when A2A is enabled and it did not (defensive — the factory raises first), and warns only on the explicit opt-out.

### Regression test

`tests/test_a2a_sdk_contract.py::TestA2AAvailabilityIsFatal` — the runnable check that a missing/incompatible SDK can never again start the app quietly. The main one installs a meta-path finder that rejects every `a2a` import (standing in for the 1.x package rewrite without installing it), reloads the module, and asserts it raises rather than degrades — plus that the cause is preserved and the message names both the missing symbol and the way out.

Against this branch's code: 41 passed. Against `main`'s code with the new tests applied: 5 failed, including

```
E  AssertionError: main.py must distinguish 'A2A explicitly off' from 'A2A missing';
   without that check a None server silently starts an API with no /a2a/
E  AttributeError: module 'kubently.modules.a2a' has no attribute 'A2A_IMPORT_ERROR'
```

Full suite: 756 passed, 2 skipped (`tests/`) + 38 passed (`kubently/tests/`). Ruff findings on the touched files are byte-identical to their pre-change baseline.

## #98 — the release job that never ran, and never will

The job was gated on `github.ref == 'refs/heads/main'`; its only real step on `startsWith(github.ref, 'refs/tags/')`. Mutually exclusive. `softprops/action-gh-release` has never executed. Evidence from the last eight `main` pushes:

```
run 32259582136 job=success CreateRelease=skipped
run 32209743744 job=success CreateRelease=skipped
run 32209643981 job=success CreateRelease=skipped
run 32209609709 job=success CreateRelease=skipped
run 32209270418 job=success CreateRelease=skipped
run 32208968549 job=success CreateRelease=skipped
run 32188164434 job=success CreateRelease=skipped
run 32085320583 job=success CreateRelease=skipped
```

The job goes green every time, because a job whose steps all skip succeeds.

**What the release history says the intended trigger is.** Releases are tag-driven, and each family already has an owner that works:

| Release | Tag | Published by |
|---|---|---|
| `CLI cli-v2.3.2` … `cli-v2.3.5` | `cli-v*.*.*` | `publish-npm.yml` (`gh release create`, after the npm publish) |
| `kubently-1.0.0` … `kubently-1.0.5` | `kubently-*` | `release-chart.yml` (chart-releaser; attaches the `.tgz`) |
| images | `v*.*.*` | `publish-docker.yml` |

`build.yml` predates `publish-npm.yml` (its release job is from the initial commit; the npm workflow was added later and is what produced every `CLI cli-v*` release). It is not even triggered on tag pushes — `on: push: branches: [main, develop]` — so aligning the two guards on `refs/tags/*` would also require adding a tag trigger, and would then put a **second** release owner on the same `cli-v*` tag, racing `publish-npm.yml`'s `gh release create` (whichever loses fails, *after* npm has already published).

So the dead job is **removed**, not rewired, and replaced by a comment recording where releases actually come from and where to attach the CLI tarball (`publish-npm.yml`) if it is ever wanted as a release asset.

### Deleting rather than repairing: what is lost, and what depends on it

#98 was written assuming a repair, so the case for deletion has to be explicit.

**What the job was supposed to do.** Attach `nodejs-dist/*` — the `npm pack` tarball plus the built `dist/` — to a GitHub release as assets. That is the *only* thing it added; the release itself would have been created by whichever workflow got there first.

**Nothing needs it now.** Every release family has a working owner (table above), and none of them is `build.yml`: `publish-npm.yml` has produced every `CLI cli-v*` release, `release-chart.yml` produced `kubently-1.0.x` and — since #101 — `kubently-1.1.0` / `kubently-1.1.1` today, `publish-docker.yml` pushes the images. The Helm workflow and this one never overlapped: it releases the chart `.tgz`, this job would have released the CLI tarball.

**No capability is removed, because it was never delivered.** The step has never executed, so no release in the repo carries an asset from it — `gh release view cli-v2.3.5 --json assets` returns `{"assets":[]}`, and the same holds for every other `cli-v*` release. The artifact it would have attached is not disappearing either: the identical tarball is published to npm as `@kubently/cli` by `publish-npm.yml` on every `cli-v*` tag, and `build-cli` still uploads it as a workflow artifact (`nodejs-dist`) on every push and PR. Deleting the job removes dead code, not a distribution channel.

**Nothing references it.** No `needs: release` anywhere, no other workflow, script or doc mentions the job or `softprops/action-gh-release`; the `nodejs-dist` artifact upload it consumed lives in `build-cli` and is untouched.

If CLI tarballs *should* be release assets, that is a new (never-working) feature and belongs one line away in `publish-npm.yml`'s `gh release create`, where the release is actually made — not in a second workflow racing it. Happy to add it here if you want it.

### Verification

Note what is *not* being claimed: a green CI run proves nothing here, since green is the broken state. There is no `action-gh-release` step left to show executing — the honest evidence is the pair above: the step has never run in any historical run, and after this change the job that reported green while doing nothing is gone. `workflow_dispatch` on this branch ([run 32260312629](https://github.com/kubently/kubently/actions/runs/32260312629)) shows `build.yml` now resolving to a single job:

```
job=build-cli conclusion=success
```

— no second job reporting green while doing nothing. The same holds for this PR's own `build.yml` run ([32261942092](https://github.com/kubently/kubently/actions/runs/32261942092)): one job, `build-cli`.

Rebased onto `ac035e4` (#104), which made `ruff check` / `ruff format --check` blocking: both pass on `kubently/` with these changes.

If you would rather keep a release step in `build.yml`, the only way to prove *that* shape executes is a real tag push (`git tag cli-v2.3.6 && git push origin cli-v2.3.6`), which publishes to npm and creates a public release — hence the recommendation to consolidate on the workflow that already owns it.
