### PR TITLE
Stream the investigation as it happens, and emit a typed tool-call event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## [Unreleased] - 2026-08-21
+
+### Changed
+- **The A2A stream narrates the investigation instead of replaying it (#115).**
+  `agent.run()` awaited `run_agent.ainvoke(...)` and yielded exactly once, at
+  the end. Every `message/stream` subscriber therefore saw the same thing: a
+  `task` event, a long quiet stretch held open only by sse_starlette's
+  keepalive comments, the ENTIRE answer in one `working` frame, and then — after
+  the answer they informed — the tool calls. The connection streamed; the
+  content did not, which is the same experience as no streaming at all plus a
+  longer-lived socket.
+
+  `run()` now drives the same graph with LangGraph's `astream_events`, so the
+  model's text reaches the client as it is produced and each tool call is
+  published the moment it finishes, in the order it ran. **Nothing about what
+  the agent may run changed** — same tools, same permissions, same single graph
+  invocation per request (streaming a diagnosis must not turn it into several
+  billable ones).
+
+  Frames are cut at newline boundaries and the newline they were cut on is
+  dropped, because A2A has no "append without a separator" semantics and
+  consumers join consecutive `working` texts with a newline. The join therefore
+  reconstructs the model's output character for character, which is what let
+  this land without touching a single existing consumer.
+
+### Added
+- **A structured tool-call event, alongside the text that was the protocol
+  (#115).** Nothing emitted a typed tool-call event; the executor wrote
+  `🔧 Tool Call: name({json})` / `✅ Result:` / `❌ Error:` onto a `working`
+  status and that prose *was* the contract, so any consumer wanting to show
+  what the agent ran had to parse it, and a cosmetic change to those strings
+  silently broke all of them.
+
+  A `working` status carrying a tool call now also carries
+  `metadata["kubently/tool_call"]` — `{schema, id, tool, args, outcome, result,
+  error, startedAt, completedAt}` — on both the status update and its message.
+  `schema` is `kubently.tool_call/v1`; a consumer that does not recognise it
+  should fall back to the text.
+
+  **The text is unchanged, byte for byte, on the same frame.** This is additive,
+  not a replacement: kubently-cloud's `dashboard/lib/stream.ts` and
+  `test-automation/test_runner.py` keep parsing exactly what they parsed
+  before, and can adopt the typed fields whenever they like.
+
+  `outcome` is derived from whether the tool *reported an error*, never from a
+  `status` key inside the tool's own payload — that is the #113 bug, where an
+  absent status defaulted to SUCCESS and every denied command was reported as a
+  success.
+
+### Fixed
+- **A run that dies mid-stream now reaches a terminal `failed` status (#115).**
+  The A2A executor caught an exception from the agent loop, put "I encountered
+  an error…" in the artifact and then emitted `completed` — so a subscriber
+  could not tell a dead run from a real answer. Failures (an exception, or an
+  `error` chunk from the agent) now terminate as `failed` with the reason on
+  the terminal status message. The tool calls that *did* run are published
+  first, so a partial investigation still shows how far it got.
+- **The incident-history trace looked up tool calls under the wrong thread id.**
+  It queried the interceptor with `actual_thread_id`, which is a fresh UUID
+  when a turn arrives with no `contextId`, while tools record under
+  `thread_id`. The lookup silently returned `[]` and the incident was recorded
+  with no commands on it.
+
 ## [Unreleased] - 2026-08-19
 
 ### Added

--- a/docs/A2A_CONFIGURATION.md
+++ b/docs/A2A_CONFIGURATION.md
@@ -154,6 +154,73 @@ curl -X POST http://localhost:8080/a2a/ \
 
 See `docs/TEST_QUERIES.md` for complete examples and message formats.
 
+### What `message/stream` emits
+
+The stream is SSE. A subscriber sees, in this order:
+
+```
+task                                    immediately
+status-update  working                  the model's text, as it is produced
+status-update  working  (tool call)     each tool call, when it finishes
+status-update  working                  more text ...
+artifact-update         debug_result    the whole answer, authoritative
+status-update  completed | failed       terminal; the stream ends here
+```
+
+Tool calls arrive **before** the answer they informed, in the order the agent
+ran them.
+
+**Text frames.** The answer is split across `working` statuses at newline
+boundaries, and the newline a frame was cut on is *not* included in the frame.
+Join consecutive `working` texts with `"\n"` and you have the model's output
+character for character. The final `artifact-update` carries the whole answer
+and is authoritative -- replace what you accumulated with it rather than
+appending to it.
+
+**Tool calls.** A `working` status for a tool call carries two renderings of
+the same facts. The text part is the original prose:
+
+```
+🔧 Tool Call: execute_kubectl({
+  "cluster_id": "prod-1",
+  "command": "get pods -n checkout"
+})
+✅ Result: checkout-7d9  0/1  CrashLoopBackOff  5  2m...
+```
+
+and `metadata` -- on the status update *and* on its message -- carries the same
+call as typed fields:
+
+```json
+"metadata": {
+  "kubently/event": "tool_call",
+  "kubently/tool_call": {
+    "schema": "kubently.tool_call/v1",
+    "id": "tc_1758...",
+    "tool": "execute_kubectl",
+    "args": {"cluster_id": "prod-1", "command": "get pods -n checkout"},
+    "outcome": "ok",
+    "result": "checkout-7d9  0/1  CrashLoopBackOff  5  2m",
+    "startedAt": "2026-08-21T10:14:07.921000",
+    "completedAt": "2026-08-21T10:14:09.104000"
+  }
+}
+```
+
+Prefer the metadata: it is typed, whereas the text is prose that a formatting
+change can break. `outcome` is `ok` or `error`, or **absent** when the call
+never reported one -- render that as unknown rather than guessing. Ignore a
+`kubently/tool_call` whose `schema` you do not recognise and fall back to the
+text, which is not going away.
+
+Other `working` statuses carry `"kubently/event": "token"` (a fragment of the
+answer), or `"message"` / `"error"`. Treat an unknown `kubently/event` as text.
+
+**Terminal states.** `completed` means the artifact is a whole answer. `failed`
+means the run died -- its status message is the reason, not an answer. A stream
+that ends without a terminal state was dropped in transit, and what you have is
+a fragment.
+
 ### Verifying A2A Configuration
 
 Check the agent card endpoint:

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent.py
@@ -108,6 +108,140 @@ def _namespaced_thread_id(thread_id: str | None) -> str | None:
     return f"{caller}:{thread_id}"
 
 
+# --------------------------------------------------------------- streaming
+#
+# The agent's answer reaches A2A consumers as a run of `working` status
+# messages. A2A has no "append this fragment without a separator" semantics,
+# and consumers join consecutive status texts with a newline (kubently-cloud's
+# dashboard/lib/stream.ts does exactly that). So model deltas are buffered and
+# cut at newline boundaries, and the newline a frame was cut on is dropped from
+# the frame: the consumer's join puts it back, and the reconstruction is
+# character-for-character what the model produced. That is what lets token
+# streaming be added WITHOUT touching any existing consumer.
+#
+# TOKEN_FRAME_MAX_CHARS bounds how long a single unbroken line may buffer
+# before it is flushed anyway, so time-to-first-text never depends on the model
+# choosing to emit a newline.
+TOKEN_FRAME_MAX_CHARS = 400
+
+# Version tag on the structured tool-call event. Consumers should ignore an
+# event whose schema they do not recognise and fall back to the plain-text
+# rendering, which is emitted alongside it and is not going away.
+TOOL_EVENT_SCHEMA = "kubently.tool_call/v1"
+
+
+def _delta_text(chunk) -> str:
+    """The plain text of one `on_chat_model_stream` chunk.
+
+    langchain 1.x (and Anthropic in particular) hands back a list of content
+    blocks mid-stream: text deltas interleaved with tool-call argument deltas
+    and, on reasoning models, thinking. Only the text is the answer — the rest
+    is machinery and must never reach the user as prose.
+    """
+    content = getattr(chunk, "content", None)
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    out = []
+    for block in content:
+        if isinstance(block, str):
+            out.append(block)
+        elif isinstance(block, dict) and block.get("type") in (None, "text", "text_delta"):
+            text = block.get("text")
+            if isinstance(text, str):
+                out.append(text)
+    return "".join(out)
+
+
+def _token_frames(buffer: str, force: bool = False) -> tuple[list[str], str]:
+    """Cut a buffer of model deltas into wire frames.
+
+    Returns the frames ready to send and whatever is left buffered. See the
+    TOKEN_FRAME_MAX_CHARS comment above for why frames are newline-aligned and
+    why the newline itself is dropped.
+    """
+    frames: list[str] = []
+    while buffer:
+        newline = buffer.rfind("\n")
+        if newline > 0:
+            frames.append(buffer[:newline])
+            buffer = buffer[newline + 1 :]
+            continue
+        if len(buffer) > TOKEN_FRAME_MAX_CHARS:
+            cut = buffer.rfind(" ", 1, TOKEN_FRAME_MAX_CHARS)
+            cut = cut + 1 if cut > 0 else TOKEN_FRAME_MAX_CHARS
+            frames.append(buffer[:cut])
+            buffer = buffer[cut:]
+            continue
+        break
+    if force and buffer:
+        frames.append(buffer)
+        buffer = ""
+    return frames, buffer
+
+
+def _jsonable(value):
+    """A value protobuf's Struct will accept (A2A metadata is a Struct)."""
+    try:
+        return json.loads(json.dumps(value, default=str))
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _tool_event(record: dict) -> dict:
+    """One interceptor record as the structured tool-call event (#115).
+
+    Consumers have had to parse the "🔧 Tool Call: name({json})" prose because
+    it was the only tool-call protocol there was. These are the same facts as
+    typed fields, carried in A2A metadata alongside that text rather than
+    instead of it.
+
+    `outcome` is derived from whether the tool REPORTED an error — never from a
+    `status` key inside the tool's own payload. That distinction is #113: on
+    /debug/execute an absent `status` defaulted to SUCCESS and every denied
+    command was reported as having succeeded.
+    """
+    outcome = {"completed": "ok", "error": "error"}.get(record.get("status"))
+    args = record.get("args")
+    event = {
+        "schema": TOOL_EVENT_SCHEMA,
+        "id": record.get("id") or "",
+        "tool": record.get("tool_name") or "tool",
+        "args": _jsonable(args) if isinstance(args, dict) else {},
+    }
+    if record.get("timestamp"):
+        event["startedAt"] = record["timestamp"]
+    # Absent outcome means the call never reported one; a consumer must render
+    # that as "unknown", not guess a tick or a cross.
+    if outcome:
+        event["outcome"] = outcome
+    if record.get("result"):
+        event["result"] = str(record["result"])
+    if record.get("error"):
+        event["error"] = str(record["error"])
+    if record.get("completed_at"):
+        event["completedAt"] = record["completed_at"]
+    return event
+
+
+def _tool_event_text(record: dict) -> str:
+    """The legacy plain-text rendering of a tool call.
+
+    Byte-for-byte what the A2A executor used to write onto a `working` status.
+    It stays because it is the tool-call protocol every deployed consumer has
+    (kubently-cloud's stream.ts, test-automation's analyzer); the structured
+    event above is additive, so an old client keeps working unchanged.
+    """
+    args = record.get("args") if isinstance(record.get("args"), dict) else {}
+    text = f"🔧 Tool Call: {record.get('tool_name')}({json.dumps(args, indent=2, default=str)})"
+    if record.get("status") == "completed" and record.get("result"):
+        text += f"\n✅ Result: {str(record['result'])[:500]}..."
+    elif record.get("error"):
+        text += f"\n❌ Error: {record['error']}"
+    return text
+
+
 def _posthog_llm_callbacks():
     """PostHog LLM observability, opt-in via POSTHOG_API_KEY.
 
@@ -450,8 +584,8 @@ class KubentlyAgent:
         # Build a deep agent (deepagents 0.6.x). Beyond a plain ReAct loop this gives
         # the model a built-in planning tool (write_todos via TodoListMiddleware), a
         # virtual filesystem, and sub-agent support — better suited to multi-step
-        # Kubernetes debugging. Returns a CompiledStateGraph, so the existing
-        # `self.agent.ainvoke({"messages": ...}, config)` call in run() is unchanged.
+        # Kubernetes debugging. Returns a CompiledStateGraph, so run() can drive
+        # it with `astream_events` and get token/tool events for free.
         # Only attach the Redis checkpointer if we have a connection for shared state.
         self.agent = create_deep_agent(
             self.llm,
@@ -1578,7 +1712,24 @@ class KubentlyAgent:
         cluster_id: str | None = None,
         mcp_servers: list | None = None,
     ) -> AsyncIterable[dict]:
-        """Run the agent and stream responses.
+        """Run the agent, streaming what it is doing as it does it.
+
+        Yields dicts, in the order the events actually happened:
+
+            {"type": "token",     "content": <fragment of the answer>}
+            {"type": "tool_call", "content": <legacy "🔧 Tool Call:" text>,
+                                  "tool_call": {schema, id, tool, args,
+                                                outcome, result, error, ...}}
+            {"type": "message",   "content": <the whole answer>,
+                                  "metadata": {"streamed": bool, ...}}
+            {"type": "error",     "content": <what went wrong>}
+
+        Before #115 this awaited `ainvoke` and yielded exactly once at the end,
+        so every consumer saw a long silence, then the whole answer in one
+        frame, then the tool calls AFTER the answer they informed. `token` and
+        `tool_call` are new; `message` and `error` are unchanged, and the
+        legacy text on `tool_call` is byte-for-byte what the A2A executor used
+        to write, so a consumer that ignores the new types still works.
 
         Args:
             messages: User messages to process
@@ -1787,9 +1938,123 @@ class KubentlyAgent:
             }
         )
 
+        # Tool-call events are drained from the interceptor as the graph runs.
+        # The interceptor — not LangGraph's own on_tool_* events — stays the
+        # source of truth for WHICH calls are user-visible: a tool is visible
+        # precisely when it calls record_tool_call, which is the existing
+        # contract and is what keeps deepagents' internal bookkeeping (planning
+        # todos, the virtual filesystem) out of the user's transcript. What
+        # changes here is WHEN: a call is streamed the moment it finishes, so
+        # it reaches the client BEFORE the answer it informed instead of after.
+        #
+        # Queried with `thread_id`, the same variable current_thread_id was set
+        # from above, so the recording side and the query side cannot drift
+        # (they used to live in different files — see tests/
+        # test_tool_trace_thread_match.py).
+        interceptor = get_tool_call_interceptor()
+        emitted_tool_calls: set[str] = set()
+
+        async def pending_tool_events(include_unfinished: bool = False) -> list[dict]:
+            """Interceptor records for this turn not yet streamed to the client."""
+            fresh = []
+            for record in await interceptor.get_tool_calls_for_thread(thread_id):
+                call_id = record.get("id")
+                if call_id in emitted_tool_calls:
+                    continue
+                if not include_unfinished and record.get("status") == "started":
+                    continue
+                emitted_tool_calls.add(call_id)
+                fresh.append(dict(record))
+            return fresh
+
+        def tool_chunk(record: dict) -> dict:
+            return {
+                "type": "tool_call",
+                # Legacy prose, unchanged, so existing consumers keep parsing.
+                "content": _tool_event_text(record),
+                # The same facts as typed fields (#115).
+                "tool_call": _tool_event(record),
+                "metadata": {"thread_id": actual_thread_id},
+            }
+
         try:
-            # Run the single agent (per-request variant when MCP servers were injected)
-            result = await run_agent.ainvoke({"messages": lc_messages}, config=config)
+            # astream_events instead of ainvoke (#115): the SAME graph, the same
+            # tools, the same single LLM run — the only difference is that its
+            # token and tool events surface while the investigation happens
+            # rather than after it. Nothing here re-invokes the graph, so one
+            # A2A request is still exactly one diagnosis (billing parity with
+            # message/send is a hard constraint downstream).
+            result: dict | None = None
+            root_run_id = None
+            answer_stream = ""  # text of the LAST model turn: the answer itself
+            buffer = ""
+
+            async for event in run_agent.astream_events(
+                {"messages": lc_messages}, config=config, version="v2"
+            ):
+                kind = event.get("event")
+                if root_run_id is None and kind == "on_chain_start":
+                    # First event of the stream is the root graph's start; its
+                    # matching on_chain_end carries the final state, which is
+                    # exactly what ainvoke() used to return.
+                    root_run_id = event.get("run_id")
+
+                if kind == "on_chat_model_stream":
+                    delta = _delta_text((event.get("data") or {}).get("chunk"))
+                    if delta:
+                        answer_stream += delta
+                        buffer += delta
+                        frames, buffer = _token_frames(buffer)
+                        for frame in frames:
+                            yield {
+                                "type": "token",
+                                "content": frame,
+                                "metadata": {"thread_id": actual_thread_id},
+                            }
+                elif kind == "on_chat_model_start":
+                    # A new model turn begins. Flush the previous turn's tail
+                    # and any tool calls it triggered, then reset the answer
+                    # accumulator so it ends up holding the FINAL turn's text
+                    # rather than every intermediate narration concatenated.
+                    frames, buffer = _token_frames(buffer, force=True)
+                    for frame in frames:
+                        yield {
+                            "type": "token",
+                            "content": frame,
+                            "metadata": {"thread_id": actual_thread_id},
+                        }
+                    for record in await pending_tool_events():
+                        yield tool_chunk(record)
+                    answer_stream = ""
+                elif kind in ("on_tool_end", "on_tool_error"):
+                    for record in await pending_tool_events():
+                        yield tool_chunk(record)
+                elif kind == "on_chain_end" and event.get("run_id") == root_run_id:
+                    output = (event.get("data") or {}).get("output")
+                    if isinstance(output, dict):
+                        result = output
+
+            frames, buffer = _token_frames(buffer, force=True)
+            for frame in frames:
+                yield {
+                    "type": "token",
+                    "content": frame,
+                    "metadata": {"thread_id": actual_thread_id},
+                }
+            # include_unfinished: a tool that never recorded a result is still
+            # worth showing (with no outcome) rather than vanishing.
+            for record in await pending_tool_events(include_unfinished=True):
+                yield tool_chunk(record)
+
+            if result is None:
+                # The root chain's end event never arrived (an SDK change, or a
+                # graph that streamed without one). The streamed text is still a
+                # real answer; use it rather than losing the turn.
+                logger.warning(
+                    "astream_events produced no final graph state; "
+                    "falling back to the streamed answer text"
+                )
+                result = {"messages": [AIMessage(content=answer_stream)] if answer_stream else []}
 
             # Extract the final message
             final_messages = result.get("messages", [])
@@ -1845,9 +2110,13 @@ class KubentlyAgent:
                                 extract_incident,
                             )
 
-                            trace = await get_tool_call_interceptor().get_tool_calls_for_thread(
-                                actual_thread_id
-                            )
+                            # `thread_id`, not `actual_thread_id`: tools record
+                            # under whatever current_thread_id was set to, and
+                            # that is `thread_id`. For a one-shot turn with no
+                            # contextId the two differ (actual_thread_id is a
+                            # fresh uuid) and this lookup silently returned []
+                            # — an incident recorded with no commands on it.
+                            trace = await interceptor.get_tool_calls_for_thread(thread_id)
                             incident = extract_incident(
                                 response_text,
                                 user_text=query_text,
@@ -1865,10 +2134,22 @@ class KubentlyAgent:
                         except Exception as e:
                             logger.warning(f"Incident recording failed (response unaffected): {e}")
 
+                    # `streamed` tells the A2A executor this text already went
+                    # out as token frames, so it publishes it once (as the
+                    # artifact) instead of repeating the whole answer as one
+                    # more `working` status. False when the answer was
+                    # substituted above, or when the model never streamed.
                     yield {
                         "type": "message",
                         "content": response_text,
-                        "metadata": {"thread_id": actual_thread_id},
+                        "metadata": {
+                            "thread_id": actual_thread_id,
+                            "streamed": (
+                                isinstance(response_text, str)
+                                and bool(answer_stream.strip())
+                                and response_text.strip() == answer_stream.strip()
+                            ),
+                        },
                     }
                 else:
                     # Fallback response
@@ -1887,6 +2168,15 @@ class KubentlyAgent:
 
         except Exception as e:
             logger.error(f"Error in agent.run: {e}", exc_info=True)
+            # A run that dies part-way still ran real commands. Publish them
+            # before the error so the transcript shows how far it got — and so
+            # a mid-stream failure ends the stream rather than leaving the
+            # subscription open on a half-told story.
+            try:
+                for record in await pending_tool_events(include_unfinished=True):
+                    yield tool_chunk(record)
+            except Exception:  # pragma: no cover - draining must never mask `e`
+                logger.warning("Could not drain tool calls after a failed run", exc_info=True)
             yield {
                 "type": "error",
                 "content": f"I encountered an error while processing your request: {e!s}",

--- a/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
+++ b/kubently/modules/a2a/protocol_bindings/a2a_server/agent_executor.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re
@@ -133,14 +132,12 @@ class KubentlyAgentExecutor(AgentExecutor):
 
         logger.info(f"Using contextId: {contextId}, cluster_id: {cluster_id}")
 
-        # Tool calls are recorded by the agent under the CALLER-NAMESPACED thread
-        # id (see agent._namespaced_thread_id), so the interceptor must be queried
-        # with the same value — matching is exact equality. Querying the raw
-        # contextId silently returns [] and the "🔧 Tool Call" stream events
-        # (which test-automation parses) vanish.
-        from .agent import _namespaced_thread_id
-
-        traceThreadId = _namespaced_thread_id(contextId)
+        # Tool-call events are no longer polled here. They are drained inside
+        # agent.run(), under the CALLER-NAMESPACED thread id it already holds
+        # (agent._namespaced_thread_id), and yielded as `tool_call` chunks.
+        # That is what makes them arrive BEFORE the answer they informed (#115),
+        # and it removes the split-brain that made #63's silent-empty-result
+        # possible: recording and querying now use one variable in one file.
 
         # Let the agent handle all queries including cluster discovery
         # The agent's memory and prompt will maintain context properly
@@ -176,12 +173,10 @@ class KubentlyAgentExecutor(AgentExecutor):
 
         # Stream results from the agent with error handling
         full_response = []
-        last_tool_check_time = None
-
-        # Import the interceptor
-        from .tool_call_interceptor import get_tool_call_interceptor
-
-        interceptor = get_tool_call_interceptor()
+        # Set when the agent reports a failure. A run that dies must reach a
+        # terminal `failed` status, not a `completed` one carrying an apology
+        # as if it were an answer — a subscriber cannot tell those apart.
+        failure: str | None = None
 
         try:
             logger.info(
@@ -190,102 +185,61 @@ class KubentlyAgentExecutor(AgentExecutor):
             chunk_count = 0
             async for chunk in self.agent.run(messages, thread_id=contextId, cluster_id=cluster_id):
                 chunk_count += 1
-                # Chunk is a dict, extract content for logging
-                chunk_str = str(chunk)[:100] if chunk else "EMPTY"
-                logger.info(f"Received chunk {chunk_count}: {chunk_str}")
-                # Extract content from chunk dict
-                chunk_content = chunk.get("content", "") if isinstance(chunk, dict) else str(chunk)
+                if not isinstance(chunk, dict):
+                    chunk = {"type": "message", "content": str(chunk)}
+                chunk_type = chunk.get("type") or "message"
+                chunk_content = chunk.get("content") or ""
+
+                if chunk_type == "token":
+                    # A fragment of the answer as the model produces it. It is
+                    # NOT accumulated into full_response: the agent sends the
+                    # whole answer once more as a `message` chunk, and that is
+                    # what the artifact is built from.
+                    await self._emit_working(
+                        event_queue, task, chunk_content, {"kubently/event": "token"}
+                    )
+                    continue
+
+                if chunk_type == "tool_call":
+                    # Two renderings of the same call: the legacy prose (which
+                    # is what every deployed consumer parses today) on the text
+                    # part, and the typed event in metadata for consumers that
+                    # would rather read fields than regexes (#115).
+                    logger.info(f"Tool call chunk {chunk_count}: {chunk_content[:120]}")
+                    await self._emit_working(
+                        event_queue,
+                        task,
+                        chunk_content,
+                        {
+                            "kubently/event": "tool_call",
+                            "kubently/tool_call": chunk.get("tool_call") or {},
+                        },
+                    )
+                    continue
+
+                logger.info(f"Received chunk {chunk_count} ({chunk_type}): {chunk_content[:100]}")
                 full_response.append(chunk_content)
+                if chunk_type == "error":
+                    failure = chunk_content
 
-                # Send streaming update
-                await event_queue.enqueue_event(
-                    TaskStatusUpdateEvent(
-                        status=TaskStatus(
-                            state=TaskState.TASK_STATE_WORKING,
-                            message=new_text_message(
-                                chunk_content,
-                                context_id=task.context_id,
-                                task_id=task.id,
-                            ),
-                        ),
-                        context_id=task.context_id,
-                        task_id=task.id,
+                # An answer already delivered as token frames is not repeated
+                # here — it goes out once more only as the final artifact.
+                if not (chunk.get("metadata") or {}).get("streamed"):
+                    await self._emit_working(
+                        event_queue, task, chunk_content, {"kubently/event": chunk_type}
                     )
-                )
-
-                # Check for new tool calls periodically
-                from datetime import datetime
-
-                current_time = datetime.now().isoformat()
-                if last_tool_check_time is None or last_tool_check_time < current_time:
-                    # Get tool calls since last check
-                    tool_calls = await interceptor.get_tool_calls_for_thread(
-                        traceThreadId, since_timestamp=last_tool_check_time
-                    )
-
-                    # Emit tool call events
-                    for tool_call in tool_calls:
-                        # Create a custom event for tool calls
-                        # Since A2A doesn't have a specific tool call event, we'll use TaskStatusUpdateEvent
-                        # with metadata in the message
-                        tool_message = f"🔧 Tool Call: {tool_call['tool_name']}({json.dumps(tool_call.get('args', {}), indent=2)})"
-                        if tool_call.get("status") == "completed" and tool_call.get("result"):
-                            tool_message += f"\n✅ Result: {tool_call['result'][:500]}..."
-                        elif tool_call.get("error"):
-                            tool_message += f"\n❌ Error: {tool_call['error']}"
-
-                        await event_queue.enqueue_event(
-                            TaskStatusUpdateEvent(
-                                status=TaskStatus(
-                                    state=TaskState.TASK_STATE_WORKING,
-                                    message=new_text_message(
-                                        tool_message,
-                                        context_id=task.context_id,
-                                        task_id=task.id,
-                                    ),
-                                ),
-                                context_id=task.context_id,
-                                task_id=task.id,
-                            )
-                        )
-
-                    last_tool_check_time = current_time
 
             # Send final result
             final_response = "\n".join(full_response)
             logger.info(
                 f"Agent execution completed. Chunks: {chunk_count}, Response: '{final_response[:200]}'"
             )
-
-            # Emit any remaining tool calls
-            final_tool_calls = await interceptor.get_tool_calls_for_thread(
-                traceThreadId, since_timestamp=last_tool_check_time
-            )
-            for tool_call in final_tool_calls:
-                tool_message = f"🔧 Tool Call: {tool_call['tool_name']}({json.dumps(tool_call.get('args', {}), indent=2)})"
-                if tool_call.get("status") == "completed" and tool_call.get("result"):
-                    tool_message += f"\n✅ Result: {tool_call['result'][:500]}..."
-                elif tool_call.get("error"):
-                    tool_message += f"\n❌ Error: {tool_call['error']}"
-
-                await event_queue.enqueue_event(
-                    TaskStatusUpdateEvent(
-                        status=TaskStatus(
-                            state=TaskState.TASK_STATE_WORKING,
-                            message=new_text_message(
-                                tool_message,
-                                context_id=task.context_id,
-                                task_id=task.id,
-                            ),
-                        ),
-                        context_id=task.context_id,
-                        task_id=task.id,
-                    )
-                )
         except Exception as e:
             error_msg = f"Agent execution failed: {e!s}\n{traceback.format_exc()}"
             logger.error(error_msg)
             final_response = f"I encountered an error while processing your request: {e!s}"
+            failure = final_response
+
         await event_queue.enqueue_event(
             TaskArtifactUpdateEvent(
                 append=False,
@@ -300,10 +254,27 @@ class KubentlyAgentExecutor(AgentExecutor):
             )
         )
 
-        # Mark task as complete. a2a-sdk 1.x dropped TaskStatusUpdateEvent.final:
-        # the stream ends when a terminal TaskState is emitted, and the v0.3
-        # compatibility layer re-derives `final: true` from that for old clients.
-        # So a terminal state here is the only thing keeping clients from hanging.
+        # Terminal state. a2a-sdk 1.x dropped TaskStatusUpdateEvent.final: the
+        # stream ends when a terminal TaskState is emitted, and the v0.3
+        # compatibility layer re-derives `final: true` from that for old
+        # clients. So a terminal state here is the only thing keeping clients
+        # from hanging — which is why the failure path emits one too, rather
+        # than reporting a dead run as `completed`.
+        if failure:
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    status=TaskStatus(
+                        state=TaskState.TASK_STATE_FAILED,
+                        message=new_text_message(
+                            failure, context_id=task.context_id, task_id=task.id
+                        ),
+                    ),
+                    context_id=task.context_id,
+                    task_id=task.id,
+                )
+            )
+            return
+
         await event_queue.enqueue_event(
             TaskStatusUpdateEvent(
                 status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
@@ -311,6 +282,37 @@ class KubentlyAgentExecutor(AgentExecutor):
                 task_id=task.id,
             )
         )
+
+    async def _emit_working(
+        self,
+        event_queue: EventQueue,
+        task,
+        text: str,
+        metadata: dict | None = None,
+    ) -> None:
+        """One `working` status carrying text and, optionally, a typed event.
+
+        A2A has no tool-call event type, so structured events ride in the
+        `metadata` Struct on both the status update and its message (consumers
+        read one or the other depending on which layer they parse). The text
+        part is unchanged from what this executor always wrote, so nothing that
+        reads only text notices the addition.
+        """
+        if not text:
+            # An empty text part is a frame a consumer has to skip anyway, and
+            # one that a "\n"-joining consumer would turn into a stray newline.
+            return
+        message = new_text_message(text, context_id=task.context_id, task_id=task.id)
+        if metadata:
+            message.metadata.update(metadata)
+        event = TaskStatusUpdateEvent(
+            status=TaskStatus(state=TaskState.TASK_STATE_WORKING, message=message),
+            context_id=task.context_id,
+            task_id=task.id,
+        )
+        if metadata:
+            event.metadata.update(metadata)
+        await event_queue.enqueue_event(event)
 
     @override
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:

--- a/tests/test_a2a_progressive_streaming.py
+++ b/tests/test_a2a_progressive_streaming.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+"""#115: the stream must narrate the investigation, not replay it afterwards.
+
+`agent.run()` used to await `ainvoke()` and yield exactly once, so a
+`message/stream` subscriber saw: the task, a long silence held open only by
+sse_starlette keepalives, the ENTIRE answer in one frame, and then — after the
+answer they informed — the tool calls. The connection streamed; the content did
+not.
+
+Every test here asserts on the SEQUENCE, because a test that only checked the
+final text would pass against that behaviour. The three properties that matter:
+
+  * tool calls arrive BEFORE the answer they informed, in the order they ran,
+  * the answer arrives as more than one frame,
+  * a run that dies mid-stream still reaches a terminal `failed` status.
+
+The tool-call event is also asserted twice over: once as the legacy
+"🔧 Tool Call: name({json})" prose that every deployed consumer parses today,
+and once as the typed `kubently/tool_call` metadata that replaces the need to
+parse it. Both, on the same frame — that is the compatibility promise.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("a2a")
+pytest.importorskip("deepagents")  # agent_executor -> agent -> deepagents
+pytest.importorskip("langchain_core")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from fastapi import FastAPI  # noqa: E402
+from langchain_core.language_models import BaseChatModel  # noqa: E402
+from langchain_core.messages import AIMessage, AIMessageChunk  # noqa: E402
+from langchain_core.outputs import (  # noqa: E402
+    ChatGeneration,
+    ChatGenerationChunk,
+    ChatResult,
+)
+from starlette.testclient import TestClient  # noqa: E402
+
+from kubently.modules.a2a import A2AModule  # noqa: E402
+from kubently.modules.a2a.protocol_bindings.a2a_server.agent import (  # noqa: E402
+    TOKEN_FRAME_MAX_CHARS,
+    KubentlyAgent,
+    _token_frames,
+)
+from kubently.modules.a2a.protocol_bindings.a2a_server.tool_call_interceptor import (  # noqa: E402
+    ToolCallInterceptor,
+)
+
+@pytest.fixture(autouse=True)
+def _restore_the_global_interceptor():
+    """These tests swap in a private interceptor; put the real one back.
+
+    The interceptor is a module-level singleton shared by every test in the
+    session — leaving a fake in its place is a cross-file failure that looks
+    like a flake."""
+    import kubently.modules.a2a.protocol_bindings.a2a_server.agent as agent_module
+
+    original = agent_module.get_tool_call_interceptor
+    yield
+    agent_module.get_tool_call_interceptor = original
+
+
+ANSWER = "The checkout pod is crashing.\nRoot cause: the image tag does not exist."
+NARRATION = "Let me look at the pods first.\n"
+KUBECTL_ARGS = {"cluster_id": "prod-1", "command": "get pods -n checkout"}
+KUBECTL_OUTPUT = "checkout-7d9  0/1  CrashLoopBackOff  5  2m"
+
+
+# --------------------------------------------------------------- agent level
+
+
+class _FakeGraph:
+    """A compiled graph that emits a realistic LangGraph event stream.
+
+    `ainvoke` is implemented too, and deliberately: against the pre-#115
+    `run()` — which awaited it — these tests still execute end to end and fail
+    on the ORDERING assertions rather than blowing up on a missing attribute.
+    A test that only passes because the fake is the wrong shape proves nothing.
+    """
+
+    def __init__(self, interceptor, script):
+        self.interceptor = interceptor
+        self.script = script
+        self.invocations = 0
+
+    async def ainvoke(self, inputs, config=None):
+        self.invocations += 1
+        return {"messages": [AIMessage(content=ANSWER)]}
+
+    def astream_events(self, inputs, config=None, version=None):
+        self.invocations += 1
+        return self.script(self.interceptor)
+
+
+def _model_chunk(text: str) -> dict:
+    return {
+        "event": "on_chat_model_stream",
+        "run_id": "llm",
+        "data": {"chunk": AIMessageChunk(content=text)},
+    }
+
+
+async def _one_tool_then_an_answer(interceptor):
+    """Narrate, run one kubectl, then answer — the shape of a real diagnosis."""
+    from kubently.modules.a2a.protocol_bindings.a2a_server.agent import current_thread_id
+
+    thread_id = current_thread_id.get()
+
+    yield {"event": "on_chain_start", "run_id": "root", "name": "kubently", "data": {}}
+    yield {"event": "on_chat_model_start", "run_id": "llm", "data": {}}
+    yield _model_chunk(NARRATION)
+
+    call_id = await interceptor.record_tool_call(
+        tool_name="execute_kubectl", args=KUBECTL_ARGS, thread_id=thread_id
+    )
+    yield {"event": "on_tool_start", "run_id": "tool", "name": "execute_kubectl", "data": {}}
+    await interceptor.record_tool_result(call_id, KUBECTL_OUTPUT)
+    yield {"event": "on_tool_end", "run_id": "tool", "name": "execute_kubectl", "data": {}}
+
+    yield {"event": "on_chat_model_start", "run_id": "llm2", "data": {}}
+    for piece in (ANSWER[:30], ANSWER[30:]):
+        yield _model_chunk(piece)
+
+    yield {
+        "event": "on_chain_end",
+        "run_id": "root",
+        "data": {"output": {"messages": [AIMessage(content=ANSWER)]}},
+    }
+
+
+def _agent(graph, interceptor) -> KubentlyAgent:
+    """A KubentlyAgent wired to a fake graph, skipping LLM/Redis setup."""
+    agent = KubentlyAgent.__new__(KubentlyAgent)
+    agent.redis_client = None
+    agent.llm = None
+    agent.tools = []
+    agent.memory = None
+    agent.runbooks = None
+    agent.incidents = None
+    agent.system_prompt = ""
+    agent._injected_runbooks = {}
+    agent._surfaced_incidents = {}
+    agent.agent = graph
+
+    async def _already_initialized():
+        return None
+
+    agent.initialize = _already_initialized
+
+    import kubently.modules.a2a.protocol_bindings.a2a_server.agent as agent_module
+
+    agent_module.get_tool_call_interceptor = lambda: interceptor
+    return agent
+
+
+async def _run(script, thread_id: str):
+    """(chunks, graph) for one turn against a fake graph."""
+    interceptor = ToolCallInterceptor()
+    graph = _FakeGraph(interceptor, script)
+    agent = _agent(graph, interceptor)
+    chunks = [
+        chunk
+        async for chunk in agent.run([{"role": "user", "content": "why is checkout down?"}],
+                                     thread_id=thread_id)
+    ]
+    return chunks, graph
+
+
+@pytest.mark.asyncio
+async def test_a_tool_call_arrives_before_the_answer_it_informed():
+    """The headline #115 regression: ordering, not content."""
+    chunks, _ = await _run(_one_tool_then_an_answer, "ctx-order")
+    kinds = [c["type"] for c in chunks]
+
+    assert "tool_call" in kinds, (
+        "no tool_call chunk: the run yielded only the finished answer, which is "
+        "exactly the pre-#115 behaviour"
+    )
+    tool_at = kinds.index("tool_call")
+
+    # The answer's own frames, not the narration that preceded the tool call.
+    answer_at = next(
+        i
+        for i, c in enumerate(chunks)
+        if c["type"] == "token" and c["content"].startswith(ANSWER[:10])
+    )
+    assert tool_at < answer_at, "the tool call was streamed after the answer it informed"
+
+    # And the terminal message is last, so nothing trails the answer.
+    assert kinds[-1] == "message"
+    assert chunks[-1]["content"] == ANSWER
+
+
+@pytest.mark.asyncio
+async def test_the_answer_arrives_as_more_than_one_frame():
+    chunks, _ = await _run(_one_tool_then_an_answer, "ctx-frames")
+    tokens = [c["content"] for c in chunks if c["type"] == "token"]
+    assert len(tokens) > 1, (
+        f"the answer arrived in {len(tokens)} frame(s); ainvoke() yields exactly one"
+    )
+    # Consumers join consecutive `working` texts with "\n" (see stream.ts).
+    # That join must reconstruct the model's output character for character.
+    assert "\n".join(tokens) == NARRATION.rstrip("\n") + "\n" + ANSWER
+
+
+@pytest.mark.asyncio
+async def test_the_graph_runs_exactly_once():
+    """Streaming must not turn one diagnosis into several runs (billing)."""
+    _, graph = await _run(_one_tool_then_an_answer, "ctx-billing")
+    assert graph.invocations == 1
+
+
+@pytest.mark.asyncio
+async def test_the_tool_call_carries_typed_fields_and_the_legacy_text():
+    chunks, _ = await _run(_one_tool_then_an_answer, "ctx-shape")
+    call = next(c for c in chunks if c["type"] == "tool_call")
+
+    event = call["tool_call"]
+    assert event["schema"] == "kubently.tool_call/v1"
+    assert event["tool"] == "execute_kubectl"
+    assert event["args"] == KUBECTL_ARGS
+    assert event["outcome"] == "ok"
+    assert KUBECTL_OUTPUT in event["result"]
+
+    # The prose every deployed consumer parses today is still there, verbatim.
+    assert call["content"].startswith("🔧 Tool Call: execute_kubectl(")
+    assert "✅ Result:" in call["content"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_tool_is_reported_as_an_error_not_a_success():
+    """#113 in the streaming path: outcome comes from whether the tool reported
+    an error, never from a `status` key inside the tool's own payload."""
+
+    async def script(interceptor):
+        from kubently.modules.a2a.protocol_bindings.a2a_server.agent import current_thread_id
+
+        yield {"event": "on_chain_start", "run_id": "root", "data": {}}
+        call_id = await interceptor.record_tool_call(
+            tool_name="execute_kubectl",
+            args={"cluster_id": "prod-1", "command": "delete pods --all"},
+            thread_id=current_thread_id.get(),
+        )
+        # The executor denies the command: no result, an error.
+        await interceptor.record_tool_result(call_id, None, "Command not allowed: delete")
+        yield {"event": "on_tool_end", "run_id": "tool", "data": {}}
+        yield {
+            "event": "on_chain_end",
+            "run_id": "root",
+            "data": {"output": {"messages": [AIMessage(content="I cannot delete pods.")]}},
+        }
+
+    chunks, _ = await _run(script, "ctx-denied")
+    call = next(c for c in chunks if c["type"] == "tool_call")
+    assert call["tool_call"]["outcome"] == "error"
+    assert "not allowed" in call["tool_call"]["error"]
+    assert "result" not in call["tool_call"]
+    assert "❌ Error:" in call["content"]
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_dies_mid_stream_still_reports_what_it_ran():
+    """The commands that DID run are worth showing, and the turn must end."""
+
+    async def script(interceptor):
+        from kubently.modules.a2a.protocol_bindings.a2a_server.agent import current_thread_id
+
+        yield {"event": "on_chain_start", "run_id": "root", "data": {}}
+        yield _model_chunk("Looking at the pods.\n")
+        call_id = await interceptor.record_tool_call(
+            tool_name="execute_kubectl", args=KUBECTL_ARGS, thread_id=current_thread_id.get()
+        )
+        await interceptor.record_tool_result(call_id, KUBECTL_OUTPUT)
+        yield {"event": "on_tool_end", "run_id": "tool", "data": {}}
+        raise RuntimeError("the model connection dropped")
+
+    chunks, _ = await _run(script, "ctx-dies")
+    kinds = [c["type"] for c in chunks]
+    assert "token" in kinds
+    assert "tool_call" in kinds
+    assert kinds[-1] == "error", "a dead run must terminate, not trail off"
+    assert "the model connection dropped" in chunks[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_from_another_caller_are_never_streamed_here():
+    """The interceptor is a shared buffer; thread matching is what isolates it."""
+
+    async def script(interceptor):
+        from kubently.modules.a2a.protocol_bindings.a2a_server.agent import current_thread_id
+
+        yield {"event": "on_chain_start", "run_id": "root", "data": {}}
+        await interceptor.record_tool_call(
+            tool_name="execute_kubectl",
+            args={"cluster_id": "someone-elses", "command": "get secrets -A"},
+            thread_id="a-different-caller:ctx-leak",
+        )
+        mine = await interceptor.record_tool_call(
+            tool_name="list_clusters", args={}, thread_id=current_thread_id.get()
+        )
+        await interceptor.record_tool_result(mine, "prod-1")
+        yield {"event": "on_tool_end", "run_id": "tool", "data": {}}
+        yield {
+            "event": "on_chain_end",
+            "run_id": "root",
+            "data": {"output": {"messages": [AIMessage(content="prod-1")]}},
+        }
+
+    chunks, _ = await _run(script, "ctx-leak")
+    tools = [c["tool_call"]["tool"] for c in chunks if c["type"] == "tool_call"]
+    assert tools == ["list_clusters"]
+    assert "someone-elses" not in json.dumps(chunks)
+
+
+def test_token_frames_reconstruct_exactly_under_a_newline_join():
+    """The property the frame cutter exists for, over awkward inputs."""
+    for text in (
+        "one line",
+        "two\nlines",
+        "trailing\n",
+        "\nleading",
+        "blank\n\nline",
+        "a" * 1000,
+        "bullet one\n- bullet two\n- bullet three\n",
+    ):
+        frames: list[str] = []
+        buffer = ""
+        # Feed it a character at a time: the worst case for a buffering cutter.
+        for char in text:
+            new, buffer = _token_frames(buffer + char)
+            frames.extend(new)
+        new, buffer = _token_frames(buffer, force=True)
+        frames.extend(new)
+        assert buffer == ""
+        joined = "\n".join(frames)
+        if "\n" in text or len(text) <= TOKEN_FRAME_MAX_CHARS:
+            # Exact, modulo the one trailing newline a final frame cannot carry.
+            expected = text[:-1] if text.endswith("\n") else text
+            assert joined == expected, text
+        else:
+            # A line longer than any consumer wants to wait for is cut anyway;
+            # the join adds newlines but never adds or drops a character.
+            assert joined.replace("\n", "") == text
+
+
+# ------------------------------------------------- the real LangGraph plumbing
+
+
+class _ScriptedModel(BaseChatModel):
+    """A chat model that streams a scripted tool call, then a scripted answer.
+
+    Everything else in the graph is real: `create_deep_agent` builds the actual
+    compiled graph (with deepagents' planning and filesystem middleware), and
+    LangGraph's own `astream_events` produces the events run() consumes. Only
+    the network calls — the model and the cluster — are scripted.
+    """
+
+    turn: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted"
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    def _next_message(self) -> AIMessage:
+        self.turn += 1
+        if self.turn == 1:
+            return AIMessage(
+                content=NARRATION,
+                tool_calls=[{"name": "peek", "args": {"cluster_id": "prod-1"}, "id": "call_1"}],
+            )
+        return AIMessage(content=ANSWER)
+
+    def _stream(self, messages, stop=None, run_manager=None, **kwargs):
+        message = self._next_message()
+        text = message.content or ""
+        for i in range(0, len(text), 5):
+            piece = text[i : i + 5]
+            chunk = ChatGenerationChunk(message=AIMessageChunk(content=piece))
+            if run_manager:
+                run_manager.on_llm_new_token(piece, chunk=chunk)
+            yield chunk
+        if message.tool_calls:
+            yield ChatGenerationChunk(
+                message=AIMessageChunk(content="", tool_calls=message.tool_calls)
+            )
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        return ChatResult(generations=[ChatGeneration(message=self._next_message())])
+
+    @property
+    def _identifying_params(self):
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_a_real_graph_streams_tokens_and_tools_in_order():
+    """End to end over the actual deepagents graph, not a scripted event list.
+
+    This is the test that would have caught "astream_events compiles but never
+    emits token events through deepagents' middleware", which no amount of
+    faking the event stream can tell you.
+    """
+    from deepagents import create_deep_agent
+    from langchain_core.tools import tool
+
+    from kubently.modules.a2a.protocol_bindings.a2a_server.agent import current_thread_id
+
+    interceptor = ToolCallInterceptor()
+
+    @tool
+    async def peek(cluster_id: str) -> str:
+        """Look at a cluster."""
+        # Exactly what the real tools do: record the call, then its result.
+        call_id = await interceptor.record_tool_call(
+            tool_name="peek", args={"cluster_id": cluster_id}, thread_id=current_thread_id.get()
+        )
+        await interceptor.record_tool_result(call_id, KUBECTL_OUTPUT)
+        return KUBECTL_OUTPUT
+
+    graph = create_deep_agent(_ScriptedModel(), [peek], system_prompt="debug clusters")
+    agent = _agent(graph, interceptor)
+
+    chunks = [
+        chunk
+        async for chunk in agent.run(
+            [{"role": "user", "content": "why is checkout down?"}], thread_id="ctx-real"
+        )
+    ]
+    kinds = [c["type"] for c in chunks]
+
+    assert kinds.count("token") > 1, "the real graph produced no incremental text"
+    assert "tool_call" in kinds
+    call = next(c for c in chunks if c["type"] == "tool_call")
+    assert call["tool_call"]["tool"] == "peek"
+    assert call["tool_call"]["outcome"] == "ok"
+
+    tool_at = kinds.index("tool_call")
+    answer_at = next(
+        i
+        for i, c in enumerate(chunks)
+        if c["type"] == "token" and c["content"].startswith(ANSWER[:10])
+    )
+    assert tool_at < answer_at
+
+    assert kinds[-1] == "message"
+    assert chunks[-1]["content"] == ANSWER
+    assert chunks[-1]["metadata"]["streamed"] is True
+
+    # And the frames still rebuild the model's output exactly.
+    tokens = [c["content"] for c in chunks if c["type"] == "token"]
+    assert "\n".join(tokens) == NARRATION.rstrip("\n") + "\n" + ANSWER
+
+
+# ----------------------------------------------------------------- SSE level
+
+
+STREAM_REQUEST = {
+    "jsonrpc": "2.0",
+    "id": "s1",
+    "method": "message/stream",
+    "params": {
+        "message": {
+            "messageId": "m1",
+            "role": "user",
+            "contextId": "ctx-sse",
+            "parts": [{"partId": "p1", "text": "why is checkout down?"}],
+        }
+    },
+}
+
+TOOL_TEXT = (
+    "🔧 Tool Call: execute_kubectl(" + json.dumps(KUBECTL_ARGS, indent=2) + ")"
+    "\n✅ Result: " + KUBECTL_OUTPUT + "..."
+)
+
+TOOL_EVENT = {
+    "schema": "kubently.tool_call/v1",
+    "id": "tc_1",
+    "tool": "execute_kubectl",
+    "args": KUBECTL_ARGS,
+    "outcome": "ok",
+    "result": KUBECTL_OUTPUT,
+}
+
+
+class _ScriptedAgent:
+    """Stands in for KubentlyAgent at the executor boundary."""
+
+    def __init__(self, chunks, explode: bool = False):
+        self.chunks = chunks
+        self.explode = explode
+
+    async def initialize(self):
+        return None
+
+    async def run(self, messages, thread_id=None, cluster_id=None, mcp_servers=None):
+        for chunk in self.chunks:
+            yield chunk
+        if self.explode:
+            raise RuntimeError("the model connection dropped")
+
+
+def _executor(agent):
+    from kubently.modules.a2a.protocol_bindings.a2a_server.agent_executor import (
+        KubentlyAgentExecutor,
+    )
+
+    executor = KubentlyAgentExecutor(redis_client=None)
+    executor.agent = agent
+    executor._initialized = True
+    return executor
+
+
+def _post(executor):
+    module = A2AModule(host="127.0.0.1", port=8080, external_url="http://localhost:8080/a2a/")
+    module._lazy_imports = lambda: (lambda redis_client=None: executor)
+    outer = FastAPI()
+    outer.mount("/a2a", module.get_app())
+    with TestClient(outer, raise_server_exceptions=False) as client:
+        return client.post(
+            "/a2a/",
+            headers={"Accept": "text/event-stream", "Content-Type": "application/json"},
+            json=STREAM_REQUEST,
+        )
+
+
+def _parts_text(container) -> str:
+    """Concatenated text of a Message's or Artifact's parts."""
+    parts = (container or {}).get("parts") or []
+    return "".join(p.get("text", "") for p in parts if p.get("kind") == "text")
+
+
+def _state(frame) -> str:
+    """`completed` / `TASK_STATE_COMPLETED` — normalise like a real client."""
+    raw = ((frame.get("result") or {}).get("status") or {}).get("state") or ""
+    return str(raw).lower().replace("task_state_", "")
+
+
+def _frames(response) -> list[dict]:
+    """The `data:` payloads of the SSE body, parsed, in order.
+
+    Events are separated by a blank line, and sse_starlette writes CRLF — a
+    reader that splits on "\n\n" alone sees one giant block and no events.
+    """
+    out = []
+    for block in re.split(r"\r?\n\r?\n", response.text):
+        data = "\n".join(
+            line[len("data:") :].strip() for line in block.splitlines() if line.startswith("data:")
+        )
+        if not data:
+            continue
+        try:
+            out.append(json.loads(data))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+DIAGNOSIS = [
+    {"type": "token", "content": "Let me look at the pods first."},
+    {"type": "tool_call", "content": TOOL_TEXT, "tool_call": TOOL_EVENT},
+    {"type": "token", "content": "The checkout pod is crashing."},
+    {"type": "token", "content": "Root cause: the image tag does not exist."},
+    {"type": "message", "content": ANSWER, "metadata": {"streamed": True}},
+]
+
+
+def test_the_wire_carries_the_tool_call_before_the_answer():
+    response = _post(_executor(_ScriptedAgent(DIAGNOSIS)))
+    assert response.status_code == 200
+    frames = _frames(response)
+
+    texts = []
+    for frame in frames:
+        result = frame.get("result", {})
+        if result.get("kind") != "status-update":
+            continue
+        texts.append(_parts_text(result.get("status", {}).get("message")))
+
+    tool_at = next(i for i, t in enumerate(texts) if "Tool Call:" in t)
+    answer_at = next(i for i, t in enumerate(texts) if "checkout pod is crashing" in t)
+    assert tool_at < answer_at, "the tool call reached the wire after the answer"
+    assert len([t for t in texts if t.strip()]) > 2, "the answer arrived in one frame"
+
+
+def test_the_wire_carries_the_typed_tool_event_alongside_the_text():
+    response = _post(_executor(_ScriptedAgent(DIAGNOSIS)))
+    frame = next(
+        f
+        for f in _frames(response)
+        if "kubently/tool_call" in json.dumps(f.get("result", {}))
+    )
+    result = frame["result"]
+
+    # On the status update itself...
+    assert result["metadata"]["kubently/event"] == "tool_call"
+    event = result["metadata"]["kubently/tool_call"]
+    assert event["tool"] == "execute_kubectl"
+    assert event["outcome"] == "ok"
+    assert event["args"]["command"] == KUBECTL_ARGS["command"]
+    # ...and on the message, for consumers that only parse that layer.
+    assert result["status"]["message"]["metadata"]["kubently/tool_call"]["tool"] == (
+        "execute_kubectl"
+    )
+    # The old text protocol is on the SAME frame — nothing had to be replaced.
+    assert _parts_text(result["status"]["message"]).startswith(
+        "🔧 Tool Call: execute_kubectl("
+    )
+
+
+def test_the_answer_is_not_repeated_once_it_has_been_streamed():
+    """`streamed` on the final message keeps the artifact authoritative without
+    re-sending the whole answer as one more `working` status."""
+    response = _post(_executor(_ScriptedAgent(DIAGNOSIS)))
+    frames = _frames(response)
+
+    working = [
+        f
+        for f in frames
+        if f.get("result", {}).get("kind") == "status-update"
+        and _state(f) == "working"
+    ]
+    whole_answer = [
+        f for f in working if ANSWER in _parts_text(f["result"]["status"].get("message"))
+    ]
+    assert not whole_answer, "the finished answer was replayed as a working status"
+    # ...and yet every line of it did reach the client, as separate frames.
+    assert "\n".join(_parts_text(f["result"]["status"].get("message")) for f in working).endswith(
+        ANSWER
+    )
+
+    artifact = next(f for f in frames if f.get("result", {}).get("kind") == "artifact-update")
+    assert _parts_text(artifact["result"]["artifact"]) == ANSWER
+    assert _state(frames[-1]) == "completed"
+
+
+def test_a_run_that_dies_mid_stream_reaches_a_terminal_failed_status():
+    """Never leave the subscription open on a half-told story."""
+    agent = _ScriptedAgent(
+        [
+            {"type": "token", "content": "Let me look at the pods first."},
+            {"type": "tool_call", "content": TOOL_TEXT, "tool_call": TOOL_EVENT},
+        ],
+        explode=True,
+    )
+    response = _post(_executor(agent))
+    assert response.status_code == 200
+    frames = _frames(response)
+
+    assert any("Tool Call:" in json.dumps(f) for f in frames), (
+        "the work that did happen was lost on the failure path"
+    )
+    terminal = frames[-1]["result"]
+    assert terminal["kind"] == "status-update"
+    assert _state(frames[-1]) == "failed", (
+        "a dead run reported itself as completed; a subscriber cannot tell that "
+        "from a real answer"
+    )
+    assert terminal["final"] is True
+    assert "the model connection dropped" in json.dumps(terminal)
+
+
+def test_an_agent_error_chunk_also_terminates_as_failed():
+    """agent.run() reports an in-graph failure as an `error` chunk, not an
+    exception. It has to end the task the same way."""
+    agent = _ScriptedAgent(
+        [
+            {"type": "token", "content": "Checking."},
+            {
+                "type": "error",
+                "content": "I encountered an error while processing your request: boom",
+            },
+        ]
+    )
+    frames = _frames(_post(_executor(agent)))
+    assert _state(frames[-1]) == "failed"
+    assert "boom" in json.dumps(frames[-1])
+
+
+def test_the_streaming_path_makes_exactly_one_agent_run():
+    """One A2A request is one diagnosis: kubently-cloud meters `message/stream`
+    identically to `message/send`, one unit per request."""
+    calls = []
+
+    class _Counting(_ScriptedAgent):
+        async def run(self, messages, thread_id=None, cluster_id=None, mcp_servers=None):
+            calls.append(thread_id)
+            async for chunk in super().run(messages, thread_id, cluster_id, mcp_servers):
+                yield chunk
+
+    _post(_executor(_Counting(DIAGNOSIS)))
+    assert len(calls) == 1
+
+
+def test_the_agent_no_longer_batches_the_run():
+    """Source guard: `run()` must not go back to a single awaited invoke."""
+    source = (
+        Path(__file__).parent.parent
+        / "kubently/modules/a2a/protocol_bindings/a2a_server/agent.py"
+    ).read_text()
+    assert "astream_events" in source
+    assert "run_agent.ainvoke(" not in source, (
+        "run() is awaiting the graph again — every consumer is back to a silent "
+        "gap and one lump (#115)"
+    )

--- a/tests/test_a2a_sdk_contract.py
+++ b/tests/test_a2a_sdk_contract.py
@@ -564,10 +564,14 @@ class TestAgentExecutorEventSequence:
 
     @pytest.mark.asyncio
     async def test_agent_failure_still_closes_the_stream(self):
-        """An agent crash must still yield a final artifact + completed status.
+        """An agent crash must still yield a final artifact + a TERMINAL status.
 
         Without this the client sees a half-open stream and waits forever, which
         is a worse failure mode than an error message.
+
+        The terminal state is `failed`, not `completed` (#115): a crashed run
+        used to end with `completed` carrying "I encountered an error…" in the
+        artifact, which a subscriber cannot tell apart from a real answer.
         """
         from a2a.types import TaskArtifactUpdateEvent, TaskState, TaskStatusUpdateEvent
         from kubently.modules.a2a.protocol_bindings.a2a_server.agent_executor import (
@@ -594,8 +598,10 @@ class TestAgentExecutorEventSequence:
         assert "llm unreachable" in artifacts[0].artifact.parts[0].text
 
         assert isinstance(events[-1], TaskStatusUpdateEvent)
-        assert events[-1].status.state == TaskState.TASK_STATE_COMPLETED
+        assert events[-1].status.state == TaskState.TASK_STATE_FAILED
         assert events[-1].status.state in _stream_ending_states()
+        # The reason is on the terminal status, where a client looks for it.
+        assert "llm unreachable" in events[-1].status.message.parts[0].text
 
 
 # =============================================================================

--- a/tests/test_incident_agent_integration.py
+++ b/tests/test_incident_agent_integration.py
@@ -36,15 +36,31 @@ RCA_ANSWER = (
 
 
 class FakeGraph:
-    """Stands in for the compiled deepagents graph."""
+    """Stands in for the compiled deepagents graph.
+
+    run() drives the graph with `astream_events` (#115), so the fake emits the
+    minimum event stream that carries a final state: the root chain's start and
+    its matching end. Everything incident history needs — the answer, and the
+    payload the model was handed — is in there.
+    """
 
     def __init__(self, answer: str):
         self.answer = answer
         self.invocations = []
 
-    async def ainvoke(self, payload, config=None):
+    def astream_events(self, payload, config=None, version=None):
         self.invocations.append(payload)
-        return {"messages": [AIMessage(content=self.answer)]}
+        answer = self.answer
+
+        async def events():
+            yield {"event": "on_chain_start", "run_id": "root", "data": {}}
+            yield {
+                "event": "on_chain_end",
+                "run_id": "root",
+                "data": {"output": {"messages": [AIMessage(content=answer)]}},
+            }
+
+        return events()
 
 
 def make_agent(redis, answer=RCA_ANSWER, incidents=True) -> KubentlyAgent:

--- a/tests/test_tool_trace_thread_match.py
+++ b/tests/test_tool_trace_thread_match.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 """Tool-call tracing: the recording side and the query side must agree.
 
-The agent records tool calls under the caller-namespaced thread id; the A2A
-executor queries the interceptor for them to emit "🔧 Tool Call" stream events,
-which test-automation parses. The interceptor matches thread_id by EXACT
-equality, so if one side namespaces and the other doesn't, the lookup silently
-returns [] — no error, just permanently missing tool visibility.
+Tool calls are recorded under the CALLER-NAMESPACED thread id. The interceptor
+matches thread_id by EXACT equality, so if the side that records and the side
+that queries disagree, the lookup silently returns [] — no error, just
+permanently missing tool visibility. That regression shipped once (the agent
+namespaced, the A2A executor still queried the raw contextId).
 
-That regression shipped once (agent namespaced, executor still queried the raw
-contextId). These tests pin both halves.
+Since #115 both halves live in `agent.run()`: it namespaces the id, stores it
+on `current_thread_id` for the tools to record under, and drains the
+interceptor with that same variable as the graph streams. So the guard is now
+that the query keeps using that variable — an executor that starts polling the
+interceptor again on its own is how the two sides drift apart a second time.
 """
 
 import re
@@ -24,26 +27,32 @@ AGENT_SRC = (A2A / "agent.py").read_text()
 EXECUTOR_SRC = (A2A / "agent_executor.py").read_text()
 
 
-def test_executor_queries_with_namespaced_thread_id():
+def test_the_query_uses_the_same_variable_the_recording_side_was_given():
     """Every get_tool_calls_for_thread call must use the namespaced id, never
     the raw client-supplied contextId."""
     calls = re.findall(
-        r"get_tool_calls_for_thread\(\s*([A-Za-z_][A-Za-z0-9_]*)", EXECUTOR_SRC
+        r"get_tool_calls_for_thread\(\s*([A-Za-z_][A-Za-z0-9_]*)", AGENT_SRC
     )
-    assert calls, "expected interceptor queries in agent_executor"
+    assert calls, "expected interceptor queries in agent.run()"
     for arg in calls:
-        assert arg != "contextId", (
-            "agent_executor queries the interceptor with the raw contextId, but the "
-            "agent records under the namespaced thread id — tool call events will "
-            "silently never be emitted"
+        assert arg == "thread_id", (
+            f"the interceptor is queried with {arg!r}, but tool calls are recorded "
+            "under `thread_id` (the namespaced one) — the lookup will silently "
+            "return [] and tool visibility disappears"
         )
-        assert arg == "traceThreadId", f"unexpected thread id argument: {arg}"
 
 
-def test_executor_derives_trace_id_from_the_same_helper():
-    """Both sides must derive the namespace from one function, so they can't drift."""
-    assert "_namespaced_thread_id" in EXECUTOR_SRC
-    assert "traceThreadId = _namespaced_thread_id(contextId)" in EXECUTOR_SRC
+def test_the_executor_does_not_poll_the_interceptor_behind_the_agents_back():
+    """A second query site is how the two halves drifted apart the first time.
+
+    The executor renders what `agent.run()` yields; it must not go looking for
+    tool calls itself, which would need its own copy of the namespacing rule
+    (and would reintroduce tool calls arriving after the answer, #115)."""
+    assert "get_tool_calls_for_thread" not in EXECUTOR_SRC
+    assert "🔧 Tool Call:" not in EXECUTOR_SRC, (
+        "the executor is formatting tool calls again; the text lives in agent.py "
+        "next to the structured event so the two cannot disagree"
+    )
 
 
 def test_agent_records_under_namespaced_id():


### PR DESCRIPTION
Closes #115

## What was wrong

`agent.run()` awaited `run_agent.ainvoke(...)` and yielded **exactly once, at the end**. Every `message/stream` subscriber saw the same thing:

```
task                immediately
  … a long quiet stretch, held open only by sse_starlette keepalives …
working             the ENTIRE answer, in one frame
working             the tool-call text, AFTER the answer it informed
artifact
status: completed
```

The connection streamed; the content did not. And nothing emitted a typed tool-call event — the executor wrote `🔧 Tool Call: name({json})` onto a `working` status, and that prose *was* the protocol, so every consumer had to parse it and a cosmetic change silently broke all of them.

## What it does now

```
task                immediately
working             "Let me look at the pods first."      ← as the model produces it
working             tool call: execute_kubectl(...)  ✅   ← the moment it finishes
working             "The checkout pod is crashing."
working             "Root cause: the image tag does not exist."
artifact            the whole answer, authoritative
status: completed   (or failed, with the reason on the status message)
```

`run()` drives the same graph with LangGraph's `astream_events`. **Same tools, same permissions, one graph invocation per request** — nothing here re-invokes the graph, so one A2A request is still exactly one diagnosis (billing parity with `message/send` is pinned by `test_the_graph_runs_exactly_once` and `test_the_streaming_path_makes_exactly_one_agent_run`).

## Compatibility: additive, not versioned

I chose **emit the structured event in addition to the existing text**, rather than versioning the endpoint, because it needs no negotiation and no client can miss it by not asking.

A `working` status for a tool call carries two renderings of the same call on the **same frame**:

* the text part is the legacy prose, **byte for byte** what the executor used to write (`_tool_event_text` is a straight move of that code, `elif` and all);
* `metadata["kubently/tool_call"]` — on the status update *and* on its message — carries the typed event:

```json
{
  "schema": "kubently.tool_call/v1",
  "id": "tc_...", "tool": "execute_kubectl",
  "args": {"cluster_id": "prod-1", "command": "get pods -n checkout"},
  "outcome": "ok",
  "result": "checkout-7d9  0/1  CrashLoopBackOff  5  2m",
  "startedAt": "...", "completedAt": "..."
}
```

So `dashboard/lib/stream.ts::stepFromCall` and `test-automation/test_runner.py` keep parsing exactly what they parsed before. kubently-cloud can map `kubently/tool_call` straight onto `ToolStep` — `{tool, args}` feed `stepFromCall`, `outcome` and `result` fill `outcome`/`detail` — whenever it likes, and drop the regex then.

**Token frames are the part that could have broken a consumer, and don't.** Consumers join consecutive `working` texts with `"\n"` (stream.ts does exactly that), so frames are cut at newline boundaries and the newline they were cut on is dropped from the frame. The consumer's join puts it back and the reconstruction is character-for-character what the model produced — no double newlines, no re-wrapped markdown. `test_token_frames_reconstruct_exactly_under_a_newline_join` feeds the cutter one character at a time over the awkward inputs (leading newline, blank line, trailing newline, a 1000-char unbroken line) and asserts exact reconstruction.

The final `message` chunk carries `metadata.streamed`, so an answer already delivered as token frames is published once more only as the artifact, not repeated as one more `working` status.

**`outcome` is derived from whether the tool reported an error**, never from a `status` key inside the tool's own payload — that is the #113 bug, where an absent status defaulted to SUCCESS and every denied command was reported as a success. `test_a_failed_tool_is_reported_as_an_error_not_a_success` pins it with a denied `kubectl delete`.

## Failures terminate

A crashed run used to end with `completed` carrying "I encountered an error…" in the artifact — a subscriber cannot tell that from a real answer. It now terminates as `failed`, with the reason on the terminal status message, and the tool calls that *did* run are published first so a partial investigation shows how far it got. `tests/test_a2a_sdk_contract.py::test_agent_failure_still_closes_the_stream` was pinning `completed`; it now pins `failed` and keeps its `_stream_ending_states()` assertion, which was always the real invariant.

## Verification

`tests/test_a2a_progressive_streaming.py` (16 tests) asserts on the **sequence**, at three levels:

1. **The real LangGraph plumbing** — `test_a_real_graph_streams_tokens_and_tools_in_order` builds an actual `create_deep_agent` graph (real middleware, real `astream_events`) with a scripted `BaseChatModel` and a tool that records to the interceptor the way the real tools do. This is what would catch "`astream_events` compiles but never emits token events through deepagents' middleware", which no amount of faking the event stream can tell you.
2. **`run()` over a scripted event stream** — ordering, the typed payload, thread isolation, a mid-run exception.
3. **The wire** — the real `A2AModule.get_app()` over real SSE, asserting the tool-call frame arrives before the answer frame, that the typed metadata and the legacy text are on the same frame, that the answer is not replayed, and that a dropped run's last frame is `"state": "failed", "final": true`.

**These fail against `ainvoke`.** Putting `run()` back on `ainvoke` (helpers left in place, so the module still imports) fails 7 of them, including the headline one:

```
FAILED test_a_tool_call_arrives_before_the_answer_it_informed
FAILED test_the_answer_arrives_as_more_than_one_frame
FAILED test_the_tool_call_carries_typed_fields_and_the_legacy_text
FAILED test_a_failed_tool_is_reported_as_an_error_not_a_success
FAILED test_a_run_that_dies_mid_stream_still_reports_what_it_ran
FAILED test_tool_calls_from_another_caller_are_never_streamed_here
FAILED test_the_agent_no_longer_batches_the_run
7 failed, 8 passed
```

Full suite: **863 passed, 2 skipped**. `ruff check kubently/` and `ruff format --check kubently/` clean. No chart files touched, so no `Chart.yaml` bump.

## Also in here

* **Tool-call draining moved from the executor into `run()`.** The executor used to poll the interceptor with its own copy of the namespacing rule (`traceThreadId = _namespaced_thread_id(contextId)`) — that split brain is how #63's silent-empty-result happened, and polling is why tool calls landed after the answer. `run()` now drains the interceptor as the graph streams, using the same `thread_id` variable it set `current_thread_id` from. `tests/test_tool_trace_thread_match.py` is rewritten to pin the new arrangement rather than the old one, and now also asserts the executor does not grow a second query site.
* **The interceptor is still the source of truth for *which* calls are visible** — a tool is visible precisely when it calls `record_tool_call`, unchanged. Deliberately not LangGraph's `on_tool_*`, which would have put deepagents' planning todos and virtual filesystem into the user's transcript.
* **Fixed:** the incident-history trace queried the interceptor with `actual_thread_id`, which is a fresh UUID for a turn with no `contextId` while tools record under `thread_id`. The lookup silently returned `[]` and the incident was recorded with no commands on it.
* `docs/A2A_CONFIGURATION.md` gains a "What `message/stream` emits" section documenting the sequence, the newline-join rule, and the typed event.

## Deferred

* **`uv.lock` is stale on `main`** — it still records `a2a-sdk 0.2.16` while `pyproject.toml` pins `1.1.2` (drift from #76). Any `uv run` regenerates ~125 lines of it. Left out of this diff deliberately; CI installs with `uv pip install -e` and never reads the lock, so nothing is broken, but it wants its own PR.
* **Sub-line latency.** Frames flush on newlines, or at `TOKEN_FRAME_MAX_CHARS` (400) for an unbroken line. Real markdown answers emit newlines constantly so this is continuous in practice, but it is line-granular, not token-granular. Going finer means either accepting spurious newlines in today's `"\n"`-joining consumers or negotiating a capability — worth doing once kubently-cloud reads `kubently/event: "token"` and concatenates without a separator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
