### PR TITLE
Stop referencing kubently.com, a domain we don't own

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -153,7 +153,7 @@ ingress:
   enabled: true
   className: nginx
   hosts:
-    - host: api.kubently.com
+    - host: api.kubently.example.com
       paths:
         - path: /
           pathType: Prefix

--- a/deployment/helm/kubently/Chart.yaml
+++ b/deployment/helm/kubently/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "1.0.0"
 home: https://github.com/kubently/kubently
 maintainers:
   - name: Kubently Team
-    email: team@kubently.com
+    email: team@kubently.io
 keywords:
   - kubernetes
   - debugging

--- a/deployment/helm/kubently/Chart.yaml
+++ b/deployment/helm/kubently/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubently
 description: Kubently - Troubleshooting Kubernetes Agentically
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.0.0"
 home: https://github.com/kubently/kubently
 maintainers:

--- a/deployment/helm/kubently/examples/tls-cert-manager.yaml
+++ b/deployment/helm/kubently/examples/tls-cert-manager.yaml
@@ -49,7 +49,7 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-protocols: "TLSv1.2 TLSv1.3"
 
   hosts:
-    - host: api.kubently.com  # CHANGE THIS to your domain
+    - host: api.kubently.example.com  # CHANGE THIS to your domain
       paths:
         - path: /
           pathType: Prefix
@@ -58,7 +58,7 @@ ingress:
   tls:
     - secretName: kubently-api-tls
       hosts:
-        - api.kubently.com  # CHANGE THIS to your domain
+        - api.kubently.example.com  # CHANGE THIS to your domain
 
 redis:
   enabled: true
@@ -85,4 +85,4 @@ executor:
 # 5. Wait for READY=True (usually 1-2 minutes)
 #
 # 6. Access your API:
-#    curl https://api.kubently.com/health
+#    curl https://api.kubently.example.com/health

--- a/deployment/helm/kubently/examples/tls-cloud-lb.yaml
+++ b/deployment/helm/kubently/examples/tls-cloud-lb.yaml
@@ -24,7 +24,7 @@
 
 # Step 1: Create ACM certificate (via AWS Console or CLI)
 aws acm request-certificate \
-  --domain-name api.kubently.com \
+  --domain-name api.kubently.example.com \
   --validation-method DNS \
   --region us-east-1
 
@@ -57,7 +57,7 @@ ingress:
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": {"Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
 
   hosts:
-    - host: api.kubently.com
+    - host: api.kubently.example.com
       paths:
         - path: /
           pathType: Prefix
@@ -130,7 +130,7 @@ ingress:
     networking.gke.io/v1beta1.FrontendConfig: kubently-frontend-config
 
   hosts:
-    - host: api.kubently.com
+    - host: api.kubently.example.com
       paths:
         - path: /*  # GCP uses /* for all paths
           pathType: ImplementationSpecific
@@ -147,7 +147,7 @@ metadata:
   namespace: kubently
 spec:
   domains:
-    - api.kubently.com
+    - api.kubently.example.com
 
 ---
 # Create FrontendConfig for HTTPS redirect
@@ -175,7 +175,7 @@ spec:
 #    # Wait for Status: Active
 #
 # 5. Access your API:
-#    curl https://api.kubently.com/health
+#    curl https://api.kubently.example.com/health
 
 # Troubleshooting:
 # - AWS: Check ALB target groups have healthy targets

--- a/deployment/helm/kubently/examples/tls-manual-cert.yaml
+++ b/deployment/helm/kubently/examples/tls-manual-cert.yaml
@@ -48,7 +48,7 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-protocols: "TLSv1.2 TLSv1.3"
 
   hosts:
-    - host: api.kubently.com  # CHANGE THIS to match your certificate CN
+    - host: api.kubently.example.com  # CHANGE THIS to match your certificate CN
       paths:
         - path: /
           pathType: Prefix
@@ -57,7 +57,7 @@ ingress:
   tls:
     - secretName: kubently-api-tls
       hosts:
-        - api.kubently.com  # CHANGE THIS to match your certificate CN
+        - api.kubently.example.com  # CHANGE THIS to match your certificate CN
 
 redis:
   enabled: true
@@ -82,7 +82,7 @@ executor:
 #    helm install kubently ./deployment/helm/kubently -f prod-values.yaml
 #
 # 4. Access your API:
-#    curl https://api.kubently.com/health
+#    curl https://api.kubently.example.com/health
 
 # Certificate renewal:
 # When your certificate expires, update the secret:

--- a/deployment/helm/kubently/values.yaml
+++ b/deployment/helm/kubently/values.yaml
@@ -623,7 +623,7 @@ ingress:
   # tls:
   #   - secretName: kubently-api-tls  # You must create this secret
   #     hosts:
-  #       - api.kubently.com
+  #       - api.kubently.example.com
 
 # Autoscaling Configuration
 autoscaling:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -524,7 +524,7 @@ kubectl create secret tls kubently-api-tls \
 #   tls:
 #     - secretName: kubently-api-tls
 #       hosts:
-#         - api.kubently.com
+#         - api.kubently.example.com
 ```
 
 ## Monitoring Setup

--- a/docs/TLS_DEPLOYMENT.md
+++ b/docs/TLS_DEPLOYMENT.md
@@ -343,10 +343,10 @@ For multiple domains in external mode:
 ```yaml
 tls:
   external:
-    domain: "api.kubently.com"
+    domain: "api.kubently.example.com"
     additionalDomains:
-      - "api-backup.kubently.com"
-      - "*.kubently.com"
+      - "api-backup.kubently.example.com"
+      - "*.kubently.example.com"
 ```
 
 ### Certificate Pinning

--- a/docs/modules/05-agent.md
+++ b/docs/modules/05-agent.md
@@ -485,7 +485,7 @@ spec:
         image: kubently/agent:latest
         env:
         - name: KUBENTLY_API_URL
-          value: "https://api.kubently.com"
+          value: "https://api.kubently.example.com"
         - name: CLUSTER_ID
           value: "production-cluster-1"
         - name: KUBENTLY_TOKEN

--- a/docs/modules/07-deployment.md
+++ b/docs/modules/07-deployment.md
@@ -267,10 +267,10 @@ spec:
   ingressClassName: nginx
   tls:
   - hosts:
-    - api.kubently.com
+    - api.kubently.example.com
     secretName: kubently-api-tls
   rules:
-  - host: api.kubently.com
+  - host: api.kubently.example.com
     http:
       paths:
       - path: /
@@ -352,7 +352,7 @@ spec:
         image: kubently/agent:latest
         env:
         - name: KUBENTLY_API_URL
-          value: "https://api.kubently.com"
+          value: "https://api.kubently.example.com"
         - name: CLUSTER_ID
           valueFrom:
             fieldRef:
@@ -498,14 +498,14 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
   hosts:
-    - host: api.kubently.com
+    - host: api.kubently.example.com
       paths:
         - path: /
           pathType: Prefix
   tls:
     - secretName: kubently-tls
       hosts:
-        - api.kubently.com
+        - api.kubently.example.com
 
 resources:
   api:

--- a/docs/modules/08-cli.md
+++ b/docs/modules/08-cli.md
@@ -169,7 +169,7 @@ kubently debug
 
 # OAuth login
 kubently login
-> Visit: https://auth.kubently.com/device
+> Visit: https://auth.kubently.example.com/device
 > Enter code: ABCD-1234
 > ✓ Authentication successful!
 ```

--- a/kubently/modules/executor/k8s-deployment.yaml
+++ b/kubently/modules/executor/k8s-deployment.yaml
@@ -81,7 +81,7 @@ spec:
         imagePullPolicy: Always
         env:
         - name: KUBENTLY_API_URL
-          value: "https://api.kubently.com"  # HTTPS by default
+          value: "https://api.kubently.example.com"  # HTTPS by default
         - name: CLUSTER_ID
           value: "production-cluster-1"      # Change to your cluster ID
         - name: KUBENTLY_TOKEN


### PR DESCRIPTION
`kubently.com` is not ours, and it was in 15 places across the docs, the Helm examples and one deployment manifest.

## The one that isn't cosmetic

`kubently/modules/executor/k8s-deployment.yaml` shipped this default:

```yaml
- name: KUBENTLY_API_URL
  value: "https://api.kubently.com"   # HTTPS by default
```

That file is meant to be copied and edited, but it is a complete, appliable manifest — and an executor applied unmodified would present its bearer token (`kubently-executor-token`) to whoever registers `kubently.com`. Now `api.kubently.example.com`, which cannot resolve and cannot be registered.

The Helm chart was never exposed to this: `templates/executor-deployment.yaml:56` already `fail`s the render when `executor.apiUrl` is unset. This raw manifest was the only path carrying a live default.

## The rest

- **`deployment/helm/kubently/Chart.yaml`** — maintainer contact was `team@kubently.com`, a mailbox that cannot exist. `helm show chart kubently/kubently` prints it. Now `team@kubently.io`.
- **Docs and TLS examples** (10 files) — example hostnames now use `kubently.example.com`. RFC 2606 reserves `example.com` for documentation precisely so that copy-pasted samples can't be hijacked.

`kubently.company.com` is left alone in `CLAUDE.md` — it reads unmistakably as a placeholder and isn't a copy-paste default.

## Verification

```
$ grep -rn 'kubently\.com' . | grep -v kubently.example.com | grep -v kubently.company.com
docs/DEVELOPMENT.md:275:from kubently.common.logging import get_logger
```

The single remaining hit is a Python import, not a domain.

`helm lint deployment/helm/kubently` reports the same one pre-existing error before and after this change (`templates/api-hpa.yaml.disabled`, an invalid file extension) — untouched by this PR.

Closes the "Other repo" item in kubently/kubently-cloud#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)