### PR TITLE
fix: close kubectl whitelist bypass via --raw, positional resources, and unlisted flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-## [Unreleased] - 2026-08-21
+## [Unreleased] - 2026-08-25
+
+### Security
+- **Closed a whitelist bypass that let `kubectl get --raw` read restricted
+  Secrets/ConfigMaps.** `DynamicCommandWhitelist.validate_command` only checked
+  `args[1]` for restricted resources and had no reject branch for flags that
+  were neither allowlisted nor forbidden, so
+  `get --raw /api/v1/namespaces/<ns>/secrets/<name>` passed validation and the
+  executor returned the Secret — the exact control the Helm chart cites to
+  justify the `changeCorrelation.helmHistory` RBAC widening. Three fixes, all
+  in `kubently/modules/executor/dynamic_whitelist.py`:
+  - `--raw` is now in `IMMUTABLE_FORBIDDEN_PATTERNS` (it inherently bypasses
+    verb/resource restriction, in every mode).
+  - Restricted-resource names are matched against every argument, not just
+    `args[1]` (catches `-n ns secrets`, `secrets/name`, API paths).
+  - The flag check fails closed: any flag not explicitly allowlisted is
+    rejected (previously e.g. `--as=system:masters` sailed through). The
+    per-mode default allowlists were expanded to cover the flags real callers
+    send (`-n`, `-A`, `-l`, `-o`, `-c`, `--tail`, `--sort-by`, `--revision`,
+    …), which only ever worked because of the missing reject branch.
 
 ### Changed
 - **The A2A stream narrates the investigation instead of replaying it (#115).**

--- a/kubently/modules/executor/dynamic_whitelist.py
+++ b/kubently/modules/executor/dynamic_whitelist.py
@@ -98,6 +98,44 @@ class DynamicCommandWhitelist:
         "--kubeconfig=",
         "--token-file",
         "/etc/kubernetes",
+        # Raw API-server access bypasses verb/resource restriction entirely
+        # (e.g. `get --raw /api/v1/namespaces/ns/secrets/name`)
+        "--raw",
+    }
+
+    # Flags legitimate read-only diagnostics need; shared by every mode's
+    # defaults. Operators extend per-deployment via commands.allowedFlags.
+    BASE_READ_FLAGS: ClassVar[set[str]] = {
+        "-n",
+        "--namespace",
+        "-A",
+        "--all-namespaces",
+        "-l",
+        "--selector",
+        "-o",
+        "--output",
+        "-c",
+        "--container",
+        "--all-containers",
+        "-f",
+        "--follow",
+        "-p",
+        "--previous",
+        "--tail",
+        "--since",
+        "--since-time",
+        "--timestamps",
+        "--prefix",
+        "-w",
+        "--watch",
+        "--show-labels",
+        "--field-selector",
+        "--sort-by",
+        "--no-headers",
+        "--limit",
+        "--revision",
+        "--recursive",
+        "--containers",
     }
 
     # kubectl verbs that are only partially read-only: allowed only with a
@@ -126,15 +164,7 @@ class DynamicCommandWhitelist:
             # configmaps are allowed (RBAC permits them and they're core to troubleshooting);
             # secrets stay restricted as defense-in-depth alongside RBAC.
             "restrictedResources": {"secrets"},
-            "allowedFlags": {
-                "--namespace",
-                "--all-namespaces",
-                "--selector",
-                "--show-labels",
-                "--watch",
-                "--follow",
-                "--previous",
-            },
+            "allowedFlags": BASE_READ_FLAGS,
         },
         SecurityMode.EXTENDED_READ_ONLY: {
             "allowedVerbs": {
@@ -152,18 +182,13 @@ class DynamicCommandWhitelist:
                 "exec",
             },
             "restrictedResources": {"secrets"},
-            "allowedFlags": {
-                "--namespace",
-                "--all-namespaces",
-                "--selector",
-                "--show-labels",
-                "--watch",
-                "--follow",
-                "--previous",
+            "allowedFlags": BASE_READ_FLAGS
+            | {
                 "--port",
+                "-i",
                 "--stdin",
+                "-t",
                 "--tty",
-                "--container",
             },
         },
         SecurityMode.FULL_ACCESS: {
@@ -186,18 +211,14 @@ class DynamicCommandWhitelist:
                 "run",
             },
             "restrictedResources": set(),
-            "allowedFlags": {
-                "--namespace",
-                "--all-namespaces",
-                "--selector",
-                "--show-labels",
-                "--watch",
-                "--follow",
-                "--previous",
+            "allowedFlags": BASE_READ_FLAGS
+            | {
                 "--port",
+                "-i",
                 "--stdin",
+                "-t",
                 "--tty",
-                "--container",
+                "--image",
                 "--server-print",
                 "--server-version",
             },
@@ -501,21 +522,28 @@ class DynamicCommandWhitelist:
                 if pattern in arg_lower:
                     return False, f"Forbidden pattern '{pattern}' detected"
 
-        # Check resource restrictions
-        if config.restricted_resources and len(args) > 1:
-            for resource in config.restricted_resources:
-                if resource in args[1].lower():
-                    return False, f"Access to resource '{resource}' is restricted"
+        # Check resource restrictions across every argument, not just args[1] —
+        # restricted resource names can appear anywhere (API paths, slash
+        # syntax like secrets/name, flag values).
+        if config.restricted_resources:
+            for arg in args[1:]:
+                arg_lower = arg.lower()
+                for resource in config.restricted_resources:
+                    if resource in arg_lower:
+                        return False, f"Access to resource '{resource}' is restricted"
 
-        # Check flags
+        # Check flags — fail closed: any flag not explicitly allowlisted is
+        # rejected, so new kubectl flags can't silently bypass restrictions.
         for arg in args[1:]:
+            if arg == "--":
+                # kubectl passthrough separator (e.g. exec pod -- ls -la);
+                # what follows isn't kubectl flags. Forbidden-pattern and
+                # restricted-resource scans above already covered those args.
+                break
             if arg.startswith("-"):
                 flag_base = arg.split("=")[0]
                 if flag_base not in config.allowed_flags:
-                    # Check if it's a forbidden flag
-                    for forbidden in self.IMMUTABLE_FORBIDDEN_PATTERNS:
-                        if forbidden in flag_base:
-                            return False, f"Forbidden flag '{flag_base}' detected"
+                    return False, f"Flag '{flag_base}' is not allowed"
 
         return True, None
 

--- a/tests/test_dynamic_whitelist.py
+++ b/tests/test_dynamic_whitelist.py
@@ -167,6 +167,53 @@ class TestDynamicCommandWhitelist:
         assert ok_secret is False
         assert "restricted" in reason
 
+    def test_raw_api_access_blocked(self):
+        """`get --raw` bypasses verb/resource restriction entirely; always blocked."""
+        whitelist = DynamicCommandWhitelist(config_path="/nonexistent/path")
+
+        is_valid, reason = whitelist.validate_command(
+            ["get", "--raw", "/api/v1/namespaces/ns/secrets/name"]
+        )
+        assert is_valid is False
+        assert "--raw" in reason
+
+    def test_restricted_resource_in_any_position(self):
+        """Restricted resources are caught anywhere in the args, not just args[1]."""
+        whitelist = DynamicCommandWhitelist(config_path="/nonexistent/path")
+
+        for args in (
+            ["get", "-n", "kube-system", "secrets"],
+            ["get", "secrets/db-creds", "-n", "prod"],
+            ["describe", "-n", "prod", "secrets", "db-creds"],
+        ):
+            is_valid, reason = whitelist.validate_command(args)
+            assert is_valid is False, args
+            assert "restricted" in reason
+
+    def test_unlisted_flag_rejected(self):
+        """Flags fail closed: anything not explicitly allowlisted is rejected."""
+        whitelist = DynamicCommandWhitelist(config_path="/nonexistent/path")
+
+        is_valid, reason = whitelist.validate_command(
+            ["get", "pods", "--as=system:masters"]
+        )
+        assert is_valid is False
+        assert "not allowed" in reason
+
+    def test_common_diagnostic_flags_allowed(self):
+        """The flags real callers send survive the fail-closed flag check."""
+        whitelist = DynamicCommandWhitelist(config_path="/nonexistent/path")
+
+        for args in (
+            ["get", "pods", "-n", "default", "-o", "json"],
+            ["get", "deploy,sts,ds", "-A", "-l", "app=x", "-o", "jsonpath={.items}"],
+            ["logs", "my-pod", "-c", "app", "--tail=50", "--previous"],
+            ["get", "events", "--sort-by=.lastTimestamp", "--field-selector", "type=Warning"],
+            ["rollout", "history", "deployment/api", "--revision=2"],
+        ):
+            is_valid, reason = whitelist.validate_command(args)
+            assert is_valid is True, (args, reason)
+
     def test_security_modes(self):
         """Test different security modes have correct defaults."""
         # Test READ_ONLY mode

--- a/tests/test_dynamic_whitelist.py
+++ b/tests/test_dynamic_whitelist.py
@@ -9,7 +9,6 @@ import os
 import sys
 import tempfile
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import yaml
@@ -20,9 +19,8 @@ from kubently.modules.executor.command_analyzer import CommandAnalyzer, CommandC
 from kubently.modules.executor.dynamic_whitelist import (
     DynamicCommandWhitelist,
     SecurityMode,
-    WhitelistConfig,
 )
-from kubently.modules.executor.learning_engine import LearningEngine, LearningSuggestion, Pattern
+from kubently.modules.executor.learning_engine import LearningEngine, Pattern
 
 
 class TestDynamicCommandWhitelist:
@@ -194,9 +192,7 @@ class TestDynamicCommandWhitelist:
         """Flags fail closed: anything not explicitly allowlisted is rejected."""
         whitelist = DynamicCommandWhitelist(config_path="/nonexistent/path")
 
-        is_valid, reason = whitelist.validate_command(
-            ["get", "pods", "--as=system:masters"]
-        )
+        is_valid, reason = whitelist.validate_command(["get", "pods", "--as=system:masters"])
         assert is_valid is False
         assert "not allowed" in reason
 


### PR DESCRIPTION
## Summary

`DynamicCommandWhitelist.validate_command` — the only gate between `POST /debug/execute` and the executor running kubectl — had two holes that composed into a Secrets/ConfigMaps exfiltration path:

- The restricted-resource check only inspected `args[1]`.
- The flag check had no reject branch for a flag that was neither allowlisted nor forbidden (fail-open).

Result: `kubectl get --raw /api/v1/namespaces/<ns>/secrets/<name>` passed validation and returned the Secret. This is the exact control the Helm chart cites (`values.yaml`, `executor-rbac.yaml`) to justify the `changeCorrelation.helmHistory` cluster-wide Secrets RBAC widening. Any authenticated API-key holder could exfiltrate ConfigMaps against a default install, and Secrets once that setting is on.

## Fixes

1. **`--raw` added to `IMMUTABLE_FORBIDDEN_PATTERNS`** — raw API-server access inherently bypasses verb/resource restriction; blocked in every mode, no config can re-enable it.
2. **Restricted resources matched against every argument**, not just `args[1]` — catches `-n ns secrets`, `secrets/name` slash syntax, and API paths.
3. **Flag check fails closed** — any flag whose base isn't explicitly allowlisted is rejected (previously e.g. `--as=system:masters` sailed through). A bare `--` stops flag parsing (kubectl passthrough separator); args after it remain covered by the forbidden-pattern and restricted-resource scans.

Failing closed required expanding the per-mode default flag allowlists to what real callers (A2A agent, `changes.py`, `verify_deployment.py`) actually send — `-n`, `-A`, `-l`, `-o`, `-c`, `--tail`, `--sort-by`, `--field-selector`, `--revision`, etc. — now in a shared `BASE_READ_FLAGS` set. Those flags only ever worked because of the missing reject branch; a test now pins them as allowed so fail-closed can't regress them.

## Testing

- New regression tests for all three vectors (`--raw`, positional resources, unlisted flags) plus a pin on real-caller flags.
- Full suite: 829 passed, 2 skipped.
- Direct repro of the reported bypass now rejects:
  - `get --raw /api/v1/namespaces/ns/secrets/name` → `Forbidden pattern '--raw' detected`
  - `get -n kube-system secrets` → `Access to resource 'secrets' is restricted`
  - `get pods --as=system:masters` → `Flag '--as' is not allowed`

## Reviewer notes

- Known cost of fail-closed: combined short flags like `-ojson` (no space) are rejected; the agent gets a clear error and retries as `-o json`. Operators can extend `commands.allowedFlags` per deployment.
- Deployments running with `changeCorrelation.helmHistory.enabled` should treat cluster Secrets as potentially exposed to any API-key holder until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)