### PR TITLE
kubently audit: surface and export the command audit trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,69 @@
 
 ## [Unreleased] - 2026-08-19
 
+### Added
+- **`kubently audit`: the command audit trail is readable at last (#55).**
+  Kubently executes kubectl against production clusters on an LLM's initiative,
+  and until now the only way to ask what it had run was to open `redis-cli` and
+  read a list by hand. There is now a `kubently audit` subcommand, a read-only
+  `GET /audit` endpoint behind API-key auth, and `docs/AUDIT.md`.
+
+  The issue described the trail as already being recorded and merely
+  unsurfaced. **It was not.** `auth:audit` held authentication events only —
+  `api_key_verified`, `executor_token_created`, `executor_token_revoked` — and
+  nothing anywhere recorded a command. (`SessionModule._publish_event`, which
+  would have written `session:events`, has no callers either.) So surfacing the
+  list would have shipped a `kubently audit` that could show an operator every
+  time a key authenticated and not one command it ran. `/debug/execute` now
+  records a `command_executed` entry — cluster, session, kubectl argv,
+  timestamp, outcome — into the same `auth:audit` list, written after the
+  result is known so the outcome is real.
+
+  **Command output is deliberately not recorded.** The trail says what ran and
+  how it ended, not what came back; errors are kept but truncated to 200
+  characters. Recording kubectl output would put pod logs and ConfigMap
+  contents into a long-retained list readable by every holder of the issuing
+  API key.
+
+  **Reads are scoped by service identity and fail closed.** A caller sees the
+  entries their own identity produced and nothing else: no parameter widens it,
+  no admin identity bypasses it, and naming another identity's cluster or
+  session returns an empty list rather than their commands. Entries carrying no
+  identity are dropped from every read rather than shared with everybody, so a
+  future event type that forgets to stamp an identity becomes invisible instead
+  of becoming public. A key with no service identity (a bare `key` rather than
+  `service:key` in `API_KEYS`) has no scope to filter on and is refused with
+  403 instead of being quietly shown everything.
+
+  Identity scoping is the strongest guarantee available here, and it is worth
+  being precise about what it is not: Kubently has no tenant→cluster ownership
+  model — every valid API key may target every registered cluster — so the
+  trail can answer "the commands you ran" but not "everything that happened to
+  your cluster". `docs/AUDIT.md` says so plainly rather than implying an
+  isolation the authorization layer does not provide.
+
+  Retention is documented from a running deployment rather than asserted:
+  `auth:audit` is capped at the most recent 10,000 events by `LTRIM` and has no
+  TTL (`TTL auth:audit` → `-1`). The doc also records the part that bites — the
+  list is shared with one `api_key_verified` event per authenticated request,
+  so commands are a minority of it and a busy deployment evicts them well
+  before 10,000 commands have run — and that redis-stack's default persistence
+  is `save 3600 1 300 100 60 10000` with `appendonly no`, meaning an ungraceful
+  pod kill can lose everything since the last snapshot.
+
 ### Fixed
+- **A failed kubectl command was recorded as a successful one.** `/debug/execute`
+  derived its status from `result.get("status", ExecutionStatus.SUCCESS)`, but
+  executors post a `CommandResult`, whose model has no `status` field at all —
+  so the lookup always missed and always defaulted to `SUCCESS`. A `kubectl get
+  secrets` that came back `Error from server (Forbidden)` was reported as
+  having succeeded. The new audit entry derives its outcome from `success`, the
+  field that actually exists, so the trail records denials as failures; found by
+  running a real session against a real executor rather than by reading the
+  model. The same defect still affects the `status` field of the
+  `CommandResponse` returned to callers, which is left alone here as a
+  pre-existing bug outside this change's blast radius.
+
 - **`deployment/scripts/test_unified_port.py` asserted three URLs the app has
   never served.** The script exists to prove the single port routes to both the
   admin API and A2A, and three of its five checks were written against assumed

--- a/docs/API.md
+++ b/docs/API.md
@@ -287,6 +287,69 @@ Authorization: Bearer <api-key>
 
 ---
 
+### Audit Trail
+
+#### GET /audit
+
+Read the command audit trail. **Read-only** -- no method other than `GET` is
+routed at this path, and nothing on it writes, deletes or alters retention.
+
+The response contains only entries produced by the calling key's own service
+identity. There is no parameter that widens that scope and no admin identity
+that bypasses it; requesting a cluster another identity used returns an empty
+list. A key configured without a service identity (a bare `key` rather than
+`service:key` in `API_KEYS`) has no scope to read and receives `403`.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `event_type` | string | all | Filter to one event type, e.g. `command_executed` |
+| `cluster_id` | string | all | Only entries targeting this cluster |
+| `session_id` | string | all | Only entries from this debug session |
+| `since` | string | unbounded | ISO 8601; only entries at or after this time |
+| `until` | string | unbounded | ISO 8601; only entries at or before this time |
+| `limit` | integer | 100 | Maximum entries to return (1-1000) |
+
+**Response (200 OK):**
+
+```json
+{
+  "entries": [
+    {
+      "timestamp": "2026-08-20T19:25:51.952254+00:00",
+      "type": "command_executed",
+      "service_identity": "team-a",
+      "cluster_id": "prod-a",
+      "session_id": "ba9feb75-1699-4c9b-8d69-67640639c351",
+      "command_id": "23a4976c-fc89-4957-9c9c-339ddaa4aa4b",
+      "command": "get secrets -n default",
+      "outcome": "failure",
+      "error": "Error from server (Forbidden): secrets is forbidden",
+      "correlation_id": null
+    }
+  ],
+  "count": 1,
+  "service_identity": "team-a"
+}
+```
+
+Command output is never included -- the trail records what ran and how it
+ended, not what came back.
+
+**Errors:**
+
+| Status | Meaning |
+| --- | --- |
+| 400 | `since` or `until` is not valid ISO 8601 |
+| 401 | Missing or invalid API key |
+| 403 | API key has no service identity, so its scope cannot be determined |
+
+See **[AUDIT.md](AUDIT.md)** for the `kubently audit` CLI, export formats and
+retention behaviour.
+
+---
+
 ### Agent Endpoints
 
 #### GET /agent/status

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,0 +1,184 @@
+# Audit Trail
+
+Kubently records every kubectl command it executes against a cluster, and
+`kubently audit` reads that record back.
+
+The question this answers is the one an operator asks before letting an AI
+agent near a production cluster: **what exactly did it run, where, and when.**
+
+```bash
+kubently audit
+```
+
+```
+Audit trail for team-a — 3 entries
+
+TIME                  CLUSTER           OUTCOME   COMMAND
+2026-08-20 19:25:51   prod-a            failure   get secrets -n default
+2026-08-20 19:25:51   prod-a            success   describe pod web-0 -n default
+2026-08-20 19:25:51   prod-a            success   get pods -n default
+```
+
+## What is recorded
+
+One entry per command executed through `/debug/execute`, written after the
+result comes back so the outcome is real:
+
+| Field | Meaning |
+| --- | --- |
+| `timestamp` | When the command completed (ISO 8601, UTC) |
+| `cluster_id` | Cluster the command ran against |
+| `session_id` | Debug session, when the command belonged to one |
+| `command_id` | Unique ID, correlatable with the API logs |
+| `command` | The full kubectl argv, including defaulted flags like `-n default` |
+| `outcome` | `success`, `failure`, or `timeout` |
+| `error` | The error, truncated to 200 characters |
+| `correlation_id` | A2A correlation ID, when the caller supplied one |
+
+**Command output is deliberately not recorded.** The trail says what ran and
+how it ended, not what came back. Storing kubectl output would put pod logs,
+ConfigMap contents and anything else the agent read into a list that is
+retained for a long time and readable by every holder of the issuing API key.
+
+The same list also holds the authentication events Kubently has always
+written (`api_key_verified`, `executor_token_created`, `executor_token_revoked`).
+`kubently audit` hides those by default; `--all` includes them.
+
+## Scope: you see what you ran
+
+The audit trail is scoped by **service identity** — the `service` half of a
+`service:key` entry in `API_KEYS`. A caller reads the entries their own
+identity produced, and nothing else. There is no parameter that widens this
+and no admin identity that bypasses it: asking for a cluster somebody else
+touched returns an empty list, not their commands.
+
+Two consequences worth knowing before you deploy this:
+
+- **An API key with no service identity cannot read the trail at all.** A bare
+  `key` in `API_KEYS`, rather than `service-name:key`, has no scope to filter
+  on, so `/audit` answers `403` rather than quietly showing it everything. If
+  `kubently audit` returns 403, name your keys.
+- **Identity scoping is not cluster ownership.** Kubently has no model of
+  which clusters belong to which caller — every valid API key may target every
+  registered cluster (see `/debug/execute`). So the trail can answer "the
+  commands *you* ran" but cannot answer "everything that happened to *your*
+  cluster", because the second question has no owner to resolve against. If
+  you need per-tenant cluster isolation, that has to be built at the
+  authorization layer first; audit scoping will follow it.
+
+Entries carrying no identity are dropped from every read rather than shared
+with everybody — the filter fails closed.
+
+## Retention
+
+The trail lives in a single Redis list, `auth:audit`. The numbers below were
+read from a running deployment, not assumed.
+
+**Capped by count, not by time.** Every write runs `LTRIM auth:audit 0 9999`,
+so the list holds the **most recent 10,000 events** and older ones are
+discarded. There is **no TTL** on the key (`TTL auth:audit` returns `-1`); an
+entry is never removed because it aged, only because 10,000 newer ones
+arrived.
+
+**How long 10,000 events actually lasts is shorter than it looks.** The list
+is shared with authentication events, and one `api_key_verified` entry is
+written per authenticated API request. Commands are therefore a minority of
+the list, and a busy deployment can evict a day's commands well before 10,000
+commands have run. Export anything you need to keep:
+
+```bash
+kubently audit --limit 1000 --output csv > audit-$(date +%F).csv
+```
+
+**Durability is snapshot-based.** The Helm chart runs
+`redis-stack-server --dir /data --dbfilename dump.rdb` with `/data` backed by
+a PersistentVolumeClaim (`redis.master.persistence`, 2Gi by default), so the
+trail survives pod restarts and Helm upgrades. It inherits redis-stack's
+default persistence policy, which is RDB snapshots and no append-only file:
+
+```
+save      3600 1 300 100 60 10000
+appendonly no
+```
+
+That means a snapshot after 3600s if at least 1 key changed, after 300s if at
+least 100 changed, or after 60s if at least 10,000 changed. **An ungraceful
+pod termination can lose the entries written since the last snapshot** — up to
+an hour of them on a quiet deployment. If you need the audit trail to be
+durable to the second, set `appendonly yes` on Redis, or ship entries to an
+external log sink as they are produced.
+
+Retention is a property of the deployment. There is deliberately no way to
+change it, extend it, or delete from it through the API — see below.
+
+## Filters
+
+```bash
+kubently audit --cluster prod-a                 # one cluster
+kubently audit --session <session-id>           # one debug session
+kubently audit --since 2h                       # relative: 30s, 15m, 2h, 7d
+kubently audit --since 2026-08-20T10:00:00Z     # or absolute ISO 8601
+kubently audit --until 2026-08-20T18:00:00Z
+kubently audit --limit 500                       # default 100, max 1000
+kubently audit --all                             # include auth events
+```
+
+## Export
+
+`--output json` and `--output csv` write machine-readable records to stdout
+and suppress every decoration, so redirecting them produces a valid file:
+
+```bash
+kubently audit --output json > trail.json
+kubently audit --cluster prod-a --since 7d --output csv > prod-a-week.csv
+```
+
+The CSV is RFC 4180 with a header row and every field quoted, which matters
+because kubectl arguments contain commas (`-l app=web,tier=api`) and quotes
+(`-o jsonpath="{.items[0]}"`).
+
+## API
+
+```
+GET /audit
+```
+
+Authentication: `X-API-Key`. **Read-only** — this path never writes, deletes,
+trims, or alters retention, and no other method is routed at `/audit`.
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
+| `event_type` | all | e.g. `command_executed` |
+| `cluster_id` | all | Only entries for this cluster |
+| `session_id` | all | Only entries for this session |
+| `since` / `until` | unbounded | ISO 8601 timestamps |
+| `limit` | 100 | 1–1000 |
+
+```bash
+curl -H "X-API-Key: team-a:..." \
+  "https://kubently.example.com/audit?cluster_id=prod-a&limit=50"
+```
+
+```json
+{
+  "entries": [
+    {
+      "timestamp": "2026-08-20T19:25:51.952254+00:00",
+      "type": "command_executed",
+      "service_identity": "team-a",
+      "cluster_id": "prod-a",
+      "session_id": "ba9feb75-1699-4c9b-8d69-67640639c351",
+      "command_id": "23a4976c-fc89-4957-9c9c-339ddaa4aa4b",
+      "command": "get secrets -n default",
+      "outcome": "failure",
+      "error": "Error from server (Forbidden): secrets is forbidden",
+      "correlation_id": null
+    }
+  ],
+  "count": 1,
+  "service_identity": "team-a"
+}
+```
+
+`service_identity` is echoed back so an exported file records whose trail it
+is.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@
 - **[OAUTH_USAGE.md](OAUTH_USAGE.md)** - OAuth/OIDC login flow for the CLI
 - **[TLS_DEPLOYMENT.md](TLS_DEPLOYMENT.md)** - TLS termination patterns
 - **[MULTI_CLUSTER_TLS.md](MULTI_CLUSTER_TLS.md)** - TLS between remote executors and the central API
+- **[AUDIT.md](AUDIT.md)** - The command audit trail: `kubently audit`, the read API, scoping and retention
 
 ### Operations & Development
 - **[DEVELOPMENT.md](DEVELOPMENT.md)** - Developer guide, testing, and contribution guidelines

--- a/docs/modules/02-auth.md
+++ b/docs/modules/02-auth.md
@@ -274,6 +274,12 @@ Redis keys used:
 - `agent:token:{cluster_id}`: Dynamic agent tokens
 - `auth:audit`: Security event audit log with correlation IDs
 
+`auth:audit` is shared with the command audit trail: the audit module writes
+`command_executed` entries to the same list, and `GET /audit` reads both back
+scoped to the caller's service identity. The list is capped at the most recent
+10,000 events by `LTRIM` and carries no TTL. See **[AUDIT.md](../AUDIT.md)**
+for the read path, the scoping rule and the retention/durability details.
+
 ## Security Requirements
 
 1. **Constant-time comparison**: Use `secrets.compare_digest()` for all token comparisons

--- a/kubently-cli/nodejs/README.md
+++ b/kubently-cli/nodejs/README.md
@@ -17,6 +17,14 @@ A modern, beautiful Node.js/TypeScript implementation of the Kubently CLI - your
 - **Cluster Management**: Add, list, status check, and remove clusters
 - **Token Generation**: Automatic agent token creation and management
 
+### 📜 Audit Trail
+- **`kubently audit`**: See what the agent actually ran — cluster, time, command, outcome
+- **Filters**: By cluster, debug session, and time range (`--since 2h`)
+- **Export**: `--output json` / `--output csv` for compliance evidence
+- **Scoped**: You read the commands your own API key ran, and nothing else
+
+See [docs/AUDIT.md](../../docs/AUDIT.md) for scoping and retention.
+
 ### 🐛 A2A Debug Mode
 - **Interactive Terminal**: Real-time chat interface with the Kubently agent
 - **Natural Language**: Ask questions in plain English
@@ -133,6 +141,7 @@ nodejs-cli/
 │   │   ├── init.ts        # Configuration setup
 │   │   ├── cluster.ts     # Cluster management
 │   │   ├── exec.ts        # Command execution
+│   │   ├── audit.ts       # Audit trail listing and export
 │   │   └── debug.ts       # A2A debug session
 │   └── lib/              # Core libraries
 │       ├── config.ts      # Configuration management

--- a/kubently-cli/nodejs/src/commands/audit.test.ts
+++ b/kubently-cli/nodejs/src/commands/audit.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `kubently audit` export contract.
+ *
+ * The point of the subcommand is that its output can be handed to something
+ * else -- a spreadsheet, a compliance reviewer, `jq`. So the two things worth
+ * guarding are the ones that break silently: the CSV must survive kubectl
+ * arguments containing commas and quotes, and the JSON must round-trip.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { toCsv, parseSince } from './audit.js';
+import { AuditEntry } from '../lib/adminClient.js';
+
+function entry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    timestamp: '2026-08-20T10:00:00+00:00',
+    type: 'command_executed',
+    service_identity: 'team-a',
+    cluster_id: 'prod-a',
+    session_id: 'sess-1',
+    command_id: 'cmd-1',
+    command: 'get pods -n kube-system',
+    outcome: 'success',
+    error: null,
+    correlation_id: null,
+    ...overrides,
+  };
+}
+
+describe('CSV export', () => {
+  it('emits a header row followed by one row per entry', () => {
+    const lines = toCsv([entry(), entry({ command_id: 'cmd-2' })]).split('\n');
+
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe(
+      'timestamp,type,cluster_id,session_id,command_id,command,outcome,error,correlation_id'
+    );
+  });
+
+  it('survives commas and quotes in a command', () => {
+    // `-l app=web,tier=api` is an ordinary selector, and an unquoted comma
+    // would shift every column after it by one.
+    const csv = toCsv([
+      entry({ command: 'get pods -l app=web,tier=api -o jsonpath="{.items[0]}"' }),
+    ]);
+    const row = csv.split('\n')[1];
+
+    expect(row).toContain('"get pods -l app=web,tier=api -o jsonpath=""{.items[0]}"""');
+    // One field per column: quoting keeps the embedded comma inside its field.
+    expect(row.match(/","/g)).toHaveLength(8);
+  });
+
+  it('renders nulls as empty fields rather than the string "null"', () => {
+    const row = toCsv([entry({ error: null, session_id: null })]).split('\n')[1];
+    expect(row).not.toContain('null');
+    expect(row).toContain('""');
+  });
+
+  it('emits a usable header even with no entries', () => {
+    expect(toCsv([])).toBe(
+      'timestamp,type,cluster_id,session_id,command_id,command,outcome,error,correlation_id'
+    );
+  });
+});
+
+describe('JSON export', () => {
+  it('round-trips', () => {
+    const entries = [entry(), entry({ outcome: 'failure', error: 'Forbidden' })];
+    expect(JSON.parse(JSON.stringify(entries))).toEqual(entries);
+  });
+});
+
+describe('--since parsing', () => {
+  it('accepts relative offsets', () => {
+    const before = Date.now();
+    const parsed = Date.parse(parseSince('2h'));
+
+    expect(before - parsed).toBeGreaterThanOrEqual(2 * 3600 * 1000);
+    expect(before - parsed).toBeLessThan(2 * 3600 * 1000 + 5000);
+  });
+
+  it('accepts every supported unit', () => {
+    // `now` is sampled after each call: sampling it once up front makes the
+    // offset come out a millisecond short and the test flaky.
+    const ago = (spec: string) => Date.now() - Date.parse(parseSince(spec));
+
+    expect(ago('30s')).toBeGreaterThanOrEqual(30 * 1000);
+    expect(ago('30m')).toBeGreaterThanOrEqual(30 * 60 * 1000);
+    expect(ago('7d')).toBeGreaterThanOrEqual(7 * 86400 * 1000);
+  });
+
+  it('passes absolute times through as ISO 8601', () => {
+    expect(parseSince('2026-08-20T10:00:00Z')).toBe('2026-08-20T10:00:00.000Z');
+  });
+
+  it('rejects something that is not a time', () => {
+    expect(() => parseSince('last tuesday')).toThrow(/Invalid time/);
+  });
+});

--- a/kubently-cli/nodejs/src/commands/audit.ts
+++ b/kubently-cli/nodejs/src/commands/audit.ts
@@ -1,0 +1,162 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { Config } from '../lib/config.js';
+import { KubentlyAdminClient, AuditEntry } from '../lib/adminClient.js';
+
+/**
+ * `kubently audit` - read back the command audit trail.
+ *
+ * The API decides what this caller may see; the CLI only asks and formats.
+ * There is deliberately no flag here for reading somebody else's scope,
+ * because there is no such request to make.
+ */
+
+/** ISO 8601 for an absolute time, or a relative offset like `2h` / `7d`. */
+export function parseSince(value: string): string {
+  const relative = /^(\d+)([smhd])$/.exec(value.trim());
+  if (relative) {
+    const amount = Number(relative[1]);
+    const seconds = { s: 1, m: 60, h: 3600, d: 86400 }[relative[2]]!;
+    return new Date(Date.now() - amount * seconds * 1000).toISOString();
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid time '${value}'. Use ISO 8601 (2026-08-20T10:00:00Z) or an offset (30m, 2h, 7d).`);
+  }
+  return parsed.toISOString();
+}
+
+/** The columns an export carries, in order. */
+const COLUMNS: Array<keyof AuditEntry> = [
+  'timestamp',
+  'type',
+  'cluster_id',
+  'session_id',
+  'command_id',
+  'command',
+  'outcome',
+  'error',
+  'correlation_id',
+];
+
+/**
+ * RFC 4180: quote every field, double the embedded quotes. Quoting
+ * unconditionally is shorter than deciding when to, and kubectl arguments are
+ * full of commas and spaces that would otherwise need the decision.
+ */
+export function toCsv(entries: AuditEntry[]): string {
+  const escape = (value: unknown): string => `"${String(value ?? '').replace(/"/g, '""')}"`;
+  const rows = entries.map((entry) => COLUMNS.map((column) => escape(entry[column])).join(','));
+  return [COLUMNS.join(','), ...rows].join('\n');
+}
+
+function renderTable(entries: AuditEntry[]): void {
+  console.log(
+    chalk.gray('TIME'.padEnd(22)) +
+      chalk.gray('CLUSTER'.padEnd(18)) +
+      chalk.gray('OUTCOME'.padEnd(10)) +
+      chalk.gray('COMMAND')
+  );
+
+  for (const entry of entries) {
+    // Second precision: an audit list is scanned by eye, and milliseconds
+    // push the command column off an 80-column terminal.
+    const time = (entry.timestamp || '').replace('T', ' ').slice(0, 19);
+    const outcome = entry.outcome || '-';
+    const colour =
+      outcome === 'success' ? chalk.green : outcome === 'timeout' ? chalk.yellow : outcome === '-' ? chalk.gray : chalk.red;
+
+    console.log(
+      chalk.white(time.padEnd(22)) +
+        chalk.cyan((entry.cluster_id || '-').padEnd(18)) +
+        colour(outcome.padEnd(10)) +
+        chalk.white(entry.command || entry.type)
+    );
+  }
+}
+
+export function auditCommand(config: Config): Command {
+  const audit = new Command('audit');
+
+  audit
+    .description('📜 Show the command audit trail (read-only)')
+    .option('-c, --cluster <cluster-id>', 'Only commands run against this cluster')
+    .option('-s, --session <session-id>', 'Only commands from this debug session')
+    .option('--since <time>', 'Only entries after this time (ISO 8601, or 30m/2h/7d)')
+    .option('--until <time>', 'Only entries before this time (ISO 8601, or 30m/2h/7d)')
+    .option('-n, --limit <count>', 'Maximum entries to show', '100')
+    .option('--all', 'Include authentication events, not just executed commands', false)
+    .option('-o, --output <format>', 'Output format: table, json, or csv', 'table')
+    .action(async (options) => {
+      const apiUrl = config.getApiUrl();
+      const apiKey = config.getApiKey();
+
+      if (!apiUrl || !apiKey) {
+        console.log(chalk.red('✗ API URL and API key are required.'));
+        console.log(chalk.yellow('Run "kubently init" or set environment variables:'));
+        console.log(chalk.gray('  export KUBENTLY_API_URL=http://your-api-url'));
+        console.log(chalk.gray('  export KUBENTLY_API_KEY=your-api-key'));
+        process.exit(1);
+      }
+
+      const format = String(options.output).toLowerCase();
+      if (!['table', 'json', 'csv'].includes(format)) {
+        console.log(chalk.red(`✗ Unknown output format '${options.output}'. Use table, json, or csv.`));
+        process.exit(1);
+      }
+
+      // Machine-readable output owns stdout: a spinner or a banner in the
+      // middle of a JSON document makes the export unparseable.
+      const quiet = format !== 'table';
+      const spinner = quiet ? null : ora('Fetching audit trail...').start();
+
+      try {
+        const client = new KubentlyAdminClient(apiUrl, apiKey);
+        const result = await client.getAudit({
+          // The trail shares one Redis list with an `api_key_verified` event
+          // per authenticated request, which outnumbers the commands several
+          // to one. Default to the commands; --all shows the rest.
+          event_type: options.all ? undefined : 'command_executed',
+          cluster_id: options.cluster,
+          session_id: options.session,
+          since: options.since ? parseSince(options.since) : undefined,
+          until: options.until ? parseSince(options.until) : undefined,
+          limit: Number(options.limit),
+        });
+
+        spinner?.stop();
+
+        if (format === 'json') {
+          console.log(JSON.stringify(result.entries, null, 2));
+          return;
+        }
+        if (format === 'csv') {
+          console.log(toCsv(result.entries));
+          return;
+        }
+
+        if (result.entries.length === 0) {
+          console.log(chalk.yellow('No audit entries found for this API key.'));
+          console.log(
+            chalk.gray(`The trail is scoped to '${result.service_identity}' — it shows the commands this key ran.`)
+          );
+          if (!options.all) {
+            console.log(chalk.gray('Pass --all to include authentication events.'));
+          }
+          return;
+        }
+
+        console.log(chalk.cyan(`\nAudit trail for ${chalk.bold(result.service_identity)} — ${result.count} entr${result.count === 1 ? 'y' : 'ies'}\n`));
+        renderTable(result.entries);
+        console.log('');
+      } catch (error) {
+        spinner?.fail('Failed to fetch audit trail');
+        console.log(chalk.red(`✗ Error: ${error instanceof Error ? error.message : 'Unknown error'}`));
+        process.exit(1);
+      }
+    });
+
+  return audit;
+}

--- a/kubently-cli/nodejs/src/commands/wiring.test.ts
+++ b/kubently-cli/nodejs/src/commands/wiring.test.ts
@@ -27,6 +27,7 @@ import { initCommand } from './init.js';
 import { installCommand } from './install.js';
 import { clusterCommands } from './cluster.js';
 import { debugCommand } from './debug.js';
+import { auditCommand } from './audit.js';
 import { execCommand } from './exec.js';
 import { createLoginCommand } from './login.js';
 import { Config } from '../lib/config.js';
@@ -45,6 +46,7 @@ describe('command factories', () => {
     ['install', () => installCommand(config)],
     ['cluster', () => clusterCommands(config)],
     ['debug', () => debugCommand(config)],
+    ['audit', () => auditCommand(config)],
     ['exec', () => execCommand(config)],
     ['login', () => createLoginCommand()],
   ];
@@ -93,8 +95,37 @@ describe('root program wiring', () => {
     program.addCommand(mcpCommand(config));
     program.addCommand(initCommand(config));
     program.addCommand(clusterCommands(config));
+    program.addCommand(auditCommand(config));
 
-    expect(program.commands.map((c) => c.name()).sort()).toEqual(['cluster', 'init', 'mcp']);
+    expect(program.commands.map((c) => c.name()).sort()).toEqual([
+      'audit',
+      'cluster',
+      'init',
+      'mcp',
+    ]);
+  });
+
+  it('parses the audit filter flags into the keys the handler reads', () => {
+    // The action reads opts.cluster / opts.session / opts.since / opts.limit /
+    // opts.output. A rename in commander's derivation turns each into
+    // undefined, which silently drops the filter and exports the wrong scope.
+    const cmd = auditCommand(config);
+    cmd.action(() => {});
+    cmd.parse(
+      ['--cluster', 'prod-a', '--session', 's1', '--since', '2h', '--limit', '5', '--output', 'csv'],
+      { from: 'user' }
+    );
+
+    const opts = cmd.opts();
+    expect(opts.cluster).toBe('prod-a');
+    expect(opts.session).toBe('s1');
+    expect(opts.since).toBe('2h');
+    expect(opts.limit).toBe('5');
+    expect(opts.output).toBe('csv');
+  });
+
+  it('defaults audit output to the human-readable table', () => {
+    expect(auditCommand(config).opts().output).toBe('table');
   });
 
   it('maps --a2a-path to opts.a2aPath and defaults --debug to false', () => {

--- a/kubently-cli/nodejs/src/index.ts
+++ b/kubently-cli/nodejs/src/index.ts
@@ -8,6 +8,7 @@ import { installCommand } from './commands/install.js';
 import { mcpCommand } from './commands/mcp.js';
 import { clusterCommands } from './commands/cluster.js';
 import { debugCommand } from './commands/debug.js';
+import { auditCommand } from './commands/audit.js';
 import { createLoginCommand } from './commands/login.js';
 import { Config } from './lib/config.js';
 import { runInteractiveMode } from './commands/interactive.js';
@@ -49,7 +50,15 @@ program
   .hook('preAction', (thisCommand) => {
     // Show banner for main commands (not subcommands).
     // Never for `mcp`: an MCP client owns stdout — any stray output corrupts the JSON-RPC stream.
-    if (thisCommand.name() === 'kubently' && process.argv.length > 2 && process.argv[2] !== 'mcp') {
+    // Never for `audit` either: its whole purpose is emitting a record, and
+    // `kubently audit --output json > trail.json` produced a file starting with
+    // ASCII art, which no JSON parser accepts.
+    const stdoutIsData = ['mcp', 'audit'];
+    if (
+      thisCommand.name() === 'kubently' &&
+      process.argv.length > 2 &&
+      !stdoutIsData.includes(process.argv[2])
+    ) {
       showBanner();
     }
     
@@ -80,6 +89,7 @@ program.addCommand(initCommand(config));
 program.addCommand(createLoginCommand());
 program.addCommand(clusterCommands(config));
 program.addCommand(debugCommand(config));
+program.addCommand(auditCommand(config));
 
 // Admin command - direct access to admin operations
 program

--- a/kubently-cli/nodejs/src/lib/adminClient.ts
+++ b/kubently-cli/nodejs/src/lib/adminClient.ts
@@ -36,6 +36,34 @@ export interface ClusterListItem {
   lastSeen?: string;
 }
 
+export interface AuditEntry {
+  timestamp: string | null;
+  type: string;
+  service_identity: string | null;
+  cluster_id: string | null;
+  session_id: string | null;
+  command_id: string | null;
+  command: string | null;
+  outcome: string | null;
+  error: string | null;
+  correlation_id: string | null;
+}
+
+export interface AuditResponse {
+  entries: AuditEntry[];
+  count: number;
+  service_identity: string;
+}
+
+export interface AuditQuery {
+  event_type?: string;
+  cluster_id?: string;
+  session_id?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+}
+
 export interface CommandResult {
   success: boolean;
   output?: string;
@@ -113,6 +141,20 @@ export class KubentlyAdminClient {
       cluster_id: clusterId,
       args,
     });
+    return response.data;
+  }
+
+  /**
+   * Read the audit trail. The API scopes the result to this key's own
+   * identity; there is no parameter that widens it.
+   */
+  async getAudit(params: AuditQuery = {}): Promise<AuditResponse> {
+    // Undefined filters are dropped rather than sent as empty strings, which
+    // the API would treat as a filter matching nothing.
+    const query = Object.fromEntries(
+      Object.entries(params).filter(([, value]) => value !== undefined && value !== '')
+    );
+    const response = await this.client.get('/audit', { params: query });
     return response.data;
   }
 

--- a/kubently/main.py
+++ b/kubently/main.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import redis.asyncio as redis
 import uvicorn
-from fastapi import Body, Depends, FastAPI, Header, HTTPException, Request, Response
+from fastapi import Body, Depends, FastAPI, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
 from sse_starlette.sse import EventSourceResponse
@@ -32,6 +32,7 @@ from kubently.logging_config import get_logging_config
 from kubently.modules.a2a import a2a_enabled, create_a2a_server
 from kubently.modules.api import (
     ArgoCDQueryRequest,
+    AuditResponse,
     CommandResponse,
     CommandResult,
     CreateSessionRequest,
@@ -45,6 +46,7 @@ from kubently.modules.api import (
     SessionStatus,
 )
 from kubently.modules.api.oidc_discovery import create_discovery_router
+from kubently.modules.audit import AuditModule
 from kubently.modules.auth.factory import AuthFactory
 from kubently.modules.auth.service import AuthenticationService
 from kubently.modules.capability import CapabilityModule, ExecutorCapabilities
@@ -69,6 +71,7 @@ auth_service: AuthenticationService | None = None
 session_module: SessionModule | None = None
 queue_module: QueueModule | None = None
 capability_module: CapabilityModule | None = None
+audit_module: AuditModule | None = None
 redis_client: redis.Redis | None = None
 a2a_server = None  # A2A server instance
 a2a_app = None  # A2A FastAPI sub-application
@@ -122,6 +125,7 @@ async def lifespan(app: FastAPI):
     Manage application lifecycle - initialize and cleanup resources.
     """
     global auth_service, session_module, queue_module, capability_module, redis_client, a2a_server
+    global audit_module
 
     # Startup
     logger.info("Starting Kubently API  ...")
@@ -139,6 +143,7 @@ async def lifespan(app: FastAPI):
     capability_module = CapabilityModule(
         redis_client, default_ttl=config.get("capability_ttl", 3600)
     )
+    audit_module = AuditModule(redis_client)
 
     # Mount A2A server (core functionality)
     # Get external URL for A2A (for agent card)
@@ -796,6 +801,39 @@ async def execute_command(
     if result and result.get("success") and not request.session_id:
         await redis_client.expire(cluster_active_key, 60)
     # === END OPTIONAL ===
+
+    # Record what ran, where, and how it ended -- but never the output. This is
+    # the only writer of `command_executed` entries; `GET /audit` reads them
+    # back. Recording happens after the result (or the timeout) is known so the
+    # entry carries a real outcome, and never raises: an audit write must not
+    # be able to fail a command that already executed against the cluster.
+    _, caller_identity = auth_info
+    if audit_module:
+        # Outcome comes from `success`, not from `status`. The executor posts a
+        # CommandResult, whose model has no `status` field at all -- so the
+        # `result.get("status", SUCCESS)` used for the HTTP response below
+        # always falls through to "success", and a kubectl call that came back
+        # Forbidden would be filed as a successful one. An audit trail that
+        # records every denied command as succeeded is worse than no trail.
+        if not result:
+            outcome = str(ExecutionStatus.TIMEOUT)
+            error = "Command execution timeout"
+        else:
+            outcome = str(
+                ExecutionStatus.SUCCESS if result.get("success") else ExecutionStatus.FAILURE
+            )
+            error = result.get("error")
+
+        await audit_module.record_command(
+            service_identity=caller_identity,
+            cluster_id=request.cluster_id,
+            command_id=command["id"],
+            args=kubectl_args,
+            session_id=request.session_id,
+            outcome=outcome,
+            error=error,
+            correlation_id=x_correlation_id or request.correlation_id,
+        )
 
     if not result:
         return CommandResponse(
@@ -1531,6 +1569,68 @@ async def get_cluster_detail(
 
 
 # Health/Monitoring Endpoints
+
+
+def _parse_audit_time(value: str | None, field: str) -> datetime | None:
+    """Parse an ISO 8601 query parameter, defaulting a naive value to UTC."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        raise HTTPException(400, f"Invalid {field}: expected ISO 8601, got '{value}'") from None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+@app.get("/audit", response_model=AuditResponse)
+async def get_audit(
+    event_type: str | None = Query(None, description="Only this event type, e.g. command_executed"),
+    cluster_id: str | None = Query(None, description="Only entries targeting this cluster"),
+    session_id: str | None = Query(None, description="Only entries from this debug session"),
+    since: str | None = Query(None, description="Only entries at or after this ISO 8601 time"),
+    until: str | None = Query(None, description="Only entries at or before this ISO 8601 time"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum entries to return"),
+    auth_info: tuple[bool, str | None] = Depends(verify_api_key),
+):
+    """
+    Read the command audit trail. Read-only.
+
+    This endpoint never writes: it issues a single LRANGE and returns what it
+    finds. There is deliberately no companion POST/PUT/DELETE, and no way to
+    reach the list's TTL or trim behaviour from here -- retention is a property
+    of the deployment (see docs/AUDIT.md), not something a caller may adjust.
+
+    **Scope.** The response contains only entries stamped with the caller's own
+    service identity. There is no parameter that widens that, and no admin
+    identity that bypasses it. A caller who asks for a cluster only somebody
+    else has touched gets an empty list, not somebody else's commands.
+
+    Because scoping keys off the identity, an API key configured without one
+    (a bare `key` rather than `service:key` in API_KEYS) has no scope to read
+    and is refused, rather than being quietly shown everything.
+    """
+    if not audit_module:
+        raise HTTPException(503, "Service not initialized")
+
+    _, identity = auth_info
+    if not identity:
+        raise HTTPException(
+            403,
+            "This API key has no service identity, so its audit scope cannot be "
+            "determined. Configure the key as 'service-name:key' in API_KEYS.",
+        )
+
+    entries = await audit_module.query(
+        identity=identity,
+        event_type=event_type,
+        cluster_id=cluster_id,
+        session_id=session_id,
+        since=_parse_audit_time(since, "since"),
+        until=_parse_audit_time(until, "until"),
+        limit=limit,
+    )
+
+    return AuditResponse(entries=entries, count=len(entries), service_identity=identity)
 
 
 @app.get("/healthz")

--- a/kubently/modules/api/__init__.py
+++ b/kubently/modules/api/__init__.py
@@ -12,6 +12,8 @@ All logic is delegated to appropriate modules.
 from .models import (
     ArgoCDOperation,
     ArgoCDQueryRequest,
+    AuditEntry,
+    AuditResponse,
     CommandResponse,
     CommandResult,
     CreateSessionRequest,
@@ -31,6 +33,8 @@ from .models import (
 __all__ = [
     "ArgoCDOperation",
     "ArgoCDQueryRequest",
+    "AuditEntry",
+    "AuditResponse",
     "CommandResponse",
     "CommandResult",
     "CreateSessionRequest",

--- a/kubently/modules/api/models.py
+++ b/kubently/modules/api/models.py
@@ -524,6 +524,36 @@ class CommandResponse(BaseModel):
     executed_at: datetime | None = Field(None, description="When command was executed")
 
 
+class AuditEntry(BaseModel):
+    """One entry from the audit trail.
+
+    Flat on purpose: `kubently audit --output csv` writes these fields as
+    columns, and a nested shape would force the CLI to invent a flattening
+    rule the API does not define.
+    """
+
+    timestamp: str | None = Field(None, description="When the event was recorded (ISO 8601)")
+    type: str = Field(..., description="Event type, e.g. command_executed")
+    service_identity: str | None = Field(None, description="Identity the entry belongs to")
+    cluster_id: str | None = Field(None, description="Cluster the command targeted")
+    session_id: str | None = Field(None, description="Debug session, if the command had one")
+    command_id: str | None = Field(None, description="Unique command ID")
+    command: str | None = Field(None, description="kubectl arguments that were run")
+    outcome: str | None = Field(None, description="success, failure, or timeout")
+    error: str | None = Field(None, description="Truncated error message, if the command failed")
+    correlation_id: str | None = Field(None, description="Correlation ID for A2A tracing")
+
+
+class AuditResponse(BaseModel):
+    """Response listing audit entries, newest first."""
+
+    entries: list[AuditEntry]
+    count: int
+    # Echoed back so an exported file is self-describing about whose trail it
+    # is -- an audit export with no subject on it is not evidence of much.
+    service_identity: str
+
+
 class HealthResponse(BaseModel):
     """Health check response."""
 

--- a/kubently/modules/audit/__init__.py
+++ b/kubently/modules/audit/__init__.py
@@ -1,0 +1,5 @@
+"""Audit module: records and surfaces the command/security audit trail."""
+
+from kubently.modules.audit.audit import AUDIT_KEY, AUDIT_MAX_ENTRIES, AuditModule
+
+__all__ = ["AUDIT_KEY", "AUDIT_MAX_ENTRIES", "AuditModule"]

--- a/kubently/modules/audit/audit.py
+++ b/kubently/modules/audit/audit.py
@@ -1,0 +1,218 @@
+"""
+Audit module.
+
+The audit trail lives in a single Redis list, `auth:audit`, which
+`AuthModule._log_event` has always written authentication events to. This
+module adds the one event type an operator actually asks for -- "what command
+did the agent run, where, and did it work" -- and provides the only read path
+over the list.
+
+Two properties are load-bearing and are covered by tests/test_audit.py:
+
+1. **Read-only.** `query()` issues exactly one `LRANGE`. Nothing in the read
+   path writes, deletes, trims or re-expires the key. The HTTP surface built
+   on it is a single GET.
+
+2. **Identity-scoped.** Every entry carries the `service_identity` that caused
+   it, and `query()` returns only the entries belonging to the caller's own
+   identity. An entry with no identity on it is *dropped*, never shared: the
+   filter fails closed, so a new event type that forgets to stamp an identity
+   becomes invisible rather than becoming everybody's.
+
+   Identity is the strongest scope Kubently can currently enforce. There is no
+   tenant -> cluster ownership model anywhere in the codebase (every API key
+   may target every registered cluster), so "your clusters" is not yet a
+   question the data can answer; "the commands you ran" is. See docs/AUDIT.md.
+
+Command *output* is deliberately not recorded. The audit trail answers what
+was run, against what, by whom, and whether it succeeded -- reproducing
+kubectl output into a 10,000-entry list that every holder of the issuing API
+key can read would widen the blast radius of the audit log well past its
+purpose.
+"""
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The list AuthModule has always written to. Shared deliberately: one audit
+# trail, one retention rule, one thing to back up.
+AUDIT_KEY = "auth:audit"
+
+# Mirrors the `ltrim(AUDIT_KEY, 0, 9999)` AuthModule applies on every write.
+# The list is capped by count, not by time, and carries no TTL -- see the
+# retention section of docs/AUDIT.md.
+AUDIT_MAX_ENTRIES = 10000
+
+# Errors are kept because "it ran and was denied" is the outcome operators
+# care about, but they are truncated: an error body is the one field an
+# executor can echo unbounded attacker-influenced text into.
+MAX_ERROR_CHARS = 200
+
+COMMAND_EVENT = "command_executed"
+
+
+def _decode(value: Any) -> str | None:
+    """Redis clients here are configured either way; tolerate both."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    text = _decode(value)
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    # Entries written before the timezone-aware `datetime.now(UTC)` switch are
+    # naive; treat them as UTC rather than crashing the comparison below.
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _identity_of(event: dict) -> str | None:
+    """The identity an entry belongs to, or None if it is unattributed."""
+    data = event.get("data")
+    if not isinstance(data, dict):
+        return None
+    identity = data.get("service_identity")
+    if isinstance(identity, str) and identity:
+        return identity
+    return None
+
+
+class AuditModule:
+    """Records command events and reads the audit trail back, scoped."""
+
+    def __init__(self, redis_client):
+        self.redis = redis_client
+
+    async def record_command(
+        self,
+        *,
+        service_identity: str | None,
+        cluster_id: str,
+        command_id: str,
+        args: list[str] | None = None,
+        session_id: str | None = None,
+        outcome: str = "unknown",
+        error: str | None = None,
+        correlation_id: str | None = None,
+    ) -> None:
+        """
+        Record one executed command.
+
+        Never raises: an audit write must not be able to fail a command that
+        already ran. A dropped entry is logged loudly instead.
+        """
+        now = datetime.now(UTC).isoformat()
+        event = {
+            "type": COMMAND_EVENT,
+            "data": {
+                "service_identity": service_identity,
+                "cluster_id": cluster_id,
+                "session_id": session_id,
+                "command_id": command_id,
+                # Joined for display; the args themselves are the audit record.
+                "command": " ".join(args or []),
+                "outcome": outcome,
+                "error": (error or "")[:MAX_ERROR_CHARS] or None,
+                "timestamp": now,
+            },
+            "correlation_id": correlation_id,
+            "timestamp": now,
+        }
+
+        try:
+            await self.redis.lpush(AUDIT_KEY, json.dumps(event))
+            await self.redis.ltrim(AUDIT_KEY, 0, AUDIT_MAX_ENTRIES - 1)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to record audit entry for command %s: %s", command_id, exc)
+
+    async def query(
+        self,
+        *,
+        identity: str | None,
+        event_type: str | None = None,
+        cluster_id: str | None = None,
+        session_id: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """
+        Read audit entries belonging to `identity`, newest first.
+
+        Read-only: one LRANGE, no writes. Returns [] for an absent identity
+        rather than falling back to "everything" -- the failure mode of a
+        scoped read must be no data, not all data.
+        """
+        if not identity:
+            return []
+
+        raw_entries = await self.redis.lrange(AUDIT_KEY, 0, AUDIT_MAX_ENTRIES - 1)
+
+        results: list[dict] = []
+        for raw in raw_entries:
+            text = _decode(raw)
+            if not text:
+                continue
+            try:
+                event = json.loads(text)
+            except (ValueError, TypeError):
+                # AuthModule's docs once showed `str(event)` rather than
+                # json.dumps; skip anything unparseable instead of failing the
+                # whole read.
+                continue
+            if not isinstance(event, dict):
+                continue
+
+            # === SCOPE GATE ===
+            # The only line that decides who sees what. Everything below is
+            # display filtering and must never be able to widen this.
+            if _identity_of(event) != identity:
+                continue
+            # === END SCOPE GATE ===
+
+            data = event.get("data") or {}
+            if event_type and event.get("type") != event_type:
+                continue
+            if cluster_id and data.get("cluster_id") != cluster_id:
+                continue
+            if session_id and data.get("session_id") != session_id:
+                continue
+
+            timestamp = _parse_timestamp(event.get("timestamp")) or _parse_timestamp(
+                data.get("timestamp")
+            )
+            if since and (timestamp is None or timestamp < since):
+                continue
+            if until and (timestamp is None or timestamp > until):
+                continue
+
+            results.append(
+                {
+                    "timestamp": _decode(event.get("timestamp")),
+                    "type": _decode(event.get("type")) or "unknown",
+                    "service_identity": _identity_of(event),
+                    "cluster_id": data.get("cluster_id"),
+                    "session_id": data.get("session_id"),
+                    "command_id": data.get("command_id"),
+                    "command": data.get("command"),
+                    "outcome": data.get("outcome"),
+                    "error": data.get("error"),
+                    "correlation_id": _decode(event.get("correlation_id")),
+                }
+            )
+
+            if len(results) >= limit:
+                break
+
+        return results

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""The audit trail is readable, exportable, scoped, and read-only (issue #55).
+
+`auth:audit` has always existed but nothing surfaced it, so "what did the
+agent run, where, and when" meant reading Redis by hand. These tests cover the
+three properties that make surfacing it safe rather than just convenient:
+
+- a command executed through /debug/execute turns into an entry carrying
+  cluster, timestamp and outcome, and that entry survives a JSON round-trip;
+- a caller reads only their own identity's entries -- never another
+  identity's, by any combination of filters, and never an unattributed one;
+- the read path does not write. Not a trim, not a TTL, not a delete.
+"""
+
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+fakeredis = pytest.importorskip("fakeredis")
+
+import kubently.main as main
+from kubently.modules.audit import AUDIT_KEY, AuditModule
+
+TEAM_A = "team-a"
+TEAM_B = "team-b"
+CLUSTER_A = "prod-a"
+CLUSTER_B = "prod-b"
+
+
+@pytest.fixture
+def redis():
+    return fakeredis.FakeAsyncRedis(decode_responses=True)
+
+
+@pytest.fixture
+def audit(redis):
+    return AuditModule(redis)
+
+
+@pytest.fixture
+def wired(redis, audit, monkeypatch):
+    """main.py wired to a fake Redis with the audit module installed."""
+    monkeypatch.setattr(main, "redis_client", redis)
+    monkeypatch.setattr(main, "audit_module", audit)
+    return redis
+
+
+async def _record(audit, identity, cluster, **kwargs):
+    await audit.record_command(
+        service_identity=identity,
+        cluster_id=cluster,
+        command_id=kwargs.pop("command_id", "cmd-1"),
+        args=kwargs.pop("args", ["get", "pods"]),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------- round-trip
+
+
+async def test_recorded_command_comes_back_with_cluster_time_and_outcome(audit):
+    """The acceptance criterion: a run command is visible with its context."""
+    await _record(
+        audit,
+        TEAM_A,
+        CLUSTER_A,
+        args=["get", "pods", "-n", "kube-system"],
+        session_id="sess-42",
+        outcome="success",
+    )
+
+    entries = await audit.query(identity=TEAM_A)
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["cluster_id"] == CLUSTER_A
+    assert entry["session_id"] == "sess-42"
+    assert entry["command"] == "get pods -n kube-system"
+    assert entry["outcome"] == "success"
+    assert entry["type"] == "command_executed"
+    # A timestamp that does not parse is not a timestamp.
+    assert datetime.fromisoformat(entry["timestamp"]).tzinfo is not None
+
+
+async def test_failure_outcome_and_truncated_error_are_recorded(audit):
+    await _record(
+        audit, TEAM_A, CLUSTER_A, outcome="failure", error="Error from server (Forbidden): " + "x" * 500
+    )
+
+    (entry,) = await audit.query(identity=TEAM_A)
+    assert entry["outcome"] == "failure"
+    assert entry["error"].startswith("Error from server (Forbidden):")
+    # Errors are the one field an executor can echo unbounded text into.
+    assert len(entry["error"]) == 200
+
+
+async def test_command_output_is_never_stored(audit, redis):
+    """Surfacing the trail must not widen what the trail holds."""
+    await _record(audit, TEAM_A, CLUSTER_A, outcome="success")
+
+    raw = await redis.lrange(AUDIT_KEY, 0, -1)
+    stored = json.loads(raw[0])
+    assert "output" not in stored["data"]
+    assert "output" not in stored
+
+
+async def test_json_export_round_trips(audit):
+    """What the CLI writes with --output json must parse back identically."""
+    await _record(audit, TEAM_A, CLUSTER_A, session_id="sess-1", outcome="success")
+    await _record(audit, TEAM_A, CLUSTER_B, command_id="cmd-2", outcome="failure")
+
+    entries = await audit.query(identity=TEAM_A)
+    assert json.loads(json.dumps(entries)) == entries
+
+
+# ------------------------------------------------------------------ filters
+
+
+async def test_filters_by_cluster_and_session(audit):
+    await _record(audit, TEAM_A, CLUSTER_A, command_id="a", session_id="s1")
+    await _record(audit, TEAM_A, CLUSTER_B, command_id="b", session_id="s2")
+
+    assert [e["command_id"] for e in await audit.query(identity=TEAM_A, cluster_id=CLUSTER_A)] == [
+        "a"
+    ]
+    assert [e["command_id"] for e in await audit.query(identity=TEAM_A, session_id="s2")] == ["b"]
+
+
+async def test_filters_by_time_range(audit, redis):
+    await _record(audit, TEAM_A, CLUSTER_A)
+
+    future = datetime.now(UTC) + timedelta(hours=1)
+    past = datetime.now(UTC) - timedelta(hours=1)
+
+    assert await audit.query(identity=TEAM_A, since=past) != []
+    assert await audit.query(identity=TEAM_A, since=future) == []
+    assert await audit.query(identity=TEAM_A, until=past) == []
+    assert await audit.query(identity=TEAM_A, until=future) != []
+
+
+async def test_newest_first_and_limit_applies(audit):
+    for i in range(5):
+        await _record(audit, TEAM_A, CLUSTER_A, command_id=f"cmd-{i}")
+
+    entries = await audit.query(identity=TEAM_A, limit=2)
+    assert [e["command_id"] for e in entries] == ["cmd-4", "cmd-3"]
+
+
+# -------------------------------------------------------- scope isolation
+
+
+async def test_cross_scope_read_returns_nothing(audit):
+    """The non-negotiable: one identity can never read another's entries."""
+    await _record(audit, TEAM_A, CLUSTER_A, command_id="a-secret", args=["get", "secrets"])
+    await _record(audit, TEAM_B, CLUSTER_B, command_id="b-own")
+
+    b_entries = await audit.query(identity=TEAM_B)
+
+    assert [e["command_id"] for e in b_entries] == ["b-own"]
+    assert all(e["service_identity"] == TEAM_B for e in b_entries)
+    assert "a-secret" not in json.dumps(b_entries)
+
+
+async def test_cross_scope_read_cannot_be_widened_by_filters(audit):
+    """Naming somebody else's cluster/session yields empty, not their data."""
+    await _record(audit, TEAM_A, CLUSTER_A, command_id="a-secret", session_id="a-sess")
+
+    # Team B explicitly targets team A's cluster and session.
+    assert await audit.query(identity=TEAM_B, cluster_id=CLUSTER_A) == []
+    assert await audit.query(identity=TEAM_B, session_id="a-sess") == []
+    assert await audit.query(identity=TEAM_B, limit=1000) == []
+
+
+async def test_unattributed_entries_are_never_returned(audit, redis):
+    """The filter fails closed: no identity means nobody, not everybody.
+
+    AuthModule writes `executor_token_created`/`executor_token_revoked` with a
+    cluster_id and no service_identity. Those must not become readable by the
+    first caller who asks.
+    """
+    await redis.lpush(
+        AUDIT_KEY,
+        json.dumps(
+            {
+                "type": "executor_token_created",
+                "data": {"cluster_id": CLUSTER_A, "timestamp": datetime.now(UTC).isoformat()},
+                "correlation_id": None,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        ),
+    )
+
+    assert await audit.query(identity=TEAM_A) == []
+    assert await audit.query(identity=TEAM_B) == []
+    assert await audit.query(identity=None) == []
+    assert await audit.query(identity="") == []
+
+
+async def test_existing_auth_events_stay_scoped_to_their_own_identity(audit, redis):
+    """AuthModule's api_key_verified entries follow the same rule."""
+    await redis.lpush(
+        AUDIT_KEY,
+        json.dumps(
+            {
+                "type": "api_key_verified",
+                "data": {"service_identity": TEAM_A, "timestamp": datetime.now(UTC).isoformat()},
+                "correlation_id": None,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        ),
+    )
+
+    assert [e["type"] for e in await audit.query(identity=TEAM_A)] == ["api_key_verified"]
+    assert await audit.query(identity=TEAM_B) == []
+
+
+async def test_unparseable_entries_are_skipped_not_fatal(audit, redis):
+    """Old docs showed `str(event)` rather than json.dumps; don't die on it."""
+    await redis.lpush(AUDIT_KEY, "{not json at all")
+    await _record(audit, TEAM_A, CLUSTER_A)
+
+    assert len(await audit.query(identity=TEAM_A)) == 1
+
+
+# ------------------------------------------------------------- read-only
+
+
+async def test_query_only_reads(audit, redis, monkeypatch):
+    """No write command may appear on the read path."""
+    await _record(audit, TEAM_A, CLUSTER_A)
+
+    forbidden = ["lpush", "rpush", "ltrim", "delete", "expire", "set", "setex", "persist", "lrem"]
+    calls = []
+    for name in forbidden:
+
+        def deny(*args, _name=name, **kwargs):
+            calls.append(_name)
+            raise AssertionError(f"read path called {_name}")
+
+        monkeypatch.setattr(redis, name, deny)
+
+    assert len(await audit.query(identity=TEAM_A)) == 1
+    assert calls == []
+
+
+# ------------------------------------------------- /debug/execute wiring
+
+
+async def test_executing_a_command_records_an_audit_entry(wired, audit, monkeypatch):
+    """The end-to-end premise: running a command puts it in the trail.
+
+    Nothing recorded command execution before this change -- `auth:audit` held
+    only authentication events -- so `kubently audit` had nothing to show. This
+    is the test that keeps the writer wired to the endpoint.
+    """
+    from unittest.mock import AsyncMock
+
+    from kubently.modules.api import ExecuteCommandRequest
+
+    await wired.set(f"executor:token:{CLUSTER_A}", "tok")
+
+    queue = AsyncMock()
+    queue.wait_for_result.return_value = {
+        "success": True,
+        "output": "NAME  READY\nweb-0  1/1",
+    }
+    monkeypatch.setattr(main, "queue_module", queue)
+    monkeypatch.setattr(main, "session_module", AsyncMock())
+
+    await main.execute_command(
+        ExecuteCommandRequest(cluster_id=CLUSTER_A, command_type="get", args=["pods"]),
+        auth_info=(True, TEAM_A),
+        x_correlation_id="corr-9",
+        x_request_timeout=5,
+    )
+
+    (entry,) = await audit.query(identity=TEAM_A)
+    assert entry["cluster_id"] == CLUSTER_A
+    # The full argv handed to the executor, not the request as typed: the
+    # defaulted `-n default` is part of what actually ran against the cluster.
+    assert entry["command"] == "get pods -n default"
+    assert entry["outcome"] == "success"
+    assert entry["correlation_id"] == "corr-9"
+    assert entry["timestamp"]
+    # The output came back to the caller but must not reach the trail.
+    assert "web-0" not in json.dumps(entry)
+
+
+async def test_a_denied_command_is_recorded_as_a_failure(wired, audit, monkeypatch):
+    """A Forbidden kubectl call must not be filed as a success.
+
+    The executor posts a CommandResult, which has a `success` field and no
+    `status` field -- so deriving the outcome from `status` silently records
+    every denied command as having succeeded. Caught by running a real session
+    against a real executor, not by reading the model.
+    """
+    from unittest.mock import AsyncMock
+
+    from kubently.modules.api import ExecuteCommandRequest
+
+    await wired.set(f"executor:token:{CLUSTER_A}", "tok")
+
+    queue = AsyncMock()
+    queue.wait_for_result.return_value = {
+        "success": False,
+        "error": "Error from server (Forbidden): secrets is forbidden",
+    }
+    monkeypatch.setattr(main, "queue_module", queue)
+    monkeypatch.setattr(main, "session_module", AsyncMock())
+
+    await main.execute_command(
+        ExecuteCommandRequest(cluster_id=CLUSTER_A, command_type="get", args=["secrets"]),
+        auth_info=(True, TEAM_A),
+        x_correlation_id=None,
+        x_request_timeout=5,
+    )
+
+    (entry,) = await audit.query(identity=TEAM_A)
+    assert entry["outcome"] == "failure"
+    assert "Forbidden" in entry["error"]
+
+
+async def test_a_timed_out_command_is_still_recorded(wired, audit, monkeypatch):
+    """A command that ran and hung is exactly what an operator hunts for."""
+    from unittest.mock import AsyncMock
+
+    from kubently.modules.api import ExecuteCommandRequest
+
+    await wired.set(f"executor:token:{CLUSTER_A}", "tok")
+
+    queue = AsyncMock()
+    queue.wait_for_result.return_value = None
+    monkeypatch.setattr(main, "queue_module", queue)
+    monkeypatch.setattr(main, "session_module", AsyncMock())
+
+    await main.execute_command(
+        ExecuteCommandRequest(cluster_id=CLUSTER_A, command_type="get", args=["pods"]),
+        auth_info=(True, TEAM_A),
+        x_correlation_id=None,
+        x_request_timeout=5,
+    )
+
+    (entry,) = await audit.query(identity=TEAM_A)
+    assert entry["outcome"] == "timeout"
+
+
+# --------------------------------------------------------- HTTP endpoint
+#
+# Driven through the real app so the registered route, its query-parameter
+# parsing and the auth dependency are all exercised -- calling the handler
+# directly would leave FastAPI's Query() defaults unresolved and would not
+# prove which HTTP methods the path actually answers.
+
+
+def _client(identity):
+    """TestClient for the real app, authenticated as `identity`."""
+    main.app.dependency_overrides[main.verify_api_key] = lambda: (True, identity)
+    return TestClient(main.app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    main.app.dependency_overrides.clear()
+
+
+async def test_endpoint_returns_only_the_callers_entries(wired, audit):
+    await _record(audit, TEAM_A, CLUSTER_A, command_id="a-secret")
+    await _record(audit, TEAM_B, CLUSTER_B, command_id="b-own")
+
+    body = _client(TEAM_B).get("/audit").json()
+
+    assert body["service_identity"] == TEAM_B
+    assert body["count"] == 1
+    assert body["entries"][0]["command_id"] == "b-own"
+    assert "a-secret" not in json.dumps(body)
+
+
+async def test_endpoint_cross_scope_read_fails(wired, audit):
+    """Team B asks the API for team A's cluster and gets nothing back."""
+    await _record(audit, TEAM_A, CLUSTER_A, command_id="a-secret", session_id="a-sess")
+
+    client = _client(TEAM_B)
+
+    for params in ({"cluster_id": CLUSTER_A}, {"session_id": "a-sess"}, {"limit": 1000}):
+        response = client.get("/audit", params=params)
+        assert response.status_code == 200
+        assert response.json()["count"] == 0, params
+
+
+async def test_endpoint_refuses_a_key_with_no_identity(wired):
+    """An unscopeable caller is refused, not shown everything."""
+    assert _client(None).get("/audit").status_code == 403
+
+
+async def test_endpoint_rejects_unparseable_time(wired):
+    assert _client(TEAM_A).get("/audit", params={"since": "last tuesday"}).status_code == 400
+
+
+async def test_endpoint_is_read_only(wired, audit):
+    """No mutating method is routed at /audit."""
+    await _record(audit, TEAM_A, CLUSTER_A)
+    client = _client(TEAM_A)
+
+    for method in ("post", "put", "patch", "delete"):
+        response = getattr(client, method)("/audit")
+        assert response.status_code == 405, f"{method.upper()} /audit was routed"


### PR DESCRIPTION
Closes #55

`kubently audit` shows what the agent actually ran. There is a read-only `GET /audit` behind it, and `docs/AUDIT.md` documents scoping and retention.

```
Audit trail for team-a — 3 entries

TIME                  CLUSTER           OUTCOME   COMMAND
2026-08-20 19:33:12   prod-a            failure   get secrets -n default
2026-08-20 19:33:12   prod-a            success   describe pod web-0 -n default
2026-08-20 19:33:12   prod-a            success   get pods -n default
```

## The issue's premise was wrong, and it changed the shape of this PR

The issue says every command is *already* logged to `auth:audit` and merely needs surfacing. It is not. `auth:audit` held authentication events only — `api_key_verified`, `executor_token_created`, `executor_token_revoked` — and **nothing anywhere recorded a command**. (`SessionModule._publish_event`, which would have written `session:events`, has no callers either.)

So surfacing the list as-is would have shipped a `kubently audit` that shows an operator every time a key authenticated and not one command it ran — which fails the acceptance criteria outright. `/debug/execute` therefore now records a `command_executed` entry — cluster, session, kubectl argv, timestamp, outcome — into that same list, written after the result is known so the outcome is real. That is the one thing here that goes beyond "only surface what's there", and it is the minimum that makes the feature exist at all.

**Command output is deliberately not recorded.** The trail says what ran and how it ended, not what came back; errors are kept but truncated to 200 characters. Putting kubectl output into a long-retained list readable by every holder of the issuing API key is exactly the widening the issue warns against.

## Scoping: identity, and honest about what that isn't

Reads are scoped by **service identity** — a caller sees the entries their own identity produced. No parameter widens it, no admin identity bypasses it, and naming another identity's cluster or session returns an empty list. Entries with no identity are dropped from every read rather than shared with everybody, so the filter fails closed. A key with no service identity (a bare `key` rather than `service:key` in `API_KEYS`) has no scope to filter on and gets a `403` rather than being quietly shown everything.

Worth being explicit, because the issue asks for "their own clusters' entries": **Kubently has no tenant→cluster ownership model.** Every valid API key may target every registered cluster — `/debug/execute` checks that a cluster *exists*, never that the caller is entitled to it, and its 404 body enumerates the whole fleet. So "your clusters" is not a question the data can answer today; "the commands you ran" is, and that is what this enforces. `docs/AUDIT.md` states this plainly rather than implying an isolation the authorization layer does not provide. Real per-tenant isolation has to land in authz first; audit scoping will follow it.

## Bug found by running it

`/debug/execute` derived its status from `result.get("status", ExecutionStatus.SUCCESS)`, but executors post a `CommandResult`, **whose model has no `status` field at all** — so the lookup always missed and always defaulted to `SUCCESS`. A `kubectl get secrets` that came back `Error from server (Forbidden)` was recorded as having succeeded. Caught by running a real session against a real executor, not by reading the model. The audit entry now derives its outcome from `success`, the field that exists.

The same defect still affects the `status` on the `CommandResponse` returned to callers (and therefore to the agent). Left alone here as a pre-existing bug outside this change's blast radius — worth its own issue.

## Retention: read, not asserted

- `auth:audit` is capped at the most recent **10,000 events** by `LTRIM`, and has **no TTL** — verified, `TTL auth:audit` returns `-1`.
- The cap is shared with **one `api_key_verified` event per authenticated request**, so commands are a minority of the list and a busy deployment evicts a day's commands well before 10,000 commands have run. `docs/AUDIT.md` says so and points at export.
- Durability is snapshot-based: the chart runs `redis-stack-server --dir /data` on a PVC and inherits redis-stack's defaults, verified from the image as `save 3600 1 300 100 60 10000` and `appendonly no`. An ungraceful pod kill can lose everything since the last snapshot.

## Verification

Not assumed — run against a real Redis container and the real API with two API keys and a fake executor answering commands:

- **Scope isolation.** `team-a` sees its 3 commands, `team-b` sees its 1. `team-b` explicitly requesting `--cluster prod-a` and `?session_id=<team-a's session>&limit=1000` both return `count: 0`, not team-a's data. A key with no service identity gets `403`.
- **JSON round-trip.** `kubently audit -o json > trail.json` parses and re-serializes identically, with outcomes `[failure, success, success]`, all timestamps present and no `output` field anywhere.
- **CSV.** Parses with Python's stdlib `csv.DictReader`; RFC 4180, every field quoted, so `-l app=web,tier=api` doesn't shift columns.
- **Filters.** `--cluster`, `--session`, `--since 1h`, `--until`, `--limit`, `--all` all exercised live.

Running it also caught the banner: `kubently audit -o json > f.json` produced a file starting with ASCII art, which no JSON parser accepts. `audit` now joins `mcp` as a command whose stdout is data.

## Tests

`tests/test_audit.py` (21) — cross-scope reads by every filter combination, unattributed entries never returned, `query()` asserted to call no write command, `/audit` asserted to answer 405 on POST/PUT/PATCH/DELETE, plus the `/debug/execute` wiring for success, failure and timeout. `audit.test.ts` — CSV escaping, null handling, `--since` parsing, JSON round-trip. Wiring contract updated for the new subcommand.

No new dependencies. Chart untouched, so no version bump. Rebased past #111.
