### PR TITLE
fix: point test_unified_port.py at routes the app actually registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 ## [Unreleased] - 2026-08-19
 
 ### Fixed
+- **`deployment/scripts/test_unified_port.py` asserted three URLs the app has
+  never served.** The script exists to prove the single port routes to both the
+  admin API and A2A, and three of its five checks were written against assumed
+  URLs rather than registered routes: the agent card was fetched with `GET
+  /a2a/`, which is the JSON-RPC endpoint and answers GET with 405, and
+  `/a2a/health` and `/a2a/invoke` are routes the A2A sub-app has never
+  registered under either SDK version (both 404). Those three reported failure
+  whether or not A2A was healthy, so the script could not distinguish a broken
+  mount from a working one — a permanently red check nobody reads, the same
+  defect class as a permanently green one. Every URL is now checked against
+  what `kubently/main.py` and `kubently/modules/a2a/__init__.py` actually
+  register. The card check moves to `/a2a/.well-known/agent-card.json` (the
+  current spec path, the a2a-sdk 1.x default since #108) and additionally
+  asserts the legacy `/a2a/.well-known/agent.json` that #108 deliberately keeps
+  serving, so the compatibility promise made to pinned clients has a test.
+  `/a2a/health` is deleted rather than replaced: A2A has no health route, and
+  the card plus JSON-RPC checks already establish that the mount is live.
+  `/a2a/invoke` becomes a JSON-RPC POST to `/a2a/` carrying an unknown method,
+  which walks the full chain — mount, API-key wrapper, JSON-RPC handler — and
+  comes back as HTTP 200 with error code -32601 without spending an LLM
+  round-trip, so the check stays fast and deterministic. The default API key
+  changes from `test-key-1`, attributed by a comment to a `docker-compose.yml`
+  this repo does not contain, to the `test-api-key` that
+  `deployment/scripts/kind-e2e.sh` writes into the `kubently-api-keys` secret;
+  `KUBENTLY_URL` and `KUBENTLY_API_KEY` now override both, so pointing the
+  script at another deployment no longer means editing it.
 - **Helm chart had not published since 2026-08-16 (#100).** `Release Helm Chart`
   failed on nine consecutive pushes to `main`, always the same way: chart-releaser
   creates a GitHub release tagged `kubently-<Chart.yaml version>`, and

--- a/deployment/scripts/test_unified_port.py
+++ b/deployment/scripts/test_unified_port.py
@@ -4,13 +4,27 @@ Test script for unified single-port architecture.
 
 This script verifies that both admin API and A2A functionality
 work correctly through the single unified port.
+
+Every URL below was checked against the routes the app actually registers
+(``kubently/main.py`` for the API, ``kubently/modules/a2a/__init__.py`` for the
+mounted A2A sub-app). The script used to assert URLs nobody had verified —
+``GET /a2a/`` for the agent card (the JSON-RPC endpoint is a POST, so that was
+always a 405), plus ``/a2a/health`` and ``/a2a/invoke``, which the A2A app has
+never registered at all. Those checks reported failure whether or not A2A was
+healthy, which is worse than not testing: a permanently red check is one nobody
+reads.
 """
 
-import json
-import time
-from typing import Any, Dict
+import os
 
 import requests
+
+# The A2A app registers exactly three things: the agent card at the current
+# spec path, the same card at the 0.2.x path (kept for clients pinned to it),
+# and JSON-RPC as a POST at the mount root.
+AGENT_CARD_PATH = "/a2a/.well-known/agent-card.json"
+LEGACY_AGENT_CARD_PATH = "/a2a/.well-known/agent.json"
+A2A_JSONRPC_PATH = "/a2a/"
 
 
 def test_main_api_health(base_url: str) -> bool:
@@ -28,39 +42,31 @@ def test_main_api_health(base_url: str) -> bool:
         return False
 
 
-def test_a2a_health(base_url: str) -> bool:
-    """Test A2A health endpoint."""
-    try:
-        response = requests.get(f"{base_url}/a2a/health", timeout=5)
-        if response.status_code == 200:
-            print("✓ A2A health check passed")
-            return True
-        else:
-            print(f"✗ A2A health check failed: {response.status_code}")
-            return False
-    except Exception as e:
-        print(f"✗ A2A health check error: {e}")
-        return False
-
-
 def test_a2a_agent_card(base_url: str) -> bool:
-    """Test A2A agent card endpoint."""
-    try:
-        response = requests.get(f"{base_url}/a2a/", timeout=5)
-        if response.status_code == 200:
+    """Test that the A2A agent card is served at both well-known paths.
+
+    Unauthenticated on purpose: the auth wrapper in ``main.py`` is mounted with
+    ``public_well_known=True`` because the card is a public discovery document.
+    A 401 here means that exemption broke.
+    """
+    ok = True
+    for path in (AGENT_CARD_PATH, LEGACY_AGENT_CARD_PATH):
+        try:
+            response = requests.get(f"{base_url}{path}", timeout=5)
+            if response.status_code != 200:
+                print(f"✗ A2A agent card failed at {path}: {response.status_code}")
+                ok = False
+                continue
             agent_card = response.json()
-            if "name" in agent_card and "Kubently" in agent_card["name"]:
-                print("✓ A2A agent card retrieved successfully")
-                return True
+            if "Kubently" in agent_card.get("name", ""):
+                print(f"✓ A2A agent card retrieved successfully from {path}")
             else:
-                print(f"✗ A2A agent card invalid format: {agent_card}")
-                return False
-        else:
-            print(f"✗ A2A agent card failed: {response.status_code}")
-            return False
-    except Exception as e:
-        print(f"✗ A2A agent card error: {e}")
-        return False
+                print(f"✗ A2A agent card invalid format at {path}: {agent_card}")
+                ok = False
+        except Exception as e:
+            print(f"✗ A2A agent card error at {path}: {e}")
+            ok = False
+    return ok
 
 
 def test_admin_clusters_endpoint(base_url: str, api_key: str) -> bool:
@@ -80,30 +86,43 @@ def test_admin_clusters_endpoint(base_url: str, api_key: str) -> bool:
         return False
 
 
-def test_a2a_invoke_endpoint(base_url: str, api_key: str) -> bool:
-    """Test A2A invoke endpoint."""
+def test_a2a_jsonrpc_endpoint(base_url: str, api_key: str) -> bool:
+    """Test that the A2A JSON-RPC endpoint is mounted, authenticated and answering.
+
+    Deliberately sends an unknown method rather than a real ``message/send``:
+    the point of this script is that the single port routes to A2A at all, and
+    an unknown method proves the whole chain (mount -> API-key wrapper ->
+    JSON-RPC handler) without spending an LLM round-trip. a2a-sdk answers it
+    with HTTP 200 carrying a JSON-RPC error object, code -32601. A 404/405 here
+    means the endpoint moved; a 401 means the API key is wrong.
+    """
     try:
         headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
         payload = {
-            "messages": [{"role": "user", "content": "List available clusters"}],
-            "tools": [],
-            "tool_choice": "auto",
+            "jsonrpc": "2.0",
+            "id": "unified-port-probe",
+            "method": "kubently/does-not-exist",
+            "params": {},
         }
 
         response = requests.post(
-            f"{base_url}/a2a/invoke", headers=headers, json=payload, timeout=10
+            f"{base_url}{A2A_JSONRPC_PATH}", headers=headers, json=payload, timeout=10
         )
 
-        if response.status_code == 200:
-            result = response.json()
-            print("✓ A2A invoke endpoint works")
-            return True
-        else:
-            print(f"✗ A2A invoke endpoint failed: {response.status_code}")
+        if response.status_code != 200:
+            print(f"✗ A2A JSON-RPC endpoint failed: {response.status_code}")
             print(f"  Response: {response.text}")
             return False
+
+        result = response.json()
+        if result.get("jsonrpc") == "2.0" and result.get("error", {}).get("code") == -32601:
+            print("✓ A2A JSON-RPC endpoint works")
+            return True
+
+        print(f"✗ A2A JSON-RPC endpoint returned an unexpected body: {result}")
+        return False
     except Exception as e:
-        print(f"✗ A2A invoke endpoint error: {e}")
+        print(f"✗ A2A JSON-RPC endpoint error: {e}")
         return False
 
 
@@ -112,9 +131,10 @@ def main():
     print("Testing Unified Single-Port Architecture")
     print("=" * 50)
 
-    # Configuration
-    base_url = "http://localhost:8080"
-    api_key = "test-key-1"  # Default test API key from docker-compose
+    # Configuration. `test-api-key` is what deployment/scripts/kind-e2e.sh puts
+    # in the kubently-api-keys secret; override for any other deployment.
+    base_url = os.environ.get("KUBENTLY_URL", "http://localhost:8080")
+    api_key = os.environ.get("KUBENTLY_API_KEY", "test-api-key")
 
     print(f"Testing against: {base_url}")
     print(f"Using API key: {api_key}")
@@ -123,10 +143,9 @@ def main():
     # Run tests
     tests = [
         ("Main API Health", lambda: test_main_api_health(base_url)),
-        ("A2A Health", lambda: test_a2a_health(base_url)),
         ("A2A Agent Card", lambda: test_a2a_agent_card(base_url)),
         ("Admin Clusters", lambda: test_admin_clusters_endpoint(base_url, api_key)),
-        ("A2A Invoke", lambda: test_a2a_invoke_endpoint(base_url, api_key)),
+        ("A2A JSON-RPC", lambda: test_a2a_jsonrpc_endpoint(base_url, api_key)),
     ]
 
     passed = 0


### PR DESCRIPTION
## Problem

`deployment/scripts/test_unified_port.py` exists to prove the unified single port routes to both the admin API and A2A. Three of its five checks were written against **assumed** URLs rather than registered routes:

| Check | Request | Reality |
|---|---|---|
| A2A Agent Card | `GET /a2a/` | **405** — that is the JSON-RPC endpoint, and it is a POST |
| A2A Health | `GET /a2a/health` | **404** — the A2A sub-app has never registered it |
| A2A Invoke | `POST /a2a/invoke` | **404** — likewise, and the payload was not even JSON-RPC |

All three reported failure whether or not A2A was healthy, so the script could not distinguish a broken mount from a working one. A permanently red check is the same defect class as a permanently green one: nobody reads it.

## Fix

Every URL is now checked against what [`kubently/main.py`](kubently/main.py) and [`kubently/modules/a2a/__init__.py`](kubently/modules/a2a/__init__.py) actually register.

- **Agent card** → `/a2a/.well-known/agent-card.json`, the current spec path and the a2a-sdk 1.x default since #108. The check *also* asserts the legacy `/a2a/.well-known/agent.json` that #108 deliberately keeps serving, so the compatibility promise made to pinned clients has a test.
- **`/a2a/health`** → deleted, not replaced. A2A has no health route; inventing one is out of scope, and the card plus JSON-RPC checks already establish that the mount is live.
- **`/a2a/invoke`** → a JSON-RPC POST to `/a2a/` carrying an unknown method. It walks the full chain (mount → API-key wrapper → JSON-RPC handler) and comes back as HTTP 200 with error code `-32601`, so the check stays fast and deterministic instead of spending an LLM round-trip. `test-a2a.sh` and `kind-e2e.sh` already cover the real conversational path.
- **API key** → the default changes from `test-key-1`, credited by a comment to a `docker-compose.yml` this repo does not contain, to the `test-api-key` that `deployment/scripts/kind-e2e.sh` writes into the `kubently-api-keys` secret. `KUBENTLY_URL` and `KUBENTLY_API_KEY` override both, so pointing the script at another deployment no longer means editing it.

The two checks that were already correct — `GET /health` (unauthenticated) and `GET /debug/clusters` (API-key) — were verified against their route definitions and left alone.

## Verification

Run against the live kind baseline (`deployment/scripts/kind-e2e.sh`, rebuilt from this branch's HEAD; API pod confirmed on `a2a-sdk 1.1.2`, executor registered, agent LLM round-trip green).

**The fixed script: 4/4 pass.**

```
Running Main API Health...
✓ Main API health check passed
Running A2A Agent Card...
✓ A2A agent card retrieved successfully from /a2a/.well-known/agent-card.json
✓ A2A agent card retrieved successfully from /a2a/.well-known/agent.json
Running Admin Clusters...
✓ Admin clusters endpoint works: {'clusters': ['kind', 'kind2'], 'count': 2}
Running A2A JSON-RPC...
✓ A2A JSON-RPC endpoint works
Results: 4/4 tests passed
```

**The script on `main`, against that same healthy deployment: 1/5.**

```
✓ Main API health check passed
✗ A2A health check failed: 401
✗ A2A agent card failed: 401
✗ Admin clusters endpoint failed: 401
✗ A2A invoke endpoint failed: 401
Results: 1/5 tests passed
```

Note those are all `401`, not `405`/`404`: the hardcoded `test-key-1` is rejected by the auth wrapper *before* routing is ever reached, so the wrong-key bug was masking the wrong-URL bugs. Fixing only the URLs would still have left the script at 1/5.

**The three URLs the old script requested, on the live post-#108 app:**

```
GET  /a2a/          -> 405
GET  /a2a/health    -> 404
GET  /a2a/invoke    -> 404
POST /a2a/invoke    -> 404
```

**The JSON-RPC probe's real response body** (not a stub — this is the deployed handler):

```
HTTP=200
{"error":{"code":-32601,"message":"Method not found"},"id":"unified-port-probe","jsonrpc":"2.0"}
```

**Falsifiability.** A check that cannot go red is what caused this bug, so each was made to fail on purpose:

- Wrong API key → 2/4. The two authenticated checks go red; both card paths stay green, confirming the `public_well_known` exemption is what keeps discovery reachable.
- Unreachable host → 0/4.

**Pre-#108 note.** The previous deployment (a2a-sdk 0.2.16) was probed before the rebuild: `agent-card.json` 404s there and only `agent.json` answers. The fixed script asserts *both* paths, so it is deliberately stricter than a pre-#108 deployment — correct, since the script ships with the repo and tracks HEAD, and it gives the legacy-path compatibility promise the regression test it never had.
