### PR TITLE
Migrate the A2A bindings to a2a-sdk 1.x (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,42 @@
   and `deployment/README.md` no longer point at files that do not exist.
 
 ### Changed
+- **Migrated the A2A bindings to `a2a-sdk` 1.1.2** (#76, closes Dependabot #35).
+  1.x is a package rewrite, not a version bump, so this is one commit across
+  `kubently/modules/a2a/`: `a2a.server.apps.A2AStarletteApplication` is gone and
+  `A2AModule.get_app()` now assembles the endpoint from `a2a.server.routes`
+  (`create_agent_card_routes` + `create_jsonrpc_routes`); the `new_*` helpers
+  moved from `a2a.utils` to `a2a.helpers`, with `new_agent_text_message(text,
+  ctx, task)` replaced by `new_text_message(text, context_id=…, task_id=…)` and
+  `new_task(message)` by `new_task_from_user_message(message)`; and `a2a.types`
+  is protobuf-generated, so every event is built with snake_case fields
+  (`context_id`, `task_id`, `last_chunk`) and `TaskState.TASK_STATE_*` members.
+  The pin is `a2a-sdk[http-server]==1.1.2` — starlette and sse-starlette moved
+  behind that extra in 1.x, and without it the JSON-RPC/SSE routes raise
+  `ImportError` when the app is built.
+
+  **The wire contract is unchanged.** 1.x renamed the JSON-RPC methods
+  (`message/stream` → `SendStreamingMessage`), so the endpoint is built with
+  `enable_v0_3_compat=True` and answers both spellings: the Kubently CLI and
+  every other deployed client keep working, rather than receiving
+  `-32601 Method not found`. `TaskStatusUpdateEvent.final` no longer exists in
+  1.x — the stream ends on a terminal `TaskState`, and the compatibility layer
+  re-derives `final: true` from it — so the executor emits terminal states where
+  it used to set the flag, and the #65 guard in `tests/test_a2a_streaming.py`
+  now drives the real `A2AModule.get_app()` (not a hand-assembled copy of it) so
+  a broken composition cannot pass.
+- **The agent card advertises what it actually serves** (#76, finishing #92).
+  1.x replaced the card's single `url`/`protocolVersion` pair with a list of
+  `supportedInterfaces`, so the card now declares two — protocol `1.0` and `0.3`
+  over JSON-RPC, which is exactly what the endpoint answers. The SDK derives the
+  pre-1.x top-level `url`, `protocolVersion` and `preferredTransport` fields from
+  the 0.3 interface, so clients that read those still find them; `protocolVersion`
+  becomes `0.3` instead of the stale `0.2.6` the SDK default used to publish. The
+  card is served at both `/.well-known/agent-card.json` (the 1.x default and the
+  current spec) and `/.well-known/agent.json` (what 0.2.x served), because a
+  discovery path is a public contract. Skills still come from
+  `kubently/modules/a2a/skills.py`, unchanged, so the gating #92 established is
+  intact.
 - **The CI lint job can now fail the build** (#79). Both ruff steps were
   `continue-on-error: true`, which made them a third check that could not fire:
   `ruff check kubently/` reported 971 violations and `ruff format --check`

--- a/docs/A2A_CONFIGURATION.md
+++ b/docs/A2A_CONFIGURATION.md
@@ -158,7 +158,9 @@ See `docs/TEST_QUERIES.md` for complete examples and message formats.
 
 Check the agent card endpoint:
 ```bash
-curl http://localhost:8080/a2a/.well-known/agent.json | jq .
+# `/.well-known/agent-card.json` is the current spec path; Kubently also
+# serves the pre-1.0 `/.well-known/agent.json` for older clients.
+curl http://localhost:8080/a2a/.well-known/agent-card.json | jq .
 ```
 
 Expected response:

--- a/docs/DEPENDENCY_UPGRADES.md
+++ b/docs/DEPENDENCY_UPGRADES.md
@@ -3,77 +3,53 @@
 Notes on dependency bumps that are **not** safe to apply as version changes, so
 the next person (or the next Dependabot PR) does not have to rediscover why.
 
-## a2a-sdk: held at 0.2.16
+## a2a-sdk: migrated to 1.1.2 (#76)
 
-Dependabot proposes `a2a-sdk==0.2.16 -> 1.1.2` (PR #35). **Do not merge that
-bump on its own.** It is not a version change; a2a-sdk 1.x is a rewrite of the
-package, and `kubently/modules/a2a/` needs migrating first. Tracked in #76.
+Resolved. Dependabot's `0.2.16 -> 1.1.2` bump (#35) could not be applied as a
+version change, because 1.x is a rewrite of the package. The migration landed in
+#76; this section records what actually moved, because the reconnaissance that
+preceded it was written without porting the code and got some of it wrong.
 
-### Why it cannot just be bumped
+### What 1.1.2 actually changed
 
-Verified by installing `a2a-sdk==1.1.2` and resolving every symbol the codebase
-imports:
-
-| What the code imports | State in 1.1.2 |
+| What the code imported (0.2.16) | 1.1.2 |
 | --- | --- |
-| `a2a.server.apps.A2AStarletteApplication` | **Module gone.** Replaced by `a2a.server.routes` (`add_a2a_routes_to_fastapi`, `create_jsonrpc_routes`, `create_agent_card_routes`, …). Not restored by any extra — `[http-server]` and `[fastapi]` both lack it. |
-| `a2a.utils.new_agent_text_message` | **Gone.** Not present anywhere in the package. |
-| `a2a.utils.new_task`, `a2a.utils.new_text_artifact` | Moved to `a2a.helpers` / `a2a.helpers.proto_helpers`. |
-| `a2a.types.Message`, `Task`, `Part`, `Role`, `TextPart`, `Artifact`, `TaskStatus`, `TaskState`, `AgentCard`, … | `a2a.types` is now protobuf-generated (`a2a.types.a2a_pb2`). The pydantic models the bindings construct are not there under these names. |
-| `a2a.types.AgentAuthentication` | Gone — and already absent in 0.2.16 (see the dead-code note below). |
-| `DefaultRequestHandler`, `InMemoryTaskStore`, `PushNotificationSender`, `AgentExecutor`, `RequestContext`, `EventQueue` | Still resolve. |
+| `a2a.server.apps.A2AStarletteApplication` | **Module gone.** The endpoint is assembled from `a2a.server.routes`: `create_agent_card_routes(card, card_url=...)` + `create_jsonrpc_routes(handler, rpc_url="/", enable_v0_3_compat=...)`, wrapped in a plain `Starlette`. |
+| `a2a.utils.new_agent_text_message(text, ctx, task)` | Gone. Replaced by `a2a.helpers.new_text_message(text, context_id=..., task_id=..., role=Role.ROLE_AGENT)` — the agent role is the default. |
+| `a2a.utils.new_task(message)` | `a2a.helpers.new_task_from_user_message(message)`. (`a2a.helpers.new_task` also exists but takes `(task_id, context_id, state)` — *not* a drop-in.) |
+| `a2a.utils.new_text_artifact` | `a2a.helpers.new_text_artifact`, same keywords. |
+| `a2a.types` pydantic models | Protobuf-generated (`a2a.types.a2a_pb2`). `Message`, `Task`, `Part`, `Role`, `Artifact`, `TaskStatus`, `TaskState`, `AgentCard`, `AgentSkill`, `AgentCapabilities` all still resolve **under the same names**, but the field names are snake_case (`context_id`, `task_id`, `last_chunk`, `message_id`, `artifact_id`) and enums are `TaskState.TASK_STATE_WORKING` / `Role.ROLE_AGENT`. |
+| `a2a.types.TextPart` | Gone — proto `Part` carries `text` directly; build one with `a2a.helpers.new_text_part`. |
+| `DefaultRequestHandler` | Still resolves (now an alias for `DefaultRequestHandlerV2`) but **takes `agent_card` as a required argument**. |
+| `PushNotificationSender.send_notification(task)` | Now `send_notification(task_id, event)` — artifact updates are pushable too. |
+| `EventQueue` | Now an abstract producer-side interface; `EventQueueLegacy` is the concrete one with an inspectable backing queue (used by the contract tests). |
+| `TaskStatusUpdateEvent.final` | **Gone.** The stream ends when the task reaches a terminal `TaskState`; `EventConsumer` derives it, and the v0.3 layer re-derives the wire `final: true` from the same state. |
+| `AgentCard.url` / `AgentCard.protocolVersion` | Replaced by `supported_interfaces: [AgentInterface(url, protocol_binding, protocol_version)]`. The serialiser (`agent_card_to_dict`) still emits the legacy top-level `url`/`protocolVersion`/`preferredTransport`, derived from the first 0.3-compatible interface — so a card that lists **no** 0.3 interface silently drops those fields and breaks every pre-1.0 client. |
+| extras | `starlette` and `sse-starlette` moved behind the `[http-server]` extra. The pin is `a2a-sdk[http-server]==1.1.2`; without the extra the route factories raise `ImportError` at app build. |
 
-`a2a.compat.v0_3` exists but exports nothing useful, so there is no drop-in
-shim.
+Two claims in the earlier reconnaissance were wrong and cost time:
 
-### Why this was dangerous
+- **`a2a.compat.v0_3` is not empty.** Its `__init__` exports nothing, but the
+  submodules are the whole v0.3 compatibility layer, and it is reachable through
+  a supported flag: `create_jsonrpc_routes(..., enable_v0_3_compat=True)`.
+- **1.x renamed the JSON-RPC methods.** `message/send`, `message/stream`,
+  `tasks/get`, `tasks/resubscribe` became `SendMessage`,
+  `SendStreamingMessage`, `GetTask`, `SubscribeToTask`. Without
+  `enable_v0_3_compat` the migration is not "does it still import" but a **wire
+  break**: the Kubently CLI (`kubently-cli/nodejs/src/lib/a2aClient.ts` sends
+  `message/stream`) would get `-32601 Method not found` from a server that looks
+  perfectly healthy. Kubently enables it, and advertises both protocol versions
+  on the agent card because it serves both.
 
-`kubently/modules/a2a/__init__.py` wraps its SDK imports in a bare
-`except Exception` that sets `A2A_AVAILABLE = False`:
+### What the next bump should check
 
-```python
-try:
-    from a2a.server.apps import A2AStarletteApplication
-    ...
-    A2A_AVAILABLE = True
-except Exception as e:
-    A2A_AVAILABLE = False
-    logger.info(f"A2A support disabled at import time: {e}")
-```
-
-An incompatible SDK therefore does **not** crash the API. It starts normally
-with the entire A2A protocol surface missing, announced only by one INFO log
-line. Combined with the old CI (`pytest ... || true`), that bump could have
-merged and deployed with every check green.
-
-`tests/test_a2a_sdk_contract.py` now guards this. Against 1.1.2 all 35 of its
-tests fail, including an explicit assertion that `A2A_AVAILABLE is True`.
-
-### What a migration would involve
-
-1. Replace `A2AStarletteApplication(...).build()` in
-   `kubently/modules/a2a/__init__.py` with the `a2a.server.routes` factories,
-   keeping `get_mount_config()` returning `("/a2a", app)` so `main.py` and its
-   API-key ASGI wrapper are unaffected.
-2. Repoint the `new_*` helpers in `agent_executor.py` at `a2a.helpers`.
-3. Rework `helpers.py` and `agent_executor.py` event construction onto the new
-   `a2a.types` representation.
-4. Re-run `tests/test_a2a_sdk_contract.py` — updating the `SDK_IMPORT_SURFACE`
-   table to the new paths — plus a live check against `docs/TEST_QUERIES.md`,
-   since the contract tests cover shape, not wire behaviour.
-
-### Dead code to resolve first
-
-`kubently/modules/a2a/protocol_bindings/a2a_server/__main__.py` does not import
-even on the **current** pin. It has two independent bugs:
-
-- `from a2a.types import AgentAuthentication` — no such symbol in 0.2.16.
-- `from kubently.protocol_bindings.a2a_server.agent import KubentlyAgent` — the
-  real path is `kubently.modules.a2a.protocol_bindings.a2a_server.agent`.
-
-Nothing imports it; the live server is built by `A2AModule.get_app()` in
-`kubently/modules/a2a/__init__.py`. It should be deleted or repaired before the
-migration, so it does not read as a second entry point. Tracked in #77.
+`tests/test_a2a_sdk_contract.py` pins the import surface, the helper signatures,
+the constructed event shapes and the card; `tests/test_a2a_streaming.py` drives
+the real `A2AModule.get_app()` over `message/stream` and asserts the response is
+a non-empty SSE stream with a terminal event (#65), and that both well-known
+agent-card paths answer. Run both against any proposed `a2a-sdk` version before
+merging it — and note that `A2A_AVAILABLE` no longer swallows failures (#97), so
+a broken bump fails at startup instead of quietly removing `/a2a/`.
 
 ## typescript: held at ^6
 

--- a/kubently/modules/a2a/__init__.py
+++ b/kubently/modules/a2a/__init__.py
@@ -18,13 +18,19 @@ from threading import Thread
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from fastapi import FastAPI
+    from starlette.applications import Starlette as StarletteApp
 
 logger = logging.getLogger(__name__)
 
 # Environment switch that decides whether this deployment expects A2A. Whether a
 # module imported is NOT that decision (issue #97).
 A2A_ENABLED_ENV = "KUBENTLY_A2A"
+
+# The agent card path a2a-sdk 0.2.x served. The current spec (and the 1.x
+# default, `a2a.utils.constants.AGENT_CARD_WELL_KNOWN_PATH`) is
+# `/.well-known/agent-card.json`, but the card is a public contract: clients
+# pinned to the old path must not stop discovering Kubently, so both are served.
+LEGACY_AGENT_CARD_PATH = "/.well-known/agent.json"
 
 _OFF_VALUES = {"off", "false", "0", "no"}
 
@@ -57,10 +63,25 @@ A2A_IMPORT_ERROR: BaseException | None = None
 # Heavy dependencies (LangChain, LLMs, etc.) will be imported lazily inside get_app().
 try:
     import uvicorn
-    from a2a.server.apps import A2AStarletteApplication
     from a2a.server.request_handlers import DefaultRequestHandler
+    from a2a.server.routes import create_agent_card_routes, create_jsonrpc_routes
     from a2a.server.tasks import InMemoryTaskStore, PushNotificationSender
-    from a2a.types import AgentCapabilities, AgentCard, AgentSkill, Task
+    from a2a.types import (
+        AgentCapabilities,
+        AgentCard,
+        AgentInterface,
+        AgentSkill,
+        Task,
+        TaskArtifactUpdateEvent,
+        TaskStatusUpdateEvent,
+    )
+    from a2a.utils.constants import (
+        AGENT_CARD_WELL_KNOWN_PATH,
+        PROTOCOL_VERSION_0_3,
+        PROTOCOL_VERSION_CURRENT,
+        TransportProtocol,
+    )
+    from starlette.applications import Starlette
 
     A2A_AVAILABLE = True
 except Exception as e:  # Broad catch: the log level and fatality are decided below.
@@ -84,9 +105,15 @@ if A2A_AVAILABLE:
     class SimplePushNotificationSender(PushNotificationSender):
         """Simple push notification sender."""
 
-        async def send_notification(self, task: Task) -> None:
-            """Log notifications for debugging."""
-            logger.debug(f"Push notification for task {task.id}: {task.status.state}")
+        async def send_notification(
+            self, task_id: str, event: Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent
+        ) -> None:
+            """Log notifications for debugging.
+
+            a2a-sdk 1.x passes the task id alongside the event rather than a
+            whole ``Task``, because artifact updates are pushable too (#76).
+            """
+            logger.debug(f"Push notification for task {task_id}: {type(event).__name__}")
 
 
 class A2AModule:
@@ -122,7 +149,7 @@ class A2AModule:
         self.redis_client = redis_client
         self.server = None
         self.thread = None
-        self._app = None  # Cache for FastAPI sub-application
+        self._app = None  # Cache for the A2A ASGI sub-application
 
     def _lazy_imports(self):
         """Import heavy A2A bindings lazily to reduce startup memory/fragility."""
@@ -137,7 +164,7 @@ class A2AModule:
         # Lazy import to access SUPPORTED_CONTENT_TYPES only when needed
         from .protocol_bindings.a2a_server.agent import KubentlyAgent
 
-        capabilities = AgentCapabilities(streaming=True, pushNotifications=False)
+        capabilities = AgentCapabilities(streaming=True, push_notifications=False)
 
         # Skills come from the same configuration gating that registers tools, so
         # the card cannot advertise a toolset this deployment does not have (or
@@ -157,15 +184,34 @@ class A2AModule:
                 "and GitOps fix proposals. The `skills` list is what this deployment "
                 "actually has enabled."
             ),
-            url=self.external_url,
+            # 1.x replaced the card's single `url` + `protocolVersion` pair with a
+            # list of interfaces. Both are advertised because both are served:
+            # get_app() enables the SDK's v0.3 compatibility on the same endpoint,
+            # so `message/stream` and `SendStreamingMessage` both work. Listing
+            # 0.3 also keeps the legacy top-level `url`/`protocolVersion`/
+            # `preferredTransport` fields in the published JSON (the SDK derives
+            # them from the first 0.3-compatible interface), which is what every
+            # existing client — the Kubently CLI included — reads.
+            supported_interfaces=[
+                AgentInterface(
+                    url=self.external_url,
+                    protocol_binding=TransportProtocol.JSONRPC,
+                    protocol_version=PROTOCOL_VERSION_CURRENT,
+                ),
+                AgentInterface(
+                    url=self.external_url,
+                    protocol_binding=TransportProtocol.JSONRPC,
+                    protocol_version=PROTOCOL_VERSION_0_3,
+                ),
+            ],
             version="1.0.0",
-            defaultInputModes=KubentlyAgent.SUPPORTED_CONTENT_TYPES,
-            defaultOutputModes=KubentlyAgent.SUPPORTED_CONTENT_TYPES,
+            default_input_modes=KubentlyAgent.SUPPORTED_CONTENT_TYPES,
+            default_output_modes=KubentlyAgent.SUPPORTED_CONTENT_TYPES,
             capabilities=capabilities,
             skills=skills,
         )
 
-    def get_mount_config(self) -> tuple[str, FastAPI]:
+    def get_mount_config(self) -> tuple[str, StarletteApp]:
         """
         Get the mount configuration for integrating A2A into the main API.
 
@@ -173,7 +219,7 @@ class A2AModule:
         keeping the orchestration layer (main.py) from knowing implementation details.
 
         Returns:
-            Tuple of (mount_path, fastapi_app) ready to use with app.mount()
+            Tuple of (mount_path, asgi_app) ready to use with app.mount()
 
         Example:
             >>> a2a_server = create_a2a_server(...)
@@ -183,7 +229,7 @@ class A2AModule:
         return ("/a2a", self.get_app())
 
     def get_app(self):
-        """Get FastAPI sub-application for mounting under main API."""
+        """Get the A2A ASGI sub-application for mounting under the main API."""
         if self._app is None:
             # Lazily import heavy executor only when constructing the app
             KubentlyAgentExecutor = self._lazy_imports()
@@ -196,22 +242,40 @@ class A2AModule:
             # Log executor creation
             logger.info(f"Created KubentlyAgentExecutor: {agent_executor}")
 
+            agent_card = self.get_agent_card()
+
             # Use DefaultRequestHandler for now
             request_handler = DefaultRequestHandler(
                 agent_executor=agent_executor,
                 task_store=InMemoryTaskStore(),
+                agent_card=agent_card,
                 push_sender=SimplePushNotificationSender(),
             )
 
             logger.info(f"Created DefaultRequestHandler with executor: {request_handler}")
 
-            # Create A2A application
-            a2a_app = A2AStarletteApplication(
-                agent_card=self.get_agent_card(), http_handler=request_handler
+            # Build and cache the A2A ASGI app.
+            #
+            # a2a-sdk 1.x deleted A2AStarletteApplication; the routes are now
+            # assembled directly (#76). The composition below is what that class
+            # used to do, with two deliberate choices:
+            #
+            # * enable_v0_3_compat=True — 1.x renamed the JSON-RPC methods
+            #   (`message/stream` -> `SendStreamingMessage`). The Kubently CLI and
+            #   every other deployed A2A client speak the 0.3 names, so the
+            #   endpoint serves both. Without it those clients get -32601 Method
+            #   not found from a server that otherwise looks perfectly healthy.
+            # * the card is served at both well-known paths — the 1.x default
+            #   `/.well-known/agent-card.json` (the current A2A spec) and the
+            #   `/.well-known/agent.json` that 0.2.x served and existing clients,
+            #   docs and probes still request.
+            self._app = Starlette(
+                routes=[
+                    *create_agent_card_routes(agent_card, card_url=AGENT_CARD_WELL_KNOWN_PATH),
+                    *create_agent_card_routes(agent_card, card_url=LEGACY_AGENT_CARD_PATH),
+                    *create_jsonrpc_routes(request_handler, rpc_url="/", enable_v0_3_compat=True),
+                ]
             )
-
-            # Build and cache the FastAPI app
-            self._app = a2a_app.build()
 
             # NOTE: Auth is intentionally NOT added here. add_middleware() on this built
             # sub-app does not reliably run once it is mounted under the main app (Starlette
@@ -228,7 +292,7 @@ class A2AModule:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
-        # Get the FastAPI app (creates it if needed)
+        # Get the A2A app (creates it if needed)
         app = self.get_app()
 
         # Configure uvicorn

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
@@ -6,10 +6,10 @@ import traceback
 from typing import Any, override
 
 import httpx
+from a2a.helpers import new_task_from_user_message, new_text_artifact, new_text_message
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events.event_queue import EventQueue
 from a2a.types import TaskArtifactUpdateEvent, TaskState, TaskStatus, TaskStatusUpdateEvent
-from a2a.utils import new_agent_text_message, new_task, new_text_artifact
 
 # Always use real agent when LLM is configured
 from kubently.modules.a2a.protocol_bindings.a2a_server.agent import KubentlyAgent
@@ -66,7 +66,7 @@ class KubentlyAgentExecutor(AgentExecutor):
 
         task = context.current_task
         if not task:
-            task = new_task(context.message)
+            task = new_task_from_user_message(context.message)
             await event_queue.enqueue_event(task)
 
         try:
@@ -82,9 +82,9 @@ class KubentlyAgentExecutor(AgentExecutor):
             await event_queue.enqueue_event(
                 TaskArtifactUpdateEvent(
                     append=False,
-                    contextId=task.contextId,
-                    taskId=task.id,
-                    lastChunk=True,
+                    context_id=task.context_id,
+                    task_id=task.id,
+                    last_chunk=True,
                     artifact=new_text_artifact(
                         name="debug_result",
                         description="Kubernetes debugging analysis and findings",
@@ -95,12 +95,13 @@ class KubentlyAgentExecutor(AgentExecutor):
             await event_queue.enqueue_event(
                 TaskStatusUpdateEvent(
                     status=TaskStatus(
-                        state=TaskState.failed,
-                        message=new_agent_text_message(message, task.contextId, task.id),
+                        state=TaskState.TASK_STATE_FAILED,
+                        message=new_text_message(
+                            message, context_id=task.context_id, task_id=task.id
+                        ),
                     ),
-                    final=True,
-                    contextId=task.contextId,
-                    taskId=task.id,
+                    context_id=task.context_id,
+                    task_id=task.id,
                 )
             )
         except Exception:
@@ -127,7 +128,7 @@ class KubentlyAgentExecutor(AgentExecutor):
         logger.info("Debug context IDs:")
         logger.info(f"  - context.context_id: {context.context_id}")
         logger.info(f"  - context.message.context_id: {contextId}")
-        logger.info(f"  - task.contextId: {task.contextId if task else None}")
+        logger.info(f"  - task.context_id: {task.context_id if task else None}")
         logger.info(f"  - cluster_id (from metadata): {cluster_id}")
 
         logger.info(f"Using contextId: {contextId}, cluster_id: {cluster_id}")
@@ -151,9 +152,9 @@ class KubentlyAgentExecutor(AgentExecutor):
             await event_queue.enqueue_event(
                 TaskArtifactUpdateEvent(
                     append=False,
-                    contextId=task.contextId,
-                    taskId=task.id,
-                    lastChunk=True,
+                    context_id=task.context_id,
+                    task_id=task.id,
+                    last_chunk=True,
                     artifact=new_text_artifact(
                         name="debug_result",
                         description="Kubernetes debugging analysis and findings",
@@ -163,10 +164,9 @@ class KubentlyAgentExecutor(AgentExecutor):
             )
             await event_queue.enqueue_event(
                 TaskStatusUpdateEvent(
-                    status=TaskStatus(state=TaskState.completed),
-                    final=True,
-                    contextId=task.contextId,
-                    taskId=task.id,
+                    status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+                    context_id=task.context_id,
+                    task_id=task.id,
                 )
             )
             return
@@ -201,16 +201,15 @@ class KubentlyAgentExecutor(AgentExecutor):
                 await event_queue.enqueue_event(
                     TaskStatusUpdateEvent(
                         status=TaskStatus(
-                            state=TaskState.working,
-                            message=new_agent_text_message(
+                            state=TaskState.TASK_STATE_WORKING,
+                            message=new_text_message(
                                 chunk_content,
-                                task.contextId,
-                                task.id,
+                                context_id=task.context_id,
+                                task_id=task.id,
                             ),
                         ),
-                        final=False,
-                        contextId=task.contextId,
-                        taskId=task.id,
+                        context_id=task.context_id,
+                        task_id=task.id,
                     )
                 )
 
@@ -238,16 +237,15 @@ class KubentlyAgentExecutor(AgentExecutor):
                         await event_queue.enqueue_event(
                             TaskStatusUpdateEvent(
                                 status=TaskStatus(
-                                    state=TaskState.working,
-                                    message=new_agent_text_message(
+                                    state=TaskState.TASK_STATE_WORKING,
+                                    message=new_text_message(
                                         tool_message,
-                                        task.contextId,
-                                        task.id,
+                                        context_id=task.context_id,
+                                        task_id=task.id,
                                     ),
                                 ),
-                                final=False,
-                                contextId=task.contextId,
-                                taskId=task.id,
+                                context_id=task.context_id,
+                                task_id=task.id,
                             )
                         )
 
@@ -273,16 +271,15 @@ class KubentlyAgentExecutor(AgentExecutor):
                 await event_queue.enqueue_event(
                     TaskStatusUpdateEvent(
                         status=TaskStatus(
-                            state=TaskState.working,
-                            message=new_agent_text_message(
+                            state=TaskState.TASK_STATE_WORKING,
+                            message=new_text_message(
                                 tool_message,
-                                task.contextId,
-                                task.id,
+                                context_id=task.context_id,
+                                task_id=task.id,
                             ),
                         ),
-                        final=False,
-                        contextId=task.contextId,
-                        taskId=task.id,
+                        context_id=task.context_id,
+                        task_id=task.id,
                     )
                 )
         except Exception as e:
@@ -292,9 +289,9 @@ class KubentlyAgentExecutor(AgentExecutor):
         await event_queue.enqueue_event(
             TaskArtifactUpdateEvent(
                 append=False,
-                contextId=task.contextId,
-                taskId=task.id,
-                lastChunk=True,
+                context_id=task.context_id,
+                task_id=task.id,
+                last_chunk=True,
                 artifact=new_text_artifact(
                     name="debug_result",
                     description="Kubernetes debugging analysis and findings",
@@ -303,13 +300,15 @@ class KubentlyAgentExecutor(AgentExecutor):
             )
         )
 
-        # Mark task as complete
+        # Mark task as complete. a2a-sdk 1.x dropped TaskStatusUpdateEvent.final:
+        # the stream ends when a terminal TaskState is emitted, and the v0.3
+        # compatibility layer re-derives `final: true` from that for old clients.
+        # So a terminal state here is the only thing keeping clients from hanging.
         await event_queue.enqueue_event(
             TaskStatusUpdateEvent(
-                status=TaskStatus(state=TaskState.completed),
-                final=True,
-                contextId=task.contextId,
-                taskId=task.id,
+                status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+                context_id=task.context_id,
+                task_id=task.id,
             )
         )
 

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/helpers.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/helpers.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
+from a2a.helpers import new_text_part
 from a2a.types import (
     Artifact,
     Message,
@@ -12,34 +13,28 @@ from a2a.types import (
     TaskState,
     TaskStatus,
     TaskStatusUpdateEvent,
-    TextPart,
 )
 
 
 def update_task_with_agent_response(task: Task, agent_response: dict[str, Any]) -> None:
     """Updates the provided task with the agent response."""
-    task.status.timestamp = datetime.now(UTC).isoformat()
-    parts: list[Part] = [Part(root=TextPart(text=agent_response["content"]))]
+    task.status.timestamp.FromDatetime(datetime.now(UTC))
+    parts: list[Part] = [new_text_part(agent_response["content"])]
     if agent_response["require_user_input"]:
-        task.status.state = TaskState.input_required
+        task.status.state = TaskState.TASK_STATE_INPUT_REQUIRED
         message = Message(
-            messageId=str(uuid4()),
-            role=Role.agent,
+            message_id=str(uuid4()),
+            role=Role.ROLE_AGENT,
             parts=parts,
         )
-        task.status.message = message
-        if not task.history:
-            task.history = []
-
+        task.status.message.CopyFrom(message)
         task.history.append(message)
     else:
-        task.status.state = TaskState.completed
-        task.status.message = None
-        if not task.artifacts:
-            task.artifacts = []
-
-        artifact: Artifact = Artifact(parts=parts, artifactId=str(uuid4()))
-        task.artifacts.append(artifact)
+        task.status.state = TaskState.TASK_STATE_COMPLETED
+        # Protobuf has no null for a submessage: "no message" is the field being
+        # unset, which is what ClearField does (the old code assigned None).
+        task.status.ClearField("message")
+        task.artifacts.append(Artifact(parts=parts, artifact_id=str(uuid4())))
 
 
 def process_streaming_agent_response(
@@ -49,45 +44,44 @@ def process_streaming_agent_response(
     """Processes the streaming agent responses and returns TaskArtifactUpdateEvent and TaskStatusUpdateEvent."""
     is_task_complete = agent_response["is_task_complete"]
     require_user_input = agent_response["require_user_input"]
-    parts: list[Part] = [Part(root=TextPart(text=agent_response["content"]))]
+    parts: list[Part] = [new_text_part(agent_response["content"])]
 
-    end_stream = False
     artifact = None
     message = None
 
     # responses from this agent can be working/completed/input-required
     if not is_task_complete and not require_user_input:
-        task_state = TaskState.working
-        message = Message(role=Role.agent, parts=parts, messageId=str(uuid4()))
+        task_state = TaskState.TASK_STATE_WORKING
+        message = Message(role=Role.ROLE_AGENT, parts=parts, message_id=str(uuid4()))
     elif require_user_input:
-        task_state = TaskState.input_required
-        message = Message(role=Role.agent, parts=parts, messageId=str(uuid4()))
-        end_stream = True
+        task_state = TaskState.TASK_STATE_INPUT_REQUIRED
+        message = Message(role=Role.ROLE_AGENT, parts=parts, message_id=str(uuid4()))
     else:
-        task_state = TaskState.completed
-        artifact = Artifact(parts=parts, artifactId=str(uuid4()))
-        end_stream = True
+        task_state = TaskState.TASK_STATE_COMPLETED
+        artifact = Artifact(parts=parts, artifact_id=str(uuid4()))
 
     task_artifact_update_event = None
 
     if artifact:
         task_artifact_update_event = TaskArtifactUpdateEvent(
-            taskId=task.id,
-            contextId=task.contextId,
+            task_id=task.id,
+            context_id=task.context_id,
             artifact=artifact,
             append=False,
-            lastChunk=True,
+            last_chunk=True,
         )
 
+    # a2a-sdk 1.x removed TaskStatusUpdateEvent.final: the stream ends on a
+    # terminal TaskState (completed / failed / input-required), and the v0.3
+    # compatibility layer re-derives `final` from the state for older clients.
     task_status_event = TaskStatusUpdateEvent(
-        taskId=task.id,
-        contextId=task.contextId,
+        task_id=task.id,
+        context_id=task.context_id,
         status=TaskStatus(
             state=task_state,
             message=message,
-            timestamp=datetime.now(UTC).isoformat(),
         ),
-        final=end_stream,
     )
+    task_status_event.status.timestamp.FromDatetime(datetime.now(UTC))
 
     return task_artifact_update_event, task_status_event

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,15 +85,14 @@ cloud = [
 a2a = [
     # A2A Protocol and LangGraph Dependencies
     "a2a-python==0.0.1",
-    # HELD at 0.2.x. dependabot proposes 1.1.2, but a2a-sdk 1.x is a rewrite,
-    # not a version bump: a2a.server.apps is gone, the new_agent_text_message /
-    # new_task / new_text_artifact helpers moved from a2a.utils to a2a.helpers,
-    # and a2a.types is now protobuf-generated (no Message/Task/Part/Role).
-    # kubently/modules/a2a/ needs migrating first — and note that module swallows
-    # SDK ImportErrors into A2A_AVAILABLE = False, so an unguarded bump would
-    # silently disable A2A rather than fail. tests/test_a2a_sdk_contract.py now
-    # catches that. See docs/DEPENDENCY_UPGRADES.md.
-    "a2a-sdk==0.2.16",
+    # 1.x is a package rewrite, migrated in #76: a2a.server.apps is gone
+    # (routes are assembled from a2a.server.routes), the new_* helpers live in
+    # a2a.helpers, and a2a.types is protobuf-generated. The [http-server] extra
+    # is required, not optional — starlette and sse-starlette moved behind it in
+    # 1.x, and without them the JSON-RPC/SSE routes raise ImportError at build.
+    # See docs/DEPENDENCY_UPGRADES.md; tests/test_a2a_sdk_contract.py pins the
+    # surface so the next bump fails loudly instead of disabling A2A.
+    "a2a-sdk[http-server]==1.1.2",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",
     "starlette>=0.49.1",  # CVE fixes: PYSEC-2026-161/248/249, CVE-2025-62727, CVE-2026-48817/48818

--- a/tests/test_a2a_sdk_contract.py
+++ b/tests/test_a2a_sdk_contract.py
@@ -16,6 +16,13 @@ with the entire A2A protocol surface missing (issue #97). A2A is now gated on
 ``KUBENTLY_A2A`` and an unimportable SDK raises ``A2AUnavailableError``; the
 tests at the bottom of this file are what keep that from regressing.
 
+Pinned against **a2a-sdk 1.x** since #76. The 1.x surface differs from 0.2.x in
+ways this file has to encode: ``a2a.server.apps`` is gone (routes come from
+``a2a.server.routes``), the ``new_*`` helpers moved to ``a2a.helpers`` with new
+signatures, ``a2a.types`` is protobuf-generated (snake_case fields, ``TaskState``
+enum members, no ``TextPart``), and ``TaskStatusUpdateEvent`` has no ``final``
+flag — terminality is carried by the task state.
+
 Contracts under guard:
 - Every module path and symbol the codebase imports from ``a2a`` still resolves.
 - ``A2A_AVAILABLE`` is True, i.e. the SDK did not silently disable A2A.
@@ -47,8 +54,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 # (module path, symbol) for every name the codebase imports from the SDK.
 # Sourced by grepping `from a2a...` across kubently/.
 SDK_IMPORT_SURFACE = [
-    ("a2a.server.apps", "A2AStarletteApplication"),
     ("a2a.server.request_handlers", "DefaultRequestHandler"),
+    ("a2a.server.routes", "create_agent_card_routes"),
+    ("a2a.server.routes", "create_jsonrpc_routes"),
     ("a2a.server.tasks", "InMemoryTaskStore"),
     ("a2a.server.tasks", "PushNotificationSender"),
     ("a2a.server.agent_execution", "AgentExecutor"),
@@ -56,6 +64,7 @@ SDK_IMPORT_SURFACE = [
     ("a2a.server.events.event_queue", "EventQueue"),
     ("a2a.types", "AgentCapabilities"),
     ("a2a.types", "AgentCard"),
+    ("a2a.types", "AgentInterface"),
     ("a2a.types", "AgentSkill"),
     ("a2a.types", "Artifact"),
     ("a2a.types", "Message"),
@@ -66,10 +75,14 @@ SDK_IMPORT_SURFACE = [
     ("a2a.types", "TaskState"),
     ("a2a.types", "TaskStatus"),
     ("a2a.types", "TaskStatusUpdateEvent"),
-    ("a2a.types", "TextPart"),
-    ("a2a.utils", "new_agent_text_message"),
-    ("a2a.utils", "new_task"),
-    ("a2a.utils", "new_text_artifact"),
+    ("a2a.utils.constants", "AGENT_CARD_WELL_KNOWN_PATH"),
+    ("a2a.utils.constants", "PROTOCOL_VERSION_0_3"),
+    ("a2a.utils.constants", "PROTOCOL_VERSION_CURRENT"),
+    ("a2a.utils.constants", "TransportProtocol"),
+    ("a2a.helpers", "new_task_from_user_message"),
+    ("a2a.helpers", "new_text_artifact"),
+    ("a2a.helpers", "new_text_message"),
+    ("a2a.helpers", "new_text_part"),
 ]
 
 
@@ -77,9 +90,9 @@ SDK_IMPORT_SURFACE = [
 def test_sdk_symbol_still_exists(module_path, symbol):
     """Every symbol the bindings import must still resolve in the installed SDK.
 
-    A bump that relocates one of these (a2a-sdk 1.x moves the ``new_*`` helpers
-    to ``a2a.helpers`` and deletes ``a2a.server.apps`` outright) fails here with
-    the exact missing name rather than surfacing as a silent runtime downgrade.
+    A bump that relocates one of these (1.x moved the ``new_*`` helpers to
+    ``a2a.helpers`` and deleted ``a2a.server.apps`` outright) fails here with the
+    exact missing name rather than surfacing as a silent runtime downgrade.
     """
     try:
         module = importlib.import_module(module_path)
@@ -123,16 +136,23 @@ def test_agent_executor_module_imports():
 
 
 def test_sdk_helper_signatures_are_stable():
-    """The ``new_*`` helpers are called positionally, so argument order matters."""
+    """The ``new_*`` helpers are called by keyword, so the names matter."""
     import inspect
 
-    from a2a.utils import new_agent_text_message, new_task, new_text_artifact
+    from a2a.helpers import new_task_from_user_message, new_text_artifact, new_text_message
 
-    # agent_executor.py calls new_agent_text_message(text, contextId, taskId)
-    params = list(inspect.signature(new_agent_text_message).parameters)
-    assert params[:3] == ["text", "context_id", "task_id"], (
-        f"new_agent_text_message signature changed to {params}; agent_executor.py "
-        f"passes these three positionally."
+    # agent_executor.py calls new_text_message(text, context_id=..., task_id=...).
+    # 1.x replaced new_agent_text_message with this; the agent role is the default,
+    # so a change of default would silently relabel every streamed chunk as a user
+    # message.
+    params = inspect.signature(new_text_message).parameters
+    assert next(iter(params)) == "text"
+    assert {"context_id", "task_id", "role"} <= set(params)
+    from a2a.types import Role
+
+    assert params["role"].default == Role.ROLE_AGENT, (
+        "new_text_message no longer defaults to the agent role; agent_executor.py "
+        "relies on that default for every streamed chunk."
     )
 
     # agent_executor.py calls new_text_artifact(name=..., description=..., text=...)
@@ -141,8 +161,8 @@ def test_sdk_helper_signatures_are_stable():
         f"new_text_artifact no longer accepts name/text/description: {params}"
     )
 
-    # agent_executor.py calls new_task(context.message)
-    assert len(inspect.signature(new_task).parameters) >= 1
+    # agent_executor.py calls new_task_from_user_message(context.message)
+    assert len(inspect.signature(new_task_from_user_message).parameters) == 1
 
 
 # =============================================================================
@@ -150,19 +170,44 @@ def test_sdk_helper_signatures_are_stable():
 # =============================================================================
 
 
+def _stream_ending_states():
+    """The states a2a-sdk 1.x treats as ending a stream.
+
+    ``TaskStatusUpdateEvent.final`` no longer exists. ``EventConsumer`` stops
+    consuming when the task reaches one of these instead, and the v0.3
+    compatibility layer re-derives the wire-level ``final: true`` from (a subset
+    of) the same set. So a terminal task state *is* the "stream is over" signal
+    now, and asserting on it is the 1.x equivalent of asserting ``final``.
+
+    Mirrors ``a2a.server.events.event_consumer``; imported lazily so this module
+    still collects when the SDK is missing.
+    """
+    from a2a.types import TaskState
+
+    return {
+        TaskState.TASK_STATE_COMPLETED,
+        TaskState.TASK_STATE_CANCELED,
+        TaskState.TASK_STATE_FAILED,
+        TaskState.TASK_STATE_REJECTED,
+        TaskState.TASK_STATE_UNSPECIFIED,
+        TaskState.TASK_STATE_INPUT_REQUIRED,
+    }
+
+
 def _make_task():
-    """Build a minimal but valid SDK Task, the way new_task() would."""
-    from a2a.types import Message, Part, Role, Task, TaskState, TaskStatus, TextPart
+    """Build a minimal but valid SDK Task, the way new_task_from_user_message() would."""
+    from a2a.helpers import new_text_part
+    from a2a.types import Message, Role, Task, TaskState, TaskStatus
 
     return Task(
         id="task-1",
-        contextId="ctx-1",
-        status=TaskStatus(state=TaskState.submitted),
+        context_id="ctx-1",
+        status=TaskStatus(state=TaskState.TASK_STATE_SUBMITTED),
         history=[
             Message(
-                messageId="msg-1",
-                role=Role.user,
-                parts=[Part(root=TextPart(text="why is my pod crashlooping?"))],
+                message_id="msg-1",
+                role=Role.ROLE_USER,
+                parts=[new_text_part("why is my pod crashlooping?")],
             )
         ],
     )
@@ -182,12 +227,14 @@ class TestUpdateTaskWithAgentResponse:
             task, {"content": "pod is OOMKilled", "require_user_input": False}
         )
 
-        assert task.status.state == TaskState.completed
-        assert task.status.message is None
+        assert task.status.state == TaskState.TASK_STATE_COMPLETED
+        # Protobuf messages have no None: "no status message" is the field being
+        # unset, which is what the 1.x port asserts instead of `is None`.
+        assert not task.status.HasField("message")
         assert len(task.artifacts) == 1
-        assert task.artifacts[0].parts[0].root.text == "pod is OOMKilled"
+        assert task.artifacts[0].parts[0].text == "pod is OOMKilled"
         # timestamp must be set for the protocol to order events
-        assert task.status.timestamp
+        assert task.status.HasField("timestamp")
 
     def test_input_required_response_sets_message_and_history(self):
         from a2a.types import Role, TaskState
@@ -201,13 +248,13 @@ class TestUpdateTaskWithAgentResponse:
             task, {"content": "which namespace?", "require_user_input": True}
         )
 
-        assert task.status.state == TaskState.input_required
-        assert task.status.message is not None
-        assert task.status.message.role == Role.agent
-        assert task.status.message.parts[0].root.text == "which namespace?"
+        assert task.status.state == TaskState.TASK_STATE_INPUT_REQUIRED
+        assert task.status.HasField("message")
+        assert task.status.message.role == Role.ROLE_AGENT
+        assert task.status.message.parts[0].text == "which namespace?"
         # the clarifying question must land in history, or the next turn loses it
         assert len(task.history) == history_before + 1
-        assert task.artifacts is None or task.artifacts == []
+        assert not task.artifacts
 
 
 class TestProcessStreamingAgentResponse:
@@ -225,9 +272,11 @@ class TestProcessStreamingAgentResponse:
         )
 
         assert artifact_event is None, "intermediate chunks must not emit artifacts"
-        assert status_event.status.state == TaskState.working
-        assert status_event.final is False
-        assert status_event.status.message.parts[0].root.text == "checking pods..."
+        assert status_event.status.state == TaskState.TASK_STATE_WORKING
+        # 1.x dropped TaskStatusUpdateEvent.final; a non-terminal state is what
+        # keeps the stream open, so that is what gets asserted.
+        assert status_event.status.state not in _stream_ending_states()
+        assert status_event.status.message.parts[0].text == "checking pods..."
 
     def test_completed_chunk_emits_final_artifact(self):
         from a2a.types import TaskState
@@ -242,14 +291,16 @@ class TestProcessStreamingAgentResponse:
         )
 
         assert artifact_event is not None
-        assert artifact_event.taskId == task.id
-        assert artifact_event.contextId == task.contextId
-        assert artifact_event.lastChunk is True
+        assert artifact_event.task_id == task.id
+        assert artifact_event.context_id == task.context_id
+        assert artifact_event.last_chunk is True
         assert artifact_event.append is False
-        assert artifact_event.artifact.parts[0].root.text == "done: OOMKilled"
+        assert artifact_event.artifact.parts[0].text == "done: OOMKilled"
 
-        assert status_event.status.state == TaskState.completed
-        assert status_event.final is True, "completed stream must set final=True or clients hang"
+        assert status_event.status.state == TaskState.TASK_STATE_COMPLETED
+        assert status_event.status.state in _stream_ending_states(), (
+            "completed stream must reach a terminal state or clients hang"
+        )
 
     def test_input_required_chunk_ends_stream_without_artifact(self):
         from a2a.types import TaskState
@@ -263,8 +314,8 @@ class TestProcessStreamingAgentResponse:
         )
 
         assert artifact_event is None
-        assert status_event.status.state == TaskState.input_required
-        assert status_event.final is True
+        assert status_event.status.state == TaskState.TASK_STATE_INPUT_REQUIRED
+        assert status_event.status.state in _stream_ending_states()
 
 
 # =============================================================================
@@ -276,21 +327,43 @@ class TestAgentCardContract:
     """The agent card is the A2A discovery document — it must build and serialise."""
 
     def test_agent_card_builds_and_serialises(self):
+        from a2a.server.request_handlers.response_helpers import agent_card_to_dict
+        from a2a.utils.constants import (
+            PROTOCOL_VERSION_0_3,
+            PROTOCOL_VERSION_CURRENT,
+            TransportProtocol,
+        )
         from kubently.modules.a2a import A2AModule
 
         module = A2AModule(host="127.0.0.1", port=8000, external_url="https://example.test/a2a/")
         card = module.get_agent_card()
 
         assert card.name == "Kubently Kubernetes Debugger"
-        assert card.url == "https://example.test/a2a/"
         assert card.capabilities.streaming is True
 
-        # The card is served as JSON over /.well-known — round-tripping it is the
-        # real contract, and pydantic model changes in the SDK break it here.
-        payload = card.model_dump(mode="json", exclude_none=True)
+        # 1.x moved the endpoint off the card and onto per-transport interfaces.
+        # Both protocol versions must be advertised because both are served
+        # (get_app() enables the SDK's v0.3 compatibility on the same endpoint).
+        interfaces = {i.protocol_version: i for i in card.supported_interfaces}
+        assert set(interfaces) == {PROTOCOL_VERSION_CURRENT, PROTOCOL_VERSION_0_3}
+        for interface in interfaces.values():
+            assert interface.url == "https://example.test/a2a/"
+            assert interface.protocol_binding == TransportProtocol.JSONRPC
+
+        # The card is served as JSON over /.well-known — round-tripping it through
+        # the SDK's own serialiser is the real contract.
+        payload = agent_card_to_dict(card)
         assert payload["name"] == "Kubently Kubernetes Debugger"
         assert "text/plain" in payload["defaultInputModes"]
         assert [s["id"] for s in payload["skills"]] == [s.id for s in card.skills]
+
+        # ...and the published JSON must still carry the pre-1.x top-level fields,
+        # which the SDK derives from the 0.3 interface. Existing clients (the
+        # Kubently CLI included) read `url`; dropping it breaks discovery for
+        # every one of them.
+        assert payload["url"] == "https://example.test/a2a/"
+        assert payload["protocolVersion"] == PROTOCOL_VERSION_0_3
+        assert payload["preferredTransport"] == TransportProtocol.JSONRPC
 
     def test_advertised_skills_follow_the_toolset_gating(self):
         """Skills are configuration-dependent, so assert the gates — not a count.
@@ -361,24 +434,44 @@ class _StubAgent:
 
 def _make_request_context(text: str, metadata: dict | None = None):
     """Build a RequestContext the way DefaultRequestHandler does for a new task."""
+    from a2a.helpers import new_text_part
     from a2a.server.agent_execution import RequestContext
-    from a2a.types import Message, MessageSendParams, Part, Role, TextPart
+    from a2a.server.context import ServerCallContext
+    from a2a.types import Message, Role, SendMessageRequest
+    from google.protobuf.json_format import ParseDict
 
     message = Message(
-        messageId="msg-1",
-        role=Role.user,
-        parts=[Part(root=TextPart(text=text))],
-        contextId="ctx-1",
+        message_id="msg-1",
+        role=Role.ROLE_USER,
+        parts=[new_text_part(text)],
+        context_id="ctx-1",
     )
-    context = RequestContext(
-        request=MessageSendParams(message=message),
+    request = SendMessageRequest(message=message)
+    if metadata is not None:
+        # metadata carries the clusterId A2A extension the executor reads. In 1.x
+        # it hangs off SendMessageRequest rather than MessageSendParams; the v0.3
+        # compatibility layer copies `params.metadata` into it, so the CLI's
+        # clusterId still lands here.
+        ParseDict(metadata, request.metadata)
+    return RequestContext(
+        call_context=ServerCallContext(),
+        request=request,
         task_id="task-1",
         context_id="ctx-1",
     )
-    if metadata is not None:
-        # metadata carries the clusterId A2A extension the executor reads
-        context._params.metadata = metadata
-    return context
+
+
+def _event_queue():
+    """A queue the test can drain.
+
+    1.x made ``EventQueue`` an abstract producer-side interface owned by the
+    request handler; ``EventQueueLegacy`` is the concrete implementation that
+    still exposes an inspectable backing queue, which is what these tests need
+    to look at the emitted event sequence directly.
+    """
+    from a2a.server.events.event_queue import EventQueueLegacy
+
+    return EventQueueLegacy()
 
 
 async def _drain(event_queue):
@@ -397,7 +490,6 @@ class TestAgentExecutorEventSequence:
 
     @pytest.mark.asyncio
     async def test_execute_emits_task_then_stream_then_final_artifact(self):
-        from a2a.server.events.event_queue import EventQueue
         from a2a.types import (
             Task,
             TaskArtifactUpdateEvent,
@@ -415,7 +507,7 @@ class TestAgentExecutorEventSequence:
         executor._initialized = True
 
         context = _make_request_context("summarise cluster health")
-        event_queue = EventQueue()
+        event_queue = _event_queue()
 
         await executor.execute(context, event_queue)
         events = await _drain(event_queue)
@@ -423,32 +515,34 @@ class TestAgentExecutorEventSequence:
         # 1. the new Task must be published first, or the client has nothing to attach to
         assert isinstance(events[0], Task), f"first event was {type(events[0]).__name__}"
 
-        # 2. every streamed chunk reaches the client as a non-final working update
+        # 2. every streamed chunk reaches the client as a non-terminal working update
         working = [
             e
             for e in events
-            if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working
+            if isinstance(e, TaskStatusUpdateEvent)
+            and e.status.state == TaskState.TASK_STATE_WORKING
         ]
-        streamed = [e.status.message.parts[0].root.text for e in working]
+        streamed = [e.status.message.parts[0].text for e in working]
         assert "looking at pods" in streamed
         assert "found it" in streamed
-        assert all(e.final is False for e in working)
+        assert all(e.status.state not in _stream_ending_states() for e in working)
 
         # 3. exactly one final artifact carrying the joined response
         artifacts = [e for e in events if isinstance(e, TaskArtifactUpdateEvent)]
         assert len(artifacts) == 1
-        assert artifacts[0].lastChunk is True
-        assert artifacts[0].artifact.parts[0].root.text == "looking at pods\nfound it"
+        assert artifacts[0].last_chunk is True
+        assert artifacts[0].artifact.parts[0].text == "looking at pods\nfound it"
 
-        # 4. the stream terminates with final=True/completed, or clients hang forever
+        # 4. the stream terminates on a terminal state, or clients hang forever.
+        #    (1.x has no `final` flag; the state is the signal — see
+        #    _stream_ending_states.)
         assert isinstance(events[-1], TaskStatusUpdateEvent)
-        assert events[-1].status.state == TaskState.completed
-        assert events[-1].final is True
+        assert events[-1].status.state == TaskState.TASK_STATE_COMPLETED
+        assert events[-1].status.state in _stream_ending_states()
 
     @pytest.mark.asyncio
     async def test_cluster_id_from_metadata_reaches_the_agent(self):
         """clusterId arrives as an A2A metadata extension and must be forwarded."""
-        from a2a.server.events.event_queue import EventQueue
         from kubently.modules.a2a.protocol_bindings.a2a_server.agent_executor import (
             KubentlyAgentExecutor,
         )
@@ -460,7 +554,7 @@ class TestAgentExecutorEventSequence:
         executor._initialized = True
 
         context = _make_request_context("summarise cluster health", metadata={"clusterId": "prod"})
-        await executor.execute(context, EventQueue())
+        await executor.execute(context, _event_queue())
 
         assert executor.agent.received["cluster_id"] == "prod"
         assert executor.agent.received["thread_id"] == "ctx-1"
@@ -475,7 +569,6 @@ class TestAgentExecutorEventSequence:
         Without this the client sees a half-open stream and waits forever, which
         is a worse failure mode than an error message.
         """
-        from a2a.server.events.event_queue import EventQueue
         from a2a.types import TaskArtifactUpdateEvent, TaskState, TaskStatusUpdateEvent
         from kubently.modules.a2a.protocol_bindings.a2a_server.agent_executor import (
             KubentlyAgentExecutor,
@@ -492,17 +585,17 @@ class TestAgentExecutorEventSequence:
         executor._active_sessions = {}
         executor._initialized = True
 
-        event_queue = EventQueue()
+        event_queue = _event_queue()
         await executor.execute(_make_request_context("summarise cluster health"), event_queue)
         events = await _drain(event_queue)
 
         artifacts = [e for e in events if isinstance(e, TaskArtifactUpdateEvent)]
         assert len(artifacts) == 1
-        assert "llm unreachable" in artifacts[0].artifact.parts[0].root.text
+        assert "llm unreachable" in artifacts[0].artifact.parts[0].text
 
         assert isinstance(events[-1], TaskStatusUpdateEvent)
-        assert events[-1].status.state == TaskState.completed
-        assert events[-1].final is True
+        assert events[-1].status.state == TaskState.TASK_STATE_COMPLETED
+        assert events[-1].status.state in _stream_ending_states()
 
 
 # =============================================================================
@@ -597,7 +690,7 @@ class TestA2AAvailabilityIsFatal:
 
         monkeypatch.setattr(a2a_module, "A2A_AVAILABLE", False)
         monkeypatch.setattr(
-            a2a_module, "A2A_IMPORT_ERROR", ImportError("no module named 'a2a.server.apps'")
+            a2a_module, "A2A_IMPORT_ERROR", ImportError("no module named 'a2a.server.routes'")
         )
 
         monkeypatch.setenv("KUBENTLY_A2A", "off")

--- a/tests/test_a2a_streaming.py
+++ b/tests/test_a2a_streaming.py
@@ -7,9 +7,17 @@ first `enqueue_event()` therefore reaches the client as a 200 with a zero-length
 body — no events, no error, nothing. `message/send` surfaces the same failure as
 a JSON-RPC error, which is why only the streaming path looked broken.
 
-These tests drive the real `A2AStarletteApplication` + `KubentlyAgentExecutor`
-mounted the way `kubently/main.py` mounts them, and assert the stream always
-carries at least one `data:` frame and a terminal event.
+These tests drive the real app `A2AModule.get_app()` builds, with the real
+`KubentlyAgentExecutor`, mounted the way `kubently/main.py` mounts it, and assert
+the stream always carries at least one `data:` frame and a terminal event.
+
+Since #76 the app is assembled here rather than handed over by the SDK:
+a2a-sdk 1.x deleted `A2AStarletteApplication`, so `A2AModule.get_app()` composes
+`a2a.server.routes` itself. That is exactly why these tests go through
+`A2AModule` instead of standing the routes up themselves — a test that
+re-assembles the routes could pass while the app the server actually mounts is
+broken (drop `enable_v0_3_compat` and every `message/stream` client gets
+-32601 Method not found, with a hand-rolled test none the wiser).
 """
 
 import os
@@ -22,13 +30,10 @@ pytest.importorskip("deepagents")  # agent_executor -> agent -> deepagents
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from a2a.server.apps import A2AStarletteApplication  # noqa: E402
-from a2a.server.request_handlers import DefaultRequestHandler  # noqa: E402
-from a2a.server.tasks import InMemoryTaskStore  # noqa: E402
-from a2a.types import AgentCapabilities, AgentCard, AgentSkill  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
+from kubently.modules.a2a import A2AModule  # noqa: E402
 from kubently.modules.a2a.protocol_bindings.a2a_server.agent_executor import (  # noqa: E402
     KubentlyAgentExecutor,
 )
@@ -48,20 +53,11 @@ STREAM_REQUEST = {
 
 
 def _client(executor):
-    card = AgentCard(
-        name="Kubently Kubernetes Debugger",
-        description="test card",
-        url="http://localhost:8080/a2a/",
-        version="1.0.0",
-        defaultInputModes=["text"],
-        defaultOutputModes=["text"],
-        capabilities=AgentCapabilities(streaming=True, pushNotifications=False),
-        skills=[AgentSkill(id="k", name="k", description="d", tags=["k8s"])],
-    )
-    handler = DefaultRequestHandler(
-        agent_executor=executor, task_store=InMemoryTaskStore()
-    )
-    inner = A2AStarletteApplication(agent_card=card, http_handler=handler).build()
+    module = A2AModule(host="127.0.0.1", port=8080, external_url="http://localhost:8080/a2a/")
+    # get_app() builds its own executor from _lazy_imports(); swap in the one
+    # under test while leaving the rest of the real composition alone.
+    module._lazy_imports = lambda: (lambda redis_client=None: executor)
+    inner = module.get_app()
     # Mounted under /a2a exactly like kubently/main.py does.
     outer = FastAPI()
     outer.mount("/a2a", inner)
@@ -112,3 +108,67 @@ def test_stream_reports_the_failure_as_a_task_artifact():
     _assert_usable_stream(response)
     assert "redis is down" in response.text
     assert "debug_result" in response.text
+
+
+def test_the_0_3_wire_method_is_still_served():
+    """`message/stream` must keep working across the 1.x bump (#76).
+
+    a2a-sdk 1.x renamed the JSON-RPC methods (`message/stream` ->
+    `SendStreamingMessage`) and only answers the old names when the endpoint is
+    built with `enable_v0_3_compat`. The Kubently CLI, `docs/A2A_CONFIGURATION.md`
+    and every deployed client send the old names, so an endpoint that answered
+    -32601 to them would be exactly as broken as #65 was, one layer down.
+    """
+    response = _post_stream(_failing_executor(RuntimeError("boom")))
+    _assert_usable_stream(response)
+    assert "Method not found" not in response.text
+    assert "-32601" not in response.text
+
+
+def test_the_1_0_wire_method_is_served_too():
+    """The card advertises protocol 1.0, so 1.0 has to actually answer.
+
+    1.x negotiates on the `A2A-Version` header; with v0.3 compatibility on, a
+    request without it is treated as 0.3. Both halves of the advertisement are
+    checked so the card cannot claim a version the endpoint rejects.
+    """
+    with _client(_failing_executor(RuntimeError("boom"))) as client:
+        response = client.post(
+            "/a2a/",
+            headers={
+                "Accept": "text/event-stream",
+                "Content-Type": "application/json",
+                "A2A-Version": "1.0",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": "n1",
+                "method": "SendStreamingMessage",
+                "params": {
+                    "message": {
+                        "messageId": "m1",
+                        "role": "ROLE_USER",
+                        "parts": [{"text": "say hi"}],
+                    }
+                },
+            },
+        )
+    _assert_usable_stream(response)
+    assert "TASK_STATE_FAILED" in response.text, "1.0 stream never reached a terminal state"
+
+
+def test_agent_card_is_served_on_both_well_known_paths():
+    """Discovery must not break for clients pinned to the 0.2.x path.
+
+    1.x serves `/.well-known/agent-card.json` (the current spec); 0.2.x served
+    `/.well-known/agent.json`. The card is a public contract, so both answer.
+    """
+    with _client(_failing_executor(RuntimeError("unused"))) as client:
+        for path in ("/a2a/.well-known/agent-card.json", "/a2a/.well-known/agent.json"):
+            response = client.get(path)
+            assert response.status_code == 200, path
+            card = response.json()
+            assert card["name"] == "Kubently Kubernetes Debugger"
+            # The pre-1.x top-level fields the CLI reads survive the bump.
+            assert card["url"] == "http://localhost:8080/a2a/"
+            assert card["protocolVersion"]


### PR DESCRIPTION
Closes #76

`a2a-sdk` 1.x is a rewrite of the package, not a version bump, so this moves `kubently/modules/a2a/` in one commit. Deliberately sequenced behind #103: A2A no longer swallows SDK `ImportError`s, so every step of this migration was visible instead of degrading into "A2A support disabled at import time".

## What 1.1.2 actually changed

Verified against a real install rather than the reconnaissance in #76, which was right about the shape and wrong about two things that mattered.

| 0.2.16 | 1.1.2 |
| --- | --- |
| `a2a.server.apps.A2AStarletteApplication` | Gone. Endpoint assembled from `a2a.server.routes` (`create_agent_card_routes` + `create_jsonrpc_routes`) into a `Starlette` app. `get_mount_config()` still returns `("/a2a", app)`, so `main.py` and its API-key ASGI wrapper are untouched. |
| `a2a.utils.new_agent_text_message(text, ctx, task)` | Gone → `a2a.helpers.new_text_message(text, context_id=…, task_id=…)` (agent role is the default). |
| `a2a.utils.new_task(message)` | → `a2a.helpers.new_task_from_user_message(message)`. `a2a.helpers.new_task` also exists but takes `(task_id, context_id, state)` — **not** a drop-in. |
| `a2a.types` pydantic models | Protobuf-generated. Same names, but snake_case fields (`context_id`, `task_id`, `last_chunk`, `message_id`, `artifact_id`) and `TaskState.TASK_STATE_*` / `Role.ROLE_*` enums. `TextPart` is gone — proto `Part` carries `text`. |
| `DefaultRequestHandler(executor, task_store, …)` | Alias for `DefaultRequestHandlerV2`; **`agent_card` is now required**. |
| `PushNotificationSender.send_notification(task)` | → `send_notification(task_id, event)`. |
| `TaskStatusUpdateEvent.final` | **Gone.** A stream ends when the task reaches a terminal `TaskState`. |
| `AgentCard.url` / `.protocolVersion` | → `supported_interfaces: [AgentInterface(url, protocol_binding, protocol_version)]`. |
| `starlette` / `sse-starlette` | Moved behind an extra → the pin is `a2a-sdk[http-server]==1.1.2`. Without it the route factories raise `ImportError` at app build. |

**Where the reconnaissance was wrong, and it was the risky half:**

1. **`a2a.compat.v0_3` is not empty.** Its `__init__` exports nothing, but the submodules are a complete v0.3 compatibility layer, reachable through `create_jsonrpc_routes(..., enable_v0_3_compat=True)`.
2. **1.x renamed the JSON-RPC methods** — `message/send` / `message/stream` / `tasks/get` became `SendMessage` / `SendStreamingMessage` / `GetTask`. Without the compat flag this is not an import problem, it is a **wire break**: `kubently-cli/nodejs/src/lib/a2aClient.ts` sends `message/stream` and would get `-32601 Method not found` from a server that otherwise looks perfectly healthy. That failure mode is #65 one layer down.

So the endpoint is built with `enable_v0_3_compat=True` and answers both spellings. `AgentExecutor` / `RequestContext` / `EventQueue` / `InMemoryTaskStore` still resolve, as the recon said.

## Streaming, verified end to end

The event shape on the wire is byte-comparable to 0.2.16 for a `message/stream` request — 5 SSE frames: `task` → two `status-update` (`working`) → `artifact-update` (`lastChunk: true`, joined text) → `status-update` with `"final": true` and `state: completed`. The compat layer re-derives `final` from the terminal state, so the CLI's parser sees exactly what it saw before.

Checked against the real mounted app, not a stub: `message/stream` (0.3), `message/send` (0.3, non-streaming), and `SendStreamingMessage` with `A2A-Version: 1.0` (native). `clusterId` still reaches the agent — 1.x moved request metadata from `MessageSendParams` to `SendMessageRequest`, and the compat layer copies it across.

`tests/test_a2a_streaming.py` now drives **`A2AModule.get_app()`** instead of hand-assembling the SDK app. With `A2AStarletteApplication` gone there is no one-line SDK app to stand up, and a test that re-assembles the routes itself could pass while the app the server actually mounts is broken — drop `enable_v0_3_compat` and every deployed client breaks with the test still green.

## Agent card: `protocolVersion` and the well-known path (#92's leftovers)

The card declares **two** interfaces — `1.0` and `0.3` over JSON-RPC — because that is what the endpoint serves. That is also what preserves the pre-1.0 top-level fields: the SDK's serialiser derives `url`, `protocolVersion` and `preferredTransport` from the first 0.3-compatible interface, and a card listing only `1.0` silently drops them, breaking discovery for every existing client. `protocolVersion` is now `0.3`, replacing the stale `0.2.6` the SDK default published while the server already spoke 0.3 methods.

The card is served at **both** `/.well-known/agent-card.json` (1.x default, current spec) and `/.well-known/agent.json` (what 0.2.x served, and what the docs, `tests/test_mcp_auth.py` and deployed clients request). `add_api_key_auth(public_well_known=True)` already exempts any `/.well-known/` GET, so both stay public.

Skills still come from `kubently/modules/a2a/skills.py`, unchanged — #92's gating and `tests/test_agent_card.py` are untouched and still pass.

## Tests changed, and why

No assertion was weakened to make anything pass.

- **`SDK_IMPORT_SURFACE`** repointed: `a2a.server.apps` → `a2a.server.routes`, `a2a.utils.new_*` → `a2a.helpers.new_*`, `TextPart` dropped, `AgentInterface` and the `a2a.utils.constants` names added.
- **`test_sdk_helper_signatures_are_stable`** now pins `new_text_message` / `new_task_from_user_message` — including that `role` still defaults to `ROLE_AGENT`, since a changed default would silently relabel every streamed chunk as a user message.
- **`final is True/False` → terminal-state assertions.** The flag does not exist in 1.x. `_stream_ending_states()` mirrors the set in `a2a.server.events.event_consumer`, so the test asserts the same property through the mechanism that now carries it.
- **`task.status.message is None` → `not task.status.HasField("message")`.** Protobuf has no null for a submessage; "unset" is the equivalent, and `is None` would be trivially false.
- **Field/enum renames** throughout (`taskId`→`task_id`, `lastChunk`→`last_chunk`, `parts[0].root.text`→`parts[0].text`, `TaskState.completed`→`TaskState.TASK_STATE_COMPLETED`).
- **`RequestContext`** construction: 1.x requires a `ServerCallContext` and a `SendMessageRequest`.
- **`EventQueue()` → `EventQueueLegacy()`** in the executor tests: `EventQueue` is now an abstract producer-side interface; `EventQueueLegacy` is the concrete one with an inspectable backing queue.
- **Added**: `message/stream` still answered, `SendStreamingMessage` answered under `A2A-Version: 1.0`, and both well-known card paths serve the card with `url` intact.

`TestA2AAvailabilityIsFatal` (#103) is untouched apart from one string in a fixture and still passes.

## Verification

```
tests/            784 passed, 2 skipped
kubently/tests/    38 passed
ruff check kubently/         All checks passed
ruff format --check kubently/ 86 files already formatted
make helm-template            renders
```

No `deployment/helm/**` change, so no `Chart.yaml` bump (#101).

## Dependabot #35

**Redundant — close it.** It proposed the bare `a2a-sdk==0.2.16 -> 1.1.2` version change, which this supersedes: the pin here is `a2a-sdk[http-server]==1.1.2` (the extra is required in 1.x, and #35 does not add it), landed together with the code migration that makes it work. Merging #35 on its own would still break the A2A surface; it would now do so loudly, at startup, thanks to #103.

`docs/DEPENDENCY_UPGRADES.md`'s "held at 0.2.16" section is rewritten to record what actually moved and where the earlier reconnaissance was wrong, so the next bump starts from facts.
